### PR TITLE
Implement using directives

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
@@ -5,6 +5,7 @@
     <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="1" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -50,9 +51,15 @@
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
       </concept>
     </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
+      </concept>
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -65,6 +72,9 @@
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
       <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
         <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
@@ -250,6 +260,68 @@
               <node concept="3TrcHB" id="5nBCUOUhzRR" role="2OqNvi">
                 <ref role="3TsBF5" to="80bi:5LVVOtEMxfL" resolve="value" />
               </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="p4z1jPjlIe">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="AddUsingDirective" />
+    <ref role="2ZfgGC" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+    <node concept="2S6ZIM" id="p4z1jPjlIf" role="2ZfVej">
+      <node concept="3clFbS" id="p4z1jPjlIg" role="2VODD2">
+        <node concept="3clFbF" id="p4z1jPjm0o" role="3cqZAp">
+          <node concept="Xl_RD" id="p4z1jPjm0n" role="3clFbG">
+            <property role="Xl_RC" value="Add using directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="p4z1jPjlIh" role="2ZfgGD">
+      <node concept="3clFbS" id="p4z1jPjlIi" role="2VODD2">
+        <node concept="3clFbF" id="p4z1jPjIaQ" role="3cqZAp">
+          <node concept="2OqwBi" id="p4z1jPjIVf" role="3clFbG">
+            <node concept="2OqwBi" id="p4z1jPjIpc" role="2Oq$k0">
+              <node concept="2Sf5sV" id="p4z1jPjIaP" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="p4z1jPpxje" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+              </node>
+            </node>
+            <node concept="2DeJg1" id="2H$QQEVkItD" role="2OqNvi">
+              <ref role="1A0vxQ" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="2H$QQEVk$bR">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="AddUsingAlias" />
+    <ref role="2ZfgGC" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+    <node concept="2S6ZIM" id="2H$QQEVk$bS" role="2ZfVej">
+      <node concept="3clFbS" id="2H$QQEVk$bT" role="2VODD2">
+        <node concept="3clFbF" id="2H$QQEVk_lw" role="3cqZAp">
+          <node concept="Xl_RD" id="2H$QQEVk_lv" role="3clFbG">
+            <property role="Xl_RC" value="Add using alias" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="2H$QQEVk$bU" role="2ZfgGD">
+      <node concept="3clFbS" id="2H$QQEVk$bV" role="2VODD2">
+        <node concept="3clFbF" id="2H$QQEVk_nd" role="3cqZAp">
+          <node concept="2OqwBi" id="2H$QQEVkBV2" role="3clFbG">
+            <node concept="2OqwBi" id="2H$QQEVk_xr" role="2Oq$k0">
+              <node concept="2Sf5sV" id="2H$QQEVk_nc" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="2H$QQEVk_GK" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+              </node>
+            </node>
+            <node concept="2DeJg1" id="2H$QQEVkHn1" role="2OqNvi">
+              <ref role="1A0vxQ" to="80bi:2H$QQEUtQI0" resolve="UsingAliasDirective" />
             </node>
           </node>
         </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -74,6 +74,7 @@
       <concept id="8329266386016608055" name="jetbrains.mps.lang.editor.structure.ApproveDelete_Operation" flags="ng" index="2xy62i">
         <child id="8329266386016685951" name="editorContext" index="2xHN3q" />
       </concept>
+      <concept id="6718020819487620876" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Default" flags="ng" index="A1WHr" />
       <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
         <reference id="6718020819487620874" name="menu" index="A1WHt" />
       </concept>
@@ -143,6 +144,7 @@
       <concept id="2896773699153795590" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform" flags="ng" index="3cWJ9i">
         <child id="3473224453637651919" name="placeInCell" index="CtIbM" />
       </concept>
+      <concept id="7342352913006985500" name="jetbrains.mps.lang.editor.structure.TransformationLocation_Completion" flags="ng" index="3eGOoe" />
       <concept id="7342352913006985483" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Action" flags="ng" index="3eGOop">
         <child id="8612453216082699922" name="substituteHandler" index="3aKz83" />
       </concept>
@@ -222,6 +224,9 @@
         <child id="1948540814633499358" name="editorContext" index="lBI5i" />
         <child id="1948540814635895774" name="cellSelector" index="lGT1i" />
         <child id="3604384757217586546" name="selectionStart" index="3dN3m$" />
+      </concept>
+      <concept id="422708224287891156" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_ReferenceMenu" flags="ng" index="3PzhKR">
+        <reference id="422708224287891157" name="referenceLink" index="3PzhKQ" />
       </concept>
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
       <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
@@ -1295,11 +1300,17 @@
         </node>
         <node concept="VPM3Z" id="6vAOG1ADehB" role="3F10Kt" />
       </node>
-      <node concept="3F0ifn" id="6vAOG1ACMkc" role="3EZMnx">
-        <node concept="ljvvj" id="6vAOG1ACOqU" role="3F10Kt">
+      <node concept="PMmxH" id="p4z1jPjKK2" role="3EZMnx">
+        <ref role="PMmxG" node="p4z1jPbmlc" resolve="UsingDirectives" />
+      </node>
+      <node concept="3F0ifn" id="p4z1jPmrG1" role="3EZMnx">
+        <property role="1cu_pB" value="gtgu$YJ/attractsFocus" />
+        <node concept="pVoyu" id="p4z1jPmrJx" role="3F10Kt">
           <property role="VOm3f" value="true" />
         </node>
-        <node concept="VPM3Z" id="6vAOG1AD8Me" role="3F10Kt" />
+        <node concept="ljvvj" id="p4z1jPmrJP" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F2HdR" id="6vAOG1ACMk$" role="3EZMnx">
         <ref role="1NtTu8" to="80bi:6hv6i2_A$dV" resolve="namespaceMemberDeclaration" />
@@ -1590,6 +1601,41 @@
         <property role="3F0ifm" value="{" />
         <node concept="ljvvj" id="6vAOG1ACVkY" role="3F10Kt">
           <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="PMmxH" id="p4z1jPbp29" role="3EZMnx">
+        <ref role="PMmxG" node="p4z1jPbmlc" resolve="UsingDirectives" />
+        <node concept="lj46D" id="p4z1jPbp36" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="p4z1jPgJef" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="p4z1jPpPLQ" role="3EZMnx">
+        <node concept="lj46D" id="p4z1jPpPMz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pVoyu" id="p4z1jPpPMR" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="ljvvj" id="p4z1jPpPNc" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pkWqt" id="p4z1jPpPO6" role="pqm2j">
+          <node concept="3clFbS" id="p4z1jPpPO7" role="2VODD2">
+            <node concept="3clFbF" id="p4z1jPpQ48" role="3cqZAp">
+              <node concept="2OqwBi" id="p4z1jPpUBC" role="3clFbG">
+                <node concept="2OqwBi" id="p4z1jPpQyh" role="2Oq$k0">
+                  <node concept="pncrf" id="p4z1jPpQ47" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="p4z1jPpRel" role="2OqNvi">
+                    <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="p4z1jPq0jg" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
         </node>
       </node>
       <node concept="3F2HdR" id="6vAOG1AC6r8" role="3EZMnx">
@@ -21098,6 +21144,173 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="2H$QQET29s8">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="DeleteUsingDirective" />
+    <ref role="1h_SK9" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="1hA7zw" id="2H$QQET29tz" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="2H$QQET29t$" role="1hA7z_">
+        <node concept="3clFbS" id="2H$QQET29t_" role="2VODD2">
+          <node concept="3clFbJ" id="2H$QQET29yc" role="3cqZAp">
+            <node concept="2OqwBi" id="2H$QQET29H2" role="3clFbw">
+              <node concept="0IXxy" id="2H$QQET29yU" role="2Oq$k0" />
+              <node concept="2xy62i" id="2H$QQET2bIn" role="2OqNvi">
+                <node concept="1Q80Hx" id="2H$QQET2bJB" role="2xHN3q" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="2H$QQET29ye" role="3clFbx">
+              <node concept="3cpWs6" id="2H$QQET2c2u" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2H$QQETj0NV" role="3cqZAp">
+            <node concept="3cpWsn" id="2H$QQETj0NY" role="3cpWs9">
+              <property role="TrG5h" value="parent" />
+              <node concept="3Tqbb2" id="2H$QQETj0NT" role="1tU5fm">
+                <ref role="ehGHo" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+              </node>
+              <node concept="1PxgMI" id="2H$QQETFoiI" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="2H$QQETFol9" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+                </node>
+                <node concept="2OqwBi" id="2H$QQET2chR" role="1m5AlR">
+                  <node concept="0IXxy" id="2H$QQET2c7v" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="2H$QQETFnUq" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2H$QQETlVmK" role="3cqZAp">
+            <node concept="2OqwBi" id="2H$QQETlVwO" role="3clFbG">
+              <node concept="0IXxy" id="2H$QQETlVmJ" role="2Oq$k0" />
+              <node concept="3YRAZt" id="2H$QQETlVRO" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="2H$QQETj6VD" role="3cqZAp">
+            <node concept="3clFbS" id="2H$QQETj6VF" role="3clFbx">
+              <node concept="3clFbF" id="2H$QQEToAru" role="3cqZAp">
+                <node concept="2OqwBi" id="2H$QQEToAz2" role="3clFbG">
+                  <node concept="1Q80Hx" id="2H$QQEToArt" role="2Oq$k0" />
+                  <node concept="liA8E" id="2H$QQEToAN4" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorContext.selectWRTFocusPolicy(org.jetbrains.mps.openapi.model.SNode)" resolve="selectWRTFocusPolicy" />
+                    <node concept="37vLTw" id="2H$QQEToAO1" role="37wK5m">
+                      <ref role="3cqZAo" node="2H$QQETj0NY" resolve="parent" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2H$QQETj9SE" role="3clFbw">
+              <node concept="2OqwBi" id="2H$QQETj75Q" role="2Oq$k0">
+                <node concept="37vLTw" id="2H$QQETj6Xh" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2H$QQETj0NY" resolve="parent" />
+                </node>
+                <node concept="3Tsc0h" id="2H$QQETj7zd" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+                </node>
+              </node>
+              <node concept="1v1jN8" id="2H$QQETjelf" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PKFIW" id="p4z1jPbmlc">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingDirectives" />
+    <ref role="1XX52x" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+    <node concept="3F2HdR" id="p4z1jPms9B" role="2wV5jI">
+      <ref role="1NtTu8" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+      <ref role="APP_o" node="2H$QQET29s8" resolve="DeleteUsingDirectives" />
+      <node concept="2iRkQZ" id="p4z1jPms9D" role="2czzBx" />
+      <node concept="pkWqt" id="p4z1jPmB6p" role="pqm2j">
+        <node concept="3clFbS" id="p4z1jPmB6q" role="2VODD2">
+          <node concept="3clFbF" id="p4z1jPmB8K" role="3cqZAp">
+            <node concept="2OqwBi" id="p4z1jPmFaC" role="3clFbG">
+              <node concept="2OqwBi" id="p4z1jPmBy7" role="2Oq$k0">
+                <node concept="pncrf" id="p4z1jPmB8J" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="p4z1jPmBVu" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+                </node>
+              </node>
+              <node concept="3GX2aA" id="p4z1jPmLd9" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="p4z1jOxeUl">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="aqKnT" to="80bi:27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="22hDWj" id="p4z1jOxeUU" role="22hAXT" />
+    <node concept="1Qtc8_" id="p4z1jOxeVw" role="IW6Ez">
+      <node concept="3eGOoe" id="p4z1jOxeVQ" role="1Qtc8$" />
+      <node concept="3PzhKR" id="p4z1jOxeZ4" role="1Qtc8A">
+        <ref role="3PzhKQ" to="80bi:27q4jmdWXhm" resolve="referencedType" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2H$QQEVkW1m">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
+    <node concept="3EZMnI" id="4tlNOobs7hd" role="2wV5jI">
+      <node concept="l2Vlx" id="4tlNOobs7he" role="2iSdaV" />
+      <node concept="PMmxH" id="2H$QQEV9$DZ" role="3EZMnx">
+        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      </node>
+      <node concept="3F1sOY" id="2H$QQEVqVMB" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:2H$QQEVtErT" resolve="reference" />
+      </node>
+      <node concept="3F0ifn" id="4tlNOobs7it" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="4tlNOobAZFd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PKFIW" id="2H$QQEV9$DW">
+    <property role="TrG5h" value="UsingKeyword" />
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3F0ifn" id="2H$QQEV9$DX" role="2wV5jI">
+      <property role="3F0ifm" value="using" />
+      <node concept="A1WHr" id="2H$QQEV9$DY" role="3vIgyS">
+        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2H$QQEUtQI6">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:2H$QQEUtQI0" resolve="UsingAliasDirective" />
+    <node concept="3EZMnI" id="2H$QQEUtQI8" role="2wV5jI">
+      <node concept="PMmxH" id="2H$QQEV9$ET" role="3EZMnx">
+        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      </node>
+      <node concept="3F0A7n" id="2H$QQEUtQIl" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="2H$QQEUtQIt" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+      </node>
+      <node concept="3F1sOY" id="2H$QQEVkWIa" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:2H$QQEVtErW" resolve="reference" />
+      </node>
+      <node concept="3F0ifn" id="2H$QQEUtQIN" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="2H$QQEUYLQC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="2H$QQEUtQIb" role="2iSdaV" />
+      <node concept="A1WHr" id="2H$QQEUYLQG" role="3vIgyS">
+        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -78,6 +78,7 @@
         <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
         <property id="1071599937831" name="metaClass" index="20lmBu" />
         <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599698500" name="specializedLink" index="20ksaX" />
         <reference id="1071599976176" name="target" index="20lvS9" />
       </concept>
     </language>
@@ -2172,7 +2173,7 @@
     <property role="34LRSv" value="namespace" />
     <property role="3GE5qa" value="Namespace" />
     <property role="R4oN_" value="Namespace" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="p4z1jOVEuK" resolve="NamespaceContainer" />
     <node concept="1TJgyj" id="6hv6i2_A_I2" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588310402" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -2184,6 +2185,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="usingDirectiveList" />
       <ref role="20lvS9" node="6vAOG1ABcaE" resolve="UsingDirectiveList" />
+      <node concept="asaX9" id="2H$QQEUe9cW" role="lGtFl" />
     </node>
     <node concept="1TJgyj" id="6hv6i2_A_Ia" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588310410" />
@@ -2205,7 +2207,13 @@
       <node concept="1Pa9Pv" id="6Y0EU3Z5P1x" role="3H0Qfi">
         <node concept="1PaTwC" id="6Y0EU3Z5P1y" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5P1z" role="1PaTwD">
-            <property role="3oM_SC" value="Represents a namespace" />
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6j_" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jA" role="1PaTwD">
+            <property role="3oM_SC" value="namespace" />
           </node>
           <node concept="3oM_SD" id="6Y0EU3Z5PfJ" role="1PaTwD">
             <property role="3oM_SC" value="definition." />
@@ -2218,7 +2226,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5P1P" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5P1O" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: namespace-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jh" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6ji" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jj" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jk" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jl" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6jm" role="1PaTwD">
+            <property role="3oM_SC" value="namespace-declaration" />
           </node>
         </node>
       </node>
@@ -2276,10 +2302,7 @@
     <property role="TrG5h" value="File" />
     <property role="19KtqR" value="true" />
     <property role="R4oN_" value="C# source file" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="6hv6i2_Aw1g" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
+    <ref role="1TJDcQ" node="p4z1jOVEuK" resolve="NamespaceContainer" />
     <node concept="1TJgyj" id="6hv6i2_AxlC" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588292456" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -2291,6 +2314,7 @@
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="usingDirectiveList" />
       <ref role="20lvS9" node="6vAOG1ABcaE" resolve="UsingDirectiveList" />
+      <node concept="asaX9" id="2H$QQEUe9fM" role="lGtFl" />
     </node>
     <node concept="1TJgyj" id="6hv6i2_AyhC" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588296296" />
@@ -2309,7 +2333,19 @@
       <node concept="1Pa9Pv" id="6Y0EU3Z5OS_" role="3H0Qfi">
         <node concept="1PaTwC" id="6Y0EU3Z5OTg" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5OTl" role="1PaTwD">
-            <property role="3oM_SC" value="Represents a C# source file." />
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6W1" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6W2" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6W3" role="1PaTwD">
+            <property role="3oM_SC" value="source" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6W4" role="1PaTwD">
+            <property role="3oM_SC" value="file." />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5OTq" role="1PaQFQ">
@@ -2319,7 +2355,37 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5OTw" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5OTv" role="1PaTwD">
-            <property role="3oM_SC" value="This is the top-level concept in the C# base language Structure." />
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Vx" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Vy" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Vz" role="1PaTwD">
+            <property role="3oM_SC" value="top-level" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6V$" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6V_" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6VA" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6VB" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6VC" role="1PaTwD">
+            <property role="3oM_SC" value="base" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6VD" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6VE" role="1PaTwD">
+            <property role="3oM_SC" value="Structure." />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5OTC" role="1PaQFQ">
@@ -2329,7 +2395,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5OTM" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5OTL" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: compilation-unit" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wf" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wg" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wh" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wi" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wj" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs6Wk" role="1PaTwD">
+            <property role="3oM_SC" value="compilation-unit" />
           </node>
         </node>
       </node>
@@ -3881,22 +3965,22 @@
     <property role="TrG5h" value="UsingDirective" />
     <property role="3GE5qa" value="Namespace" />
     <property role="R4oN_" value="Using directive" />
+    <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="3H0Qfr" id="6Y0EU3Z5OY5" role="lGtFl">
       <node concept="1Pa9Pv" id="6Y0EU3Z5OY6" role="3H0Qfi">
         <node concept="1PaTwC" id="6Y0EU3Z5PaU" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5PbN" role="1PaTwD">
-            <property role="3oM_SC" value="Represents a using directive." />
+            <property role="3oM_SC" value="Represents" />
           </node>
-        </node>
-        <node concept="1PaTwC" id="fEeb946LC9" role="1PaQFQ">
-          <node concept="3oM_SD" id="fEeb946LC8" role="1PaTwD">
-            <property role="3oM_SC" value="" />
+          <node concept="3oM_SD" id="4tlNOobs7ej" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
           </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5OYk" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5OYj" role="1PaTwD">
-            <property role="3oM_SC" value="Note that this concept is not implemented. It is a place for extension of the C#" />
+          <node concept="3oM_SD" id="4tlNOobs7ek" role="1PaTwD">
+            <property role="3oM_SC" value="using" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEUtJ6d" role="1PaTwD">
+            <property role="3oM_SC" value="directive." />
           </node>
         </node>
         <node concept="1PaTwC" id="fEeb946LCj" role="1PaQFQ">
@@ -3906,7 +3990,58 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5OYq" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5OYp" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: using-directive" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs7dZ" role="1PaTwD">
+            <property role="3oM_SC" value="description" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs7e0" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs7e1" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs7e2" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTG3" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="4tlNOobs7e3" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+        </node>
+        <node concept="1PaTwC" id="2H$QQEVkTGd" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVkTGU" role="1PaTwD">
+            <property role="3oM_SC" value="using-directive:" />
+          </node>
+        </node>
+        <node concept="1PaTwC" id="2H$QQEVkTGX" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVkTHG" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTHI" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTHL" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTI0" role="1PaTwD">
+            <property role="3oM_SC" value="using-alias-directive" />
+          </node>
+        </node>
+        <node concept="1PaTwC" id="2H$QQEVkTI6" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVkTI5" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTIF" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVkTII" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVWaIt" role="1PaTwD">
+            <property role="3oM_SC" value="using-namespace-directive" />
           </node>
         </node>
       </node>
@@ -16748,6 +16883,113 @@
     <property role="TrG5h" value="InterfacePropertySetAccessorDeclaration" />
     <property role="34LRSv" value="set" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
+  </node>
+  <node concept="1TIwiD" id="2H$QQEVkVn6">
+    <property role="EcuMT" value="3126865292757808582" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingNamespaceDirective" />
+    <property role="34LRSv" value="using" />
+    <property role="R4oN_" value="Using directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
+            <property role="3oM_SC" value="using-namespace-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098553" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jOVEuK">
+    <property role="EcuMT" value="451639884280407984" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="NamespaceContainer" />
+    <property role="R5$K7" value="true" />
+    <property role="R4oN_" value="Represents files and namespaces" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
+      <property role="IQ2ns" value="7232527154588292748" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="usingDirectives" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    </node>
+    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2H$QQEUtQI0">
+    <property role="EcuMT" value="3126865292743371648" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingAliasDirective" />
+    <property role="34LRSv" value="using alias" />
+    <property role="R4oN_" value="Using alias directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
+    </node>
+    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
+            <property role="3oM_SC" value="using-alias-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098556" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jNJogm">
+    <property role="EcuMT" value="451639884260410390" />
+    <property role="TrG5h" value="NamespaceReference" />
+    <property role="R4oN_" value="Reference to a namespace" />
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
+      <property role="IQ2ns" value="451639884260410769" />
+      <property role="20kJfa" value="referencedType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
+      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
+    </node>
   </node>
 </model>
 

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <solution name="CsBaseLanguage.tests" uuid="85448cda-55d5-4c99-ba46-d755779e2512" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
@@ -16,7 +16,6 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">d74e25c9-4d91-43b6-bad7-d18af7bf6674(CsBaseLanguage)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
-    <dependency reexport="false">6b3888c1-9802-44d8-8baf-f8e6c33ed689(jetbrains.mps.kotlin)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:d74e25c9-4d91-43b6-bad7-d18af7bf6674:CsBaseLanguage" version="2" />
@@ -46,14 +45,11 @@
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
     <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
-    <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
     <module reference="5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
-    <module reference="6b3888c1-9802-44d8-8baf-f8e6c33ed689(jetbrains.mps.kotlin)" version="1" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
     <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
-    <module reference="c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
   </dependencyVersions>
 </solution>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/.model
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/.model
@@ -12,8 +12,7 @@
     <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
     <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" />
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
-    <import index="hcm8" ref="r:72a7bf00-0175-42ca-b99b-fe8519b6a16f(jetbrains.mps.kotlin.structure)" />
-    <import index="df4k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.editor.runtime.deletionApprover(MPS.Editor/)" />
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" />
   </imports>
 </model>
 

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingAlias.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingAlias.mpsr
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
-        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
-      </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
         <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
@@ -19,16 +18,11 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
-      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
-        <property id="1227184461946" name="keys" index="2TTd_B" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
-    </language>
-    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
-      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
-        <property id="1207318242774" name="keycode" index="pLAjf" />
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -37,9 +31,16 @@
       </concept>
     </language>
     <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292743371648" name="CsBaseLanguage.structure.UsingAliasDirective" flags="ng" index="2h4V3E">
+        <child id="3126865292760098556" name="reference" index="2g4BQm" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc" />
       <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
       <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
         <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -52,43 +53,34 @@
       </concept>
     </language>
   </registry>
-  <node concept="LiM7Y" id="fEeb945IUa">
-    <property role="TrG5h" value="FileDeclaration" />
+  <node concept="LiM7Y" id="2H$QQEVkMj1">
     <property role="3GE5qa" value="editor.BasicEditing.File" />
-    <node concept="3clFbS" id="fEeb945IUb" role="LjaKd">
-      <node concept="2TK7Tu" id="fEeb945IUc" role="3cqZAp">
-        <property role="2TTd_B" value="Program.cs" />
-      </node>
-      <node concept="yd1bK" id="fEeb945USN" role="3cqZAp">
-        <node concept="pLAjd" id="fEeb945USP" role="yd6KS">
-          <property role="pLAjf" value="VK_TAB" />
-        </node>
-      </node>
-    </node>
-    <node concept="1qefOq" id="fEeb945RP4" role="25YQCW">
-      <node concept="31LFg6" id="fEeb945RP2" role="1qenE9">
-        <node concept="31LefJ" id="fEeb945RP3" role="31LlDr" />
-        <node concept="LIFWc" id="fEeb945RP8" role="lGtFl">
+    <property role="TrG5h" value="FileDeclaration_AddUsingAlias" />
+    <node concept="1qefOq" id="2H$QQEVkMj2" role="25YQCW">
+      <node concept="31LFg6" id="2H$QQEVkMj3" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEVkMj4" role="31LlDr" />
+        <node concept="LIFWc" id="2H$QQEVkMj5" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="property_name" />
+          <property role="LIFWd" value="Constant_jqfb9k_f0" />
         </node>
       </node>
     </node>
-    <node concept="1qefOq" id="fEeb945RPc" role="25YQFr">
-      <node concept="31LFg6" id="fEeb9463zs" role="1qenE9">
-        <property role="TrG5h" value="Program.cs" />
-        <node concept="31LefJ" id="fEeb9463zt" role="31LlDr">
-          <node concept="LIFWc" id="fEeb9463zA" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="0" />
-            <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Error" />
-          </node>
+    <node concept="1qefOq" id="2H$QQEVkMj6" role="25YQFr">
+      <node concept="31LFg6" id="2H$QQEVkMj7" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEVkMj8" role="31LlDr" />
+        <node concept="2h4V3E" id="2H$QQEVP6Ul" role="31LgYG">
+          <node concept="2Gatwc" id="2H$QQEVP6Um" role="2g4BQm" />
         </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEVkMjb" role="LjaKd">
+      <node concept="1MFPAf" id="2H$QQEVkMjc" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:2H$QQEVk$bR" resolve="AddUsingAlias" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingDirective.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingDirective.mpsr
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
-        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
-      </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
         <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
@@ -19,16 +18,11 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
-      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
-        <property id="1227184461946" name="keys" index="2TTd_B" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
-    </language>
-    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
-      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
-        <property id="1207318242774" name="keycode" index="pLAjf" />
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -37,10 +31,17 @@
       </concept>
     </language>
     <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
+      </concept>
       <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
       <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
         <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
       </concept>
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -52,43 +53,34 @@
       </concept>
     </language>
   </registry>
-  <node concept="LiM7Y" id="fEeb945IUa">
-    <property role="TrG5h" value="FileDeclaration" />
+  <node concept="LiM7Y" id="2H$QQEUqHnx">
     <property role="3GE5qa" value="editor.BasicEditing.File" />
-    <node concept="3clFbS" id="fEeb945IUb" role="LjaKd">
-      <node concept="2TK7Tu" id="fEeb945IUc" role="3cqZAp">
-        <property role="2TTd_B" value="Program.cs" />
-      </node>
-      <node concept="yd1bK" id="fEeb945USN" role="3cqZAp">
-        <node concept="pLAjd" id="fEeb945USP" role="yd6KS">
-          <property role="pLAjf" value="VK_TAB" />
-        </node>
-      </node>
-    </node>
-    <node concept="1qefOq" id="fEeb945RP4" role="25YQCW">
-      <node concept="31LFg6" id="fEeb945RP2" role="1qenE9">
-        <node concept="31LefJ" id="fEeb945RP3" role="31LlDr" />
-        <node concept="LIFWc" id="fEeb945RP8" role="lGtFl">
+    <property role="TrG5h" value="FileDeclaration_AddUsingDirective" />
+    <node concept="1qefOq" id="2H$QQEUqHny" role="25YQCW">
+      <node concept="31LFg6" id="2H$QQEUqHnA" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEUqHnB" role="31LlDr" />
+        <node concept="LIFWc" id="2H$QQEUqHnE" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="property_name" />
+          <property role="LIFWd" value="Constant_jqfb9k_f0" />
         </node>
       </node>
     </node>
-    <node concept="1qefOq" id="fEeb945RPc" role="25YQFr">
-      <node concept="31LFg6" id="fEeb9463zs" role="1qenE9">
-        <property role="TrG5h" value="Program.cs" />
-        <node concept="31LefJ" id="fEeb9463zt" role="31LlDr">
-          <node concept="LIFWc" id="fEeb9463zA" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="0" />
-            <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Error" />
-          </node>
+    <node concept="1qefOq" id="2H$QQEUqHnG" role="25YQFr">
+      <node concept="31LFg6" id="2H$QQEUqHnK" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEUqHnL" role="31LlDr" />
+        <node concept="2gdQUG" id="2H$QQEVP9qG" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVP9qH" role="2g4BQj" />
         </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEUqHnQ" role="LjaKd">
+      <node concept="1MFPAf" id="2H$QQEUqHqm" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:p4z1jPjlIe" resolve="AddUsingDirectives" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingsManually.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_AddUsingsManually.mpsr
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
+      </concept>
+      <concept id="3126865292743371648" name="CsBaseLanguage.structure.UsingAliasDirective" flags="ng" index="2h4V3E">
+        <child id="3126865292760098556" name="reference" index="2g4BQm" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc" />
+      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
+      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
+        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2H$QQEVRVSQ">
+    <property role="3GE5qa" value="editor.BasicEditing.File" />
+    <property role="TrG5h" value="FileDeclaration_AddUsingsManually" />
+    <node concept="1qefOq" id="2H$QQEVRVSR" role="25YQCW">
+      <node concept="31LFg6" id="2H$QQEVRVSV" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEVRVSW" role="31LlDr" />
+        <node concept="2gdQUG" id="2H$QQEVRVSZ" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVRVT0" role="2g4BQj" />
+          <node concept="LIFWc" id="2H$QQEVT9JX" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="1" />
+            <property role="p6zMs" value="1" />
+            <property role="LIFWd" value="Constant_n57xbu_c0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEVRVTb" role="25YQFr">
+      <node concept="31LFg6" id="2H$QQEVRVTu" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEVRVTv" role="31LlDr" />
+        <node concept="2gdQUG" id="2H$QQEVRVTw" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVRVTx" role="2g4BQj" />
+        </node>
+        <node concept="2gdQUG" id="2H$QQEVS3pY" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVS3q0" role="2g4BQj" />
+        </node>
+        <node concept="2h4V3E" id="2H$QQEVT4SI" role="31LgYG">
+          <node concept="2Gatwc" id="2H$QQEVT4SL" role="2g4BQm" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEVRVUW" role="LjaKd">
+      <node concept="2HxZob" id="2H$QQEVTeI4" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVTeIl" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVRW36" role="3cqZAp">
+        <property role="2TTd_B" value="using " />
+      </node>
+      <node concept="2HxZob" id="2H$QQEVTeID" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVTeIE" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVRW8s" role="3cqZAp">
+        <property role="2TTd_B" value="using" />
+      </node>
+      <node concept="2HxZob" id="2H$QQEVS3_1" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVS3_f" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVS3EN" role="3cqZAp">
+        <property role="2TTd_B" value=" alias" />
+      </node>
+      <node concept="yd1bK" id="2H$QQEVToRV" role="3cqZAp">
+        <node concept="pLAjd" id="2H$QQEVToRX" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_RemoveLastUsing.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FileDeclaration_RemoveLastUsing.mpsr
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
+      </concept>
+      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
+      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
+        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2H$QQEUqJCE">
+    <property role="3GE5qa" value="editor.BasicEditing.File" />
+    <property role="TrG5h" value="FileDeclaration_RemoveLastUsing" />
+    <node concept="1qefOq" id="2H$QQEUqJCF" role="25YQCW">
+      <node concept="31LFg6" id="2H$QQEUqJCR" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEUqJCS" role="31LlDr" />
+        <node concept="2gdQUG" id="2H$QQEVP6Zd" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVP6Ze" role="2g4BQj" />
+          <node concept="LIFWc" id="2H$QQEVP70_" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="1" />
+            <property role="p6zMs" value="1" />
+            <property role="LIFWd" value="Constant_n57xbu_c0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEUqJCJ" role="25YQFr">
+      <node concept="31LFg6" id="2H$QQEUqJCK" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2H$QQEUqJCL" role="31LlDr" />
+        <node concept="LIFWc" id="2H$QQEUqJCZ" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_jqfb9k_f0" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEUqJCN" role="LjaKd">
+      <node concept="3clFbF" id="2H$QQEUr0Zn" role="3cqZAp">
+        <node concept="2YIFZM" id="2H$QQEUr0ZI" role="3clFbG">
+          <ref role="37wK5l" to="tp6m:14TMHtHs1EN" resolve="runWithTwoStepDeletion" />
+          <ref role="1Pybhc" to="tp6m:5s44y2Lh6_5" resolve="EditorTestUtil" />
+          <node concept="1bVj0M" id="2H$QQEUr13R" role="37wK5m">
+            <node concept="3clFbS" id="2H$QQEUr13U" role="1bW5cS">
+              <node concept="2HxZob" id="2H$QQEUr1b7" role="3cqZAp">
+                <node concept="1iFQzN" id="2H$QQEUr1do" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+              <node concept="2HxZob" id="2H$QQEUr1e8" role="3cqZAp">
+                <node concept="1iFQzN" id="2H$QQEUr1e9" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="2H$QQEUr1wu" role="37wK5m">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingAlias.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingAlias.mpsr
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
-        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
-      </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
         <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
@@ -19,16 +18,11 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
-      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
-        <property id="1227184461946" name="keys" index="2TTd_B" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
-    </language>
-    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
-      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
-        <property id="1207318242774" name="keycode" index="pLAjf" />
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -37,9 +31,13 @@
       </concept>
     </language>
     <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
-      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
-      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
-        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      <concept id="3126865292743371648" name="CsBaseLanguage.structure.UsingAliasDirective" flags="ng" index="2h4V3E">
+        <child id="3126865292760098556" name="reference" index="2g4BQm" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc" />
+      <concept id="7232527154588302801" name="CsBaseLanguage.structure.NamespaceDeclaration" flags="ng" index="31LijL" />
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -52,43 +50,32 @@
       </concept>
     </language>
   </registry>
-  <node concept="LiM7Y" id="fEeb945IUa">
-    <property role="TrG5h" value="FileDeclaration" />
-    <property role="3GE5qa" value="editor.BasicEditing.File" />
-    <node concept="3clFbS" id="fEeb945IUb" role="LjaKd">
-      <node concept="2TK7Tu" id="fEeb945IUc" role="3cqZAp">
-        <property role="2TTd_B" value="Program.cs" />
-      </node>
-      <node concept="yd1bK" id="fEeb945USN" role="3cqZAp">
-        <node concept="pLAjd" id="fEeb945USP" role="yd6KS">
-          <property role="pLAjf" value="VK_TAB" />
-        </node>
-      </node>
-    </node>
-    <node concept="1qefOq" id="fEeb945RP4" role="25YQCW">
-      <node concept="31LFg6" id="fEeb945RP2" role="1qenE9">
-        <node concept="31LefJ" id="fEeb945RP3" role="31LlDr" />
-        <node concept="LIFWc" id="fEeb945RP8" role="lGtFl">
+  <node concept="LiM7Y" id="2H$QQEVkMlf">
+    <property role="3GE5qa" value="editor.BasicEditing.NamespaceDeclaration" />
+    <property role="TrG5h" value="NamespaceDeclaration_AddUsingAlias" />
+    <node concept="1qefOq" id="2H$QQEVkMlg" role="25YQCW">
+      <node concept="31LijL" id="2H$QQEVkMlh" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="2H$QQEVkMli" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="property_name" />
+          <property role="LIFWd" value="Constant_4r64p2_a5a" />
         </node>
       </node>
     </node>
-    <node concept="1qefOq" id="fEeb945RPc" role="25YQFr">
-      <node concept="31LFg6" id="fEeb9463zs" role="1qenE9">
-        <property role="TrG5h" value="Program.cs" />
-        <node concept="31LefJ" id="fEeb9463zt" role="31LlDr">
-          <node concept="LIFWc" id="fEeb9463zA" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="0" />
-            <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Error" />
-          </node>
+    <node concept="1qefOq" id="2H$QQEVkMlj" role="25YQFr">
+      <node concept="31LijL" id="2H$QQEVkMlk" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="2h4V3E" id="2H$QQEVP6RD" role="31LgYG">
+          <node concept="2Gatwc" id="2H$QQEVP6RE" role="2g4BQm" />
         </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEVkMln" role="LjaKd">
+      <node concept="1MFPAf" id="2H$QQEVkMlo" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:2H$QQEVk$bR" resolve="AddUsingAlias" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingDirective.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingDirective.mpsr
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
   <persistence version="9" />
-  <imports />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
   <registry>
     <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
-      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
-        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
-      </concept>
       <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
         <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
         <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
@@ -19,16 +18,11 @@
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
         <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
-      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
-        <property id="1227184461946" name="keys" index="2TTd_B" />
-      </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
         <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
       </concept>
-    </language>
-    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
-      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
-        <property id="1207318242774" name="keycode" index="pLAjf" />
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
       </concept>
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -37,10 +31,14 @@
       </concept>
     </language>
     <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
-      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
-      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
-        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
       </concept>
+      <concept id="7232527154588302801" name="CsBaseLanguage.structure.NamespaceDeclaration" flags="ng" index="31LijL" />
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -52,43 +50,32 @@
       </concept>
     </language>
   </registry>
-  <node concept="LiM7Y" id="fEeb945IUa">
-    <property role="TrG5h" value="FileDeclaration" />
-    <property role="3GE5qa" value="editor.BasicEditing.File" />
-    <node concept="3clFbS" id="fEeb945IUb" role="LjaKd">
-      <node concept="2TK7Tu" id="fEeb945IUc" role="3cqZAp">
-        <property role="2TTd_B" value="Program.cs" />
-      </node>
-      <node concept="yd1bK" id="fEeb945USN" role="3cqZAp">
-        <node concept="pLAjd" id="fEeb945USP" role="yd6KS">
-          <property role="pLAjf" value="VK_TAB" />
-        </node>
-      </node>
-    </node>
-    <node concept="1qefOq" id="fEeb945RP4" role="25YQCW">
-      <node concept="31LFg6" id="fEeb945RP2" role="1qenE9">
-        <node concept="31LefJ" id="fEeb945RP3" role="31LlDr" />
-        <node concept="LIFWc" id="fEeb945RP8" role="lGtFl">
+  <node concept="LiM7Y" id="2H$QQEUmuUa">
+    <property role="3GE5qa" value="editor.BasicEditing.NamespaceDeclaration" />
+    <property role="TrG5h" value="NamespaceDeclaration_AddUsingDirective" />
+    <node concept="1qefOq" id="2H$QQEUmuVR" role="25YQCW">
+      <node concept="31LijL" id="2H$QQEUmuWv" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="2H$QQEUmuYd" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="property_name" />
+          <property role="LIFWd" value="Constant_4r64p2_a5a" />
         </node>
       </node>
     </node>
-    <node concept="1qefOq" id="fEeb945RPc" role="25YQFr">
-      <node concept="31LFg6" id="fEeb9463zs" role="1qenE9">
-        <property role="TrG5h" value="Program.cs" />
-        <node concept="31LefJ" id="fEeb9463zt" role="31LlDr">
-          <node concept="LIFWc" id="fEeb9463zA" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="0" />
-            <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Error" />
-          </node>
+    <node concept="1qefOq" id="2H$QQEUmv1l" role="25YQFr">
+      <node concept="31LijL" id="2H$QQEUmv1F" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="2gdQUG" id="2H$QQEVP9tG" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVP9tH" role="2g4BQj" />
         </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2H$QQEUmv3J" role="LjaKd">
+      <node concept="1MFPAf" id="2H$QQEUmv88" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:p4z1jPjlIe" resolve="AddUsingDirectives" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingsManually.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_AddUsingsManually.mpsr
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
+      </concept>
+      <concept id="3126865292743371648" name="CsBaseLanguage.structure.UsingAliasDirective" flags="ng" index="2h4V3E">
+        <child id="3126865292760098556" name="reference" index="2g4BQm" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc" />
+      <concept id="7232527154588302801" name="CsBaseLanguage.structure.NamespaceDeclaration" flags="ng" index="31LijL" />
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2H$QQEVTro2">
+    <property role="3GE5qa" value="editor.BasicEditing.NamespaceDeclaration" />
+    <property role="TrG5h" value="NamespaceDeclaration_AddUsingsManually" />
+    <node concept="3clFbS" id="2H$QQEVTro3" role="LjaKd">
+      <node concept="2HxZob" id="2H$QQEVTrsJ" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVTrsK" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVTrsL" role="3cqZAp">
+        <property role="2TTd_B" value="using " />
+      </node>
+      <node concept="2HxZob" id="2H$QQEVTrsM" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVTrsN" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVTrsO" role="3cqZAp">
+        <property role="2TTd_B" value="using" />
+      </node>
+      <node concept="2HxZob" id="2H$QQEVTrsP" role="3cqZAp">
+        <node concept="1iFQzN" id="2H$QQEVTrsQ" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2H$QQEVTrsR" role="3cqZAp">
+        <property role="2TTd_B" value=" alias" />
+      </node>
+      <node concept="yd1bK" id="2H$QQEVTrsS" role="3cqZAp">
+        <node concept="pLAjd" id="2H$QQEVTrsT" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEVTrod" role="25YQCW">
+      <node concept="31LijL" id="2H$QQEVTroe" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="2gdQUG" id="2H$QQEVTrof" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVTrog" role="2g4BQj" />
+          <node concept="LIFWc" id="2H$QQEVTroh" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="1" />
+            <property role="p6zMs" value="1" />
+            <property role="LIFWd" value="Constant_n57xbu_c0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEVTroi" role="25YQFr">
+      <node concept="31LijL" id="2H$QQEVTroj" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="2gdQUG" id="2H$QQEVTrsn" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVTrso" role="2g4BQj" />
+        </node>
+        <node concept="2gdQUG" id="2H$QQEVTrsr" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVTrss" role="2g4BQj" />
+        </node>
+        <node concept="2h4V3E" id="2H$QQEVTrsv" role="31LgYG">
+          <node concept="2Gatwc" id="2H$QQEVTrsw" role="2g4BQm" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_Base.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_Base.mpsr
@@ -85,12 +85,12 @@
         <property role="TrG5h" value="Program.cs" />
         <node concept="31LijL" id="yQEJGZBhsU" role="31LlDr">
           <property role="TrG5h" value="Foo" />
-          <node concept="LIFWc" id="yQEJGZBj4H" role="lGtFl">
+          <node concept="LIFWc" id="2H$QQEUrWfm" role="lGtFl">
             <property role="ZRATv" value="true" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_4r64p2_a3a" />
+            <property role="LIFWd" value="Constant_4r64p2_a5a" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_Mix.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_Mix.mpsr
@@ -130,12 +130,12 @@
         <property role="TrG5h" value="Program.cs" />
         <node concept="31LijL" id="yQEJGZBnPv" role="31LlDr">
           <property role="TrG5h" value="Foo" />
-          <node concept="LIFWc" id="yQEJGZBnPQ" role="lGtFl">
+          <node concept="LIFWc" id="2H$QQEUrPWU" role="lGtFl">
             <property role="ZRATv" value="true" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_4r64p2_a3a" />
+            <property role="LIFWd" value="Constant_4r64p2_a5a" />
           </node>
         </node>
       </node>
@@ -153,7 +153,7 @@
           </node>
           <node concept="31LiCz" id="3tcg5UgpBjd" role="31LkaE">
             <property role="TrG5h" value="Bar" />
-            <node concept="LIFWc" id="3tcg5UgpBj$" role="lGtFl">
+            <node concept="LIFWc" id="2H$QQEUrPYG" role="lGtFl">
               <property role="ZRATv" value="true" />
               <property role="OXtK3" value="true" />
               <property role="p6zMq" value="0" />

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_RemoveLastUsing.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/NamespaceDeclaration_RemoveLastUsing.mpsr
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="3126865292757808582" name="CsBaseLanguage.structure.UsingNamespaceDirective" flags="ng" index="2gdQUG">
+        <child id="3126865292760098553" name="reference" index="2g4BQj" />
+      </concept>
+      <concept id="7232527154588302801" name="CsBaseLanguage.structure.NamespaceDeclaration" flags="ng" index="31LijL" />
+      <concept id="451639884280407984" name="CsBaseLanguage.structure.NamespaceContainer" flags="ng" index="3MEyI$">
+        <child id="7232527154588292748" name="usingDirectives" index="31LgYG" />
+      </concept>
+      <concept id="451639884260410390" name="CsBaseLanguage.structure.NamespaceReference" flags="ng" index="3PYgw2" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2H$QQEUr6IE">
+    <property role="3GE5qa" value="editor.BasicEditing.NamespaceDeclaration" />
+    <property role="TrG5h" value="NamespaceDeclaration_RemoveLastUsing" />
+    <node concept="3clFbS" id="2H$QQEUr6IF" role="LjaKd">
+      <node concept="3clFbF" id="2H$QQEUr6IH" role="3cqZAp">
+        <node concept="2YIFZM" id="2H$QQEUr6II" role="3clFbG">
+          <ref role="37wK5l" to="tp6m:14TMHtHs1EN" resolve="runWithTwoStepDeletion" />
+          <ref role="1Pybhc" to="tp6m:5s44y2Lh6_5" resolve="EditorTestUtil" />
+          <node concept="1bVj0M" id="2H$QQEUr6IJ" role="37wK5m">
+            <node concept="3clFbS" id="2H$QQEUr6IK" role="1bW5cS">
+              <node concept="2HxZob" id="2H$QQEUr6IL" role="3cqZAp">
+                <node concept="1iFQzN" id="2H$QQEUr6IM" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+              <node concept="2HxZob" id="2H$QQEUr6IN" role="3cqZAp">
+                <node concept="1iFQzN" id="2H$QQEUr6IO" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="2H$QQEUr6IP" role="37wK5m">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEUr6JT" role="25YQCW">
+      <node concept="31LijL" id="2H$QQEUr6Mw" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="2gdQUG" id="2H$QQEVP9rC" role="31LgYG">
+          <node concept="3PYgw2" id="2H$QQEVP9rD" role="2g4BQj" />
+          <node concept="LIFWc" id="2H$QQEVP9rG" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="1" />
+            <property role="p6zMs" value="1" />
+            <property role="LIFWd" value="Constant_n57xbu_c0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2H$QQEUr6MA" role="25YQFr">
+      <node concept="31LijL" id="2H$QQEUr6Nu" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="2H$QQEUr6Ny" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
New concepts have been added to represent both directives specified by the C# 5.0 grammar: using-alias-directive and using-namespace-directive.

Using directives are now contained in the new abstract concept NamespaceContainer, which also provides their editor component. This obsoletes the UsingDirectiveList concept, whose usages have been marked as deprecated. An empty list of directives is hidden in order to keep the editor clean, so NamespaceContainer has two intentions for adding new directives.

The using alias is practically usable as a referenceable type, but is incorrectly shown in its own completion menu and those of its siblings. The namespace directive uses the new NamespaceReference to constrain its completion menu, but is otherwise cosmetic: the rest of the language is not yet aware of the imported scopes. For example, references are still created with fully qualified names, though users could now choose to shorten these afterwards.