### PR TITLE
Support for implicitly typed variables, small improvements

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.migration.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.migration.mps
@@ -119,10 +119,6 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
       <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
         <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
         <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
@@ -130,9 +126,6 @@
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
-      </concept>
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
-        <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -246,18 +239,12 @@
                       </node>
                       <node concept="3clFbF" id="6O4r_td9CgV" role="3cqZAp">
                         <node concept="37vLTI" id="6O4r_td9Ed1" role="3clFbG">
-                          <node concept="1PxgMI" id="6O4r_td9GJq" role="37vLTx">
-                            <property role="1BlNFB" value="true" />
-                            <node concept="chp4Y" id="6O4r_td9GXf" role="3oSUPX">
-                              <ref role="cht4Q" to="80bi:5VT83U$LgKs" resolve="Expression" />
+                          <node concept="2OqwBi" id="6O4r_td9EKo" role="37vLTx">
+                            <node concept="37vLTw" id="6O4r_td9Eji" role="2Oq$k0">
+                              <ref role="3cqZAo" node="2HvFt1LGtfv" resolve="it" />
                             </node>
-                            <node concept="2OqwBi" id="6O4r_td9EKo" role="1m5AlR">
-                              <node concept="37vLTw" id="6O4r_td9Eji" role="2Oq$k0">
-                                <ref role="3cqZAo" node="2HvFt1LGtfv" resolve="it" />
-                              </node>
-                              <node concept="3TrEf2" id="6O4r_td9FRY" role="2OqNvi">
-                                <ref role="3Tt5mk" to="80bi:1FYNzU$nYDt" resolve="variableInitializer" />
-                              </node>
+                            <node concept="3TrEf2" id="6O4r_td9FRY" role="2OqNvi">
+                              <ref role="3Tt5mk" to="80bi:1FYNzU$nYDt" resolve="variableInitializer" />
                             </node>
                           </node>
                           <node concept="2OqwBi" id="6O4r_td9CyZ" role="37vLTJ">

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -152,6 +152,9 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
@@ -168,6 +171,7 @@
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
@@ -180,6 +184,10 @@
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144100932627" name="jetbrains.mps.lang.smodel.structure.OperationParm_Inclusion" flags="ng" index="1xIGOp" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1144195091934" name="jetbrains.mps.lang.smodel.structure.Node_IsRoleOperation" flags="nn" index="1BlSNk">
         <reference id="1144195362400" name="conceptOfParent" index="1BmUXE" />
         <reference id="1144195396777" name="linkInParent" index="1Bn3mz" />
@@ -243,6 +251,7 @@
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="1M2fIO" id="3grCvve6NV9">
@@ -2499,6 +2508,62 @@
                     <node concept="2jxLKc" id="2ETkgtjnEQ2" role="1tU5fm" />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5xnAHgZmc2p">
+    <property role="3GE5qa" value="Initializers" />
+    <ref role="1M2myG" to="80bi:5VT83U$Mmmn" resolve="ArrayInitializer" />
+    <node concept="9S07l" id="5xnAHgZmc2q" role="9Vyp8">
+      <node concept="3clFbS" id="5xnAHgZmc2r" role="2VODD2">
+        <node concept="Jncv_" id="5xnAHgZme4v" role="3cqZAp">
+          <ref role="JncvD" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+          <node concept="nLn13" id="5xnAHgZme5f" role="JncvB" />
+          <node concept="3clFbS" id="5xnAHgZme4x" role="Jncv$">
+            <node concept="3cpWs6" id="5xnAHgZme91" role="3cqZAp">
+              <node concept="2OqwBi" id="5xnAHgZmhW2" role="3cqZAk">
+                <node concept="2OqwBi" id="5xnAHgZmfox" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5xnAHgZmeSv" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5xnAHgZmenm" role="2Oq$k0">
+                      <node concept="Jnkvi" id="5xnAHgZmea5" role="2Oq$k0">
+                        <ref role="1M0zk5" node="5xnAHgZme4y" resolve="declaration" />
+                      </node>
+                      <node concept="2Xjw5R" id="5xnAHgZmeCB" role="2OqNvi">
+                        <node concept="1xMEDy" id="5xnAHgZmeCD" role="1xVPHs">
+                          <node concept="chp4Y" id="5xnAHgZmeFK" role="ri$Ld">
+                            <ref role="cht4Q" to="80bi:5oHFRyIxp1s" resolve="IHaveType" />
+                          </node>
+                        </node>
+                        <node concept="1xIGOp" id="5xnAHgZmeK7" role="1xVPHs" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="5xnAHgZmfb2" role="2OqNvi">
+                      <ref role="3Tt5mk" to="80bi:5oHFRyIxpPa" resolve="type" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5xnAHgZmfAy" role="2OqNvi">
+                    <ref role="3TtcxE" to="80bi:5VT83U$LPq1" resolve="rankSpecifier" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="5xnAHgZmjUf" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="5xnAHgZme4y" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="5xnAHgZme4z" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5xnAHgZmjZ$" role="3cqZAp">
+          <node concept="2OqwBi" id="5xnAHgZmUF1" role="3cqZAk">
+            <node concept="nLn13" id="5xnAHgZmTqc" role="2Oq$k0" />
+            <node concept="1mIQ4w" id="5xnAHgZmUXp" role="2OqNvi">
+              <node concept="chp4Y" id="5xnAHgZmV0L" role="cj9EA">
+                <ref role="cht4Q" to="80bi:5VT83U$Mxwu" resolve="NewArrayTypeExpression" />
               </node>
             </node>
           </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -21314,5 +21314,24 @@
       </node>
     </node>
   </node>
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+    </node>
+  </node>
 </model>
 

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -46,7 +46,6 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="3459162043708467089" name="jetbrains.mps.lang.editor.structure.CellActionMap_CanExecuteFunction" flags="in" index="jK8Ss" />
-      <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
@@ -213,12 +212,6 @@
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
       <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
-      </concept>
-      <concept id="6684862045052272180" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_NodeToWrap" flags="ng" index="3N4pyC" />
-      <concept id="6684862045052059649" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_WrapperHandler" flags="ig" index="3N5aqt" />
-      <concept id="6684862045052059291" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Wrapper" flags="ng" index="3N5dw7">
-        <child id="6089045305655104958" name="reference" index="2klrvf" />
-        <child id="6684862045053873740" name="handler" index="3Na0zg" />
       </concept>
       <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
         <child id="1948540814633499358" name="editorContext" index="lBI5i" />
@@ -1109,7 +1102,7 @@
       <node concept="l2Vlx" id="5VT83U$MmmB" role="2iSdaV" />
       <node concept="3F2HdR" id="5VT83U$MmmY" role="3EZMnx">
         <property role="2czwfO" value="," />
-        <ref role="1NtTu8" to="80bi:5VT83U$Mmmo" resolve="varibaleInitializer" />
+        <ref role="1NtTu8" to="80bi:5VT83U$Mmmo" resolve="variableInitializer" />
         <node concept="l2Vlx" id="5VT83U$Mmn0" role="2czzBx" />
         <node concept="3F0ifn" id="5VT83U$Mmn5" role="2czzBI">
           <property role="3F0ifm" value="" />
@@ -9351,40 +9344,6 @@
     <node concept="22hDWj" id="BJMgwyacLl" role="22hAXT" />
     <node concept="3XHNnq" id="2TJLM7Ko6LO" role="3ft7WO">
       <ref role="3XGfJA" to="80bi:6JhOkL8vqK8" resolve="variableDeclaration" />
-    </node>
-  </node>
-  <node concept="22mcaB" id="1fX_MJettni">
-    <ref role="aqKnT" to="80bi:1fX_MJerWT3" resolve="AmbiguousMemberReference" />
-    <node concept="22hDWj" id="BJMgwyacLm" role="22hAXT" />
-    <node concept="3N5dw7" id="1fX_MJetvlX" role="3ft7WO">
-      <ref role="3EoQqy" to="80bi:5E$Mk4xjGdE" resolve="MemberReference" />
-      <node concept="3N5aqt" id="1fX_MJetvlY" role="3Na0zg">
-        <node concept="3clFbS" id="1fX_MJetvlZ" role="2VODD2">
-          <node concept="3cpWs6" id="1fX_MJetvun" role="3cqZAp">
-            <node concept="3N4pyC" id="1fX_MJetvxY" role="3cqZAk" />
-          </node>
-        </node>
-      </node>
-      <node concept="2kknPJ" id="1fX_MJetvoO" role="2klrvf">
-        <ref role="2ZyFGn" to="80bi:5E$Mk4xjGdE" resolve="MemberReference" />
-      </node>
-    </node>
-  </node>
-  <node concept="22mcaB" id="5gskHI0ff8g">
-    <ref role="aqKnT" to="80bi:5gskHI0ff0Y" resolve="AmbiguousTypeReference" />
-    <node concept="22hDWj" id="BJMgwyacLn" role="22hAXT" />
-    <node concept="3N5dw7" id="5gskHI0ff8h" role="3ft7WO">
-      <ref role="3EoQqy" to="80bi:27q4jmdWYxN" resolve="TypeReference" />
-      <node concept="3N5aqt" id="5gskHI0ff8i" role="3Na0zg">
-        <node concept="3clFbS" id="5gskHI0ff8j" role="2VODD2">
-          <node concept="3cpWs6" id="5gskHI0ffhb" role="3cqZAp">
-            <node concept="3N4pyC" id="5gskHI0ffkn" role="3cqZAk" />
-          </node>
-        </node>
-      </node>
-      <node concept="2kknPJ" id="5gskHI0ffdQ" role="2klrvf">
-        <ref role="2ZyFGn" to="80bi:27q4jmdWYxN" resolve="TypeReference" />
-      </node>
     </node>
   </node>
   <node concept="3ICUPy" id="3eIapyQ4M1g">
@@ -21147,6 +21106,25 @@
       </node>
     </node>
   </node>
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+    </node>
+  </node>
   <node concept="1h_SRR" id="2H$QQET29s8">
     <property role="3GE5qa" value="Namespace" />
     <property role="TrG5h" value="DeleteUsingDirective" />
@@ -21312,25 +21290,6 @@
       <node concept="A1WHr" id="2H$QQEUYLQG" role="3vIgyS">
         <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
       </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="5xnAHgZa2GI">
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
-    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
-      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      </node>
-      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
-      </node>
-      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -16991,5 +16991,248 @@
       <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
     </node>
   </node>
+  <node concept="1TIwiD" id="5xnAHgZa2vT">
+    <property role="EcuMT" value="6365726834694825977" />
+    <property role="TrG5h" value="ImplicitLocalVariableDeclaration" />
+    <property role="34LRSv" value="var" />
+    <property role="R4oN_" value="Implicitly typed local variable declaration" />
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1TJDcQ" node="1FYNzU$mBmN" resolve="DeclarationStatement" />
+    <node concept="1TJgyj" id="5xnAHgZdlnx" role="1TKVEi">
+      <property role="IQ2ns" value="6365726834695689697" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="variable" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6JhOkL8vqJY" resolve="VariableDeclaration" />
+    </node>
+    <node concept="3H0Qfr" id="5xnAHgZg7HE" role="lGtFl">
+      <node concept="1Pa9Pv" id="5xnAHgZg7HF" role="3H0Qfi">
+        <node concept="1PaTwC" id="5xnAHgZg7HG" role="1PaQFQ">
+          <node concept="3oM_SD" id="5xnAHgZg7PN" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg7Wi" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg7Qu" role="1PaTwD">
+            <property role="3oM_SC" value="local" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg7Ra" role="1PaTwD">
+            <property role="3oM_SC" value="variable" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg7Rl" role="1PaTwD">
+            <property role="3oM_SC" value="declaration" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg85j" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;whose" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg86u" role="1PaTwD">
+            <property role="3oM_SC" value="type" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg86A" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg87h" role="1PaTwD">
+            <property role="3oM_SC" value="inferred" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg87X" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg888" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg88k" role="1PaTwD">
+            <property role="3oM_SC" value="type" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg88x" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg89h" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg89w" role="1PaTwD">
+            <property role="3oM_SC" value="associated" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8ai" role="1PaTwD">
+            <property role="3oM_SC" value="initializer" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8b5" role="1PaTwD">
+            <property role="3oM_SC" value="expression&quot;" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8e6" role="1PaTwD">
+            <property role="3oM_SC" value="(C#" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8eV" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8le" role="1PaTwD">
+            <property role="3oM_SC" value="§8.5.1)." />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8xV" role="1PaTwD">
+            <property role="3oM_SC" value="Only" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8zl" role="1PaTwD">
+            <property role="3oM_SC" value="one" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8zG" role="1PaTwD">
+            <property role="3oM_SC" value="such" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8_V" role="1PaTwD">
+            <property role="3oM_SC" value="variable" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Bo" role="1PaTwD">
+            <property role="3oM_SC" value="may" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8BM" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Cd" role="1PaTwD">
+            <property role="3oM_SC" value="declared" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Db" role="1PaTwD">
+            <property role="3oM_SC" value="per" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8F7" role="1PaTwD">
+            <property role="3oM_SC" value="statement" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjkT7" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8F_" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8GA" role="1PaTwD">
+            <property role="3oM_SC" value="initializer" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjkU4" role="1PaTwD">
+            <property role="3oM_SC" value="expression" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Ia" role="1PaTwD">
+            <property role="3oM_SC" value="must" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Jd" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8JJ" role="1PaTwD">
+            <property role="3oM_SC" value="present" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8PM" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8QS" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8WG" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Xk" role="1PaTwD">
+            <property role="3oM_SC" value="compile-time" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8Yv" role="1PaTwD">
+            <property role="3oM_SC" value="type" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg8ZF" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg92N" role="1PaTwD">
+            <property role="3oM_SC" value="does" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg941" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg94I" role="1PaTwD">
+            <property role="3oM_SC" value="refer" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg95Y" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg96H" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg97t" role="1PaTwD">
+            <property role="3oM_SC" value="declared" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg99O" role="1PaTwD">
+            <property role="3oM_SC" value="variable" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg9Ta" role="1PaTwD">
+            <property role="3oM_SC" value="itself." />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg9Vy" role="1PaTwD">
+            <property role="3oM_SC" value="Additionally," />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm5e" role="1PaTwD">
+            <property role="3oM_SC" value="implicitly" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm6p" role="1PaTwD">
+            <property role="3oM_SC" value="typed" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm7_" role="1PaTwD">
+            <property role="3oM_SC" value="variables" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm8M" role="1PaTwD">
+            <property role="3oM_SC" value="cannot" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjma0" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmbf" role="1PaTwD">
+            <property role="3oM_SC" value="declared" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmiv" role="1PaTwD">
+            <property role="3oM_SC" value="if" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjlR3" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjlTA" role="1PaTwD">
+            <property role="3oM_SC" value="type" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg9Oi" role="1PaTwD">
+            <property role="3oM_SC" value="named" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZg9On" role="1PaTwD">
+            <property role="3oM_SC" value="&quot;var&quot;" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmjD" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmkO" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmod" role="1PaTwD">
+            <property role="3oM_SC" value="scope," />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm_9" role="1PaTwD">
+            <property role="3oM_SC" value="because" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmrm" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmuy" role="1PaTwD">
+            <property role="3oM_SC" value="typename" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmvA" role="1PaTwD">
+            <property role="3oM_SC" value="has" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmwF" role="1PaTwD">
+            <property role="3oM_SC" value="precedence" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmxL" role="1PaTwD">
+            <property role="3oM_SC" value="over" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjmyS" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZjm$0" role="1PaTwD">
+            <property role="3oM_SC" value="keyword." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="PrWs8" id="5xnAHgZghJ3" role="PzmwI">
+      <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
+    </node>
+  </node>
 </model>
 

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -16189,7 +16189,7 @@
       <property role="IQ2ns" value="3125407777189916705" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="initializer" />
-      <ref role="20lvS9" node="5VT83U$LgKs" resolve="Expression" />
+      <ref role="20lvS9" node="1FYNzU$nG$p" resolve="IVariableInitializer" />
     </node>
   </node>
   <node concept="PlHQZ" id="6JhOkL8vqKa">
@@ -16884,113 +16884,6 @@
     <property role="34LRSv" value="set" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
   </node>
-  <node concept="1TIwiD" id="2H$QQEVkVn6">
-    <property role="EcuMT" value="3126865292757808582" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingNamespaceDirective" />
-    <property role="34LRSv" value="using" />
-    <property role="R4oN_" value="Using directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
-            <property role="3oM_SC" value="using-namespace-directive" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098553" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="p4z1jOVEuK">
-    <property role="EcuMT" value="451639884280407984" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="NamespaceContainer" />
-    <property role="R5$K7" value="true" />
-    <property role="R4oN_" value="Represents files and namespaces" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
-    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588292748" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="usingDirectives" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    </node>
-    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="2H$QQEUtQI0">
-    <property role="EcuMT" value="3126865292743371648" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingAliasDirective" />
-    <property role="34LRSv" value="using alias" />
-    <property role="R4oN_" value="Using alias directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
-      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
-    </node>
-    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
-            <property role="3oM_SC" value="using-alias-directive" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098556" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="p4z1jNJogm">
-    <property role="EcuMT" value="451639884260410390" />
-    <property role="TrG5h" value="NamespaceReference" />
-    <property role="R4oN_" value="Reference to a namespace" />
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
-      <property role="IQ2ns" value="451639884260410769" />
-      <property role="20kJfa" value="referencedType" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
-      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
-    </node>
-  </node>
   <node concept="1TIwiD" id="5xnAHgZa2vT">
     <property role="EcuMT" value="6365726834694825977" />
     <property role="TrG5h" value="ImplicitLocalVariableDeclaration" />
@@ -17232,6 +17125,113 @@
     </node>
     <node concept="PrWs8" id="5xnAHgZghJ3" role="PzmwI">
       <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2H$QQEVkVn6">
+    <property role="EcuMT" value="3126865292757808582" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingNamespaceDirective" />
+    <property role="34LRSv" value="using" />
+    <property role="R4oN_" value="Using directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
+            <property role="3oM_SC" value="using-namespace-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098553" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jOVEuK">
+    <property role="EcuMT" value="451639884280407984" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="NamespaceContainer" />
+    <property role="R5$K7" value="true" />
+    <property role="R4oN_" value="Represents files and namespaces" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
+      <property role="IQ2ns" value="7232527154588292748" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="usingDirectives" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    </node>
+    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2H$QQEUtQI0">
+    <property role="EcuMT" value="3126865292743371648" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingAliasDirective" />
+    <property role="34LRSv" value="using alias" />
+    <property role="R4oN_" value="Using alias directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
+    </node>
+    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
+            <property role="3oM_SC" value="using-alias-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098556" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jNJogm">
+    <property role="EcuMT" value="451639884260410390" />
+    <property role="TrG5h" value="NamespaceReference" />
+    <property role="R4oN_" value="Reference to a namespace" />
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
+      <property role="IQ2ns" value="451639884260410769" />
+      <property role="20kJfa" value="referencedType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
+      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -711,14 +711,14 @@
   <node concept="1TIwiD" id="5VT83U$Mmmn">
     <property role="EcuMT" value="6843536562190902679" />
     <property role="TrG5h" value="ArrayInitializer" />
-    <property role="34LRSv" value="{init}" />
+    <property role="34LRSv" value="{" />
     <property role="R4oN_" value="array initializer" />
     <property role="3GE5qa" value="Initializers" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
     <node concept="1TJgyj" id="5VT83U$Mmmo" role="1TKVEi">
       <property role="IQ2ns" value="6843536562190902680" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="varibaleInitializer" />
+      <property role="20kJfa" value="variableInitializer" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="1FYNzU$nG$p" resolve="IVariableInitializer" />
     </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
@@ -109,5 +109,51 @@
       <ref role="1YaFvo" to="80bi:6hv6i2_B48E" resolve="ConstantDeclarator" />
     </node>
   </node>
+  <node concept="18kY7G" id="5xnAHgZgi8F">
+    <property role="TrG5h" value="check_ImplicitLocalVariableDeclaration" />
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <node concept="3clFbS" id="5xnAHgZgi8G" role="18ibNy">
+      <node concept="3clFbJ" id="5xnAHgZgibI" role="3cqZAp">
+        <node concept="2OqwBi" id="5xnAHgZgl17" role="3clFbw">
+          <node concept="2OqwBi" id="5xnAHgZgktN" role="2Oq$k0">
+            <node concept="2OqwBi" id="5xnAHgZgio9" role="2Oq$k0">
+              <node concept="1YBJjd" id="5xnAHgZgics" role="2Oq$k0">
+                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
+              </node>
+              <node concept="3TrEf2" id="5xnAHgZgkgk" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="5xnAHgZgkNk" role="2OqNvi">
+              <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+            </node>
+          </node>
+          <node concept="3w_OXm" id="5xnAHgZgltq" role="2OqNvi" />
+        </node>
+        <node concept="3clFbS" id="5xnAHgZgibK" role="3clFbx">
+          <node concept="2MkqsV" id="5xnAHgZglyy" role="3cqZAp">
+            <node concept="Xl_RD" id="5xnAHgZglzg" role="2MkJ7o">
+              <property role="Xl_RC" value="An implicitly typed declaration must be initialized." />
+            </node>
+            <node concept="2OqwBi" id="5xnAHgZglOj" role="1urrMF">
+              <node concept="1YBJjd" id="5xnAHgZglEg" role="2Oq$k0">
+                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
+              </node>
+              <node concept="3TrEf2" id="5xnAHgZgmrI" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
+              </node>
+            </node>
+            <node concept="AMVWg" id="5xnAHgZgmvK" role="lGtFl">
+              <property role="TrG5h" value="VarMustBeInitialized" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5xnAHgZgi8I" role="1YuTPh">
+      <property role="TrG5h" value="var" />
+      <ref role="1YaFvo" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    </node>
+  </node>
 </model>
 

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AddInitializer.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AddInitializer.mpsr
@@ -32,7 +32,7 @@
       <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
         <child id="3125407777189916705" name="initializer" index="1qY_RL" />
       </concept>
-      <concept id="6843536562190617628" name="CsBaseLanguage.structure.Expression" flags="ng" index="3Uf2Ky" />
+      <concept id="1945218857511602457" name="CsBaseLanguage.structure.IVariableInitializer" flags="ngI" index="2YC0sB" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -53,9 +53,9 @@
       </node>
     </node>
     <node concept="1qefOq" id="2ETkgtjYbm5" role="25YQFr">
-      <node concept="zF7EM" id="2ETkgtjZcjK" role="1qenE9">
+      <node concept="zF7EM" id="5xnAHgZm7JG" role="1qenE9">
         <property role="TrG5h" value="x" />
-        <node concept="3Uf2Ky" id="2ETkgtjZcjN" role="1qY_RL" />
+        <node concept="2YC0sB" id="5xnAHgZm7JJ" role="1qY_RL" />
       </node>
     </node>
     <node concept="1qefOq" id="2ETkgtjYbvx" role="25YQCW">

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Field_ArrayInitializer.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Field_ArrayInitializer.mpsr
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131554" name="CsBaseLanguage.structure.VariableDeclaratorList" flags="ng" index="1ux1y">
+        <child id="7486903154347131555" name="VariableDeclarator" index="1ux1z" />
+      </concept>
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
+        <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="1945218857511602457" name="CsBaseLanguage.structure.IVariableInitializer" flags="ngI" index="2YC0sB" />
+      <concept id="7232527154588443306" name="CsBaseLanguage.structure.FieldDeclaration" flags="ng" index="31KRIa">
+        <child id="7232527154588443341" name="variableDeclaratorList" index="31KRJH" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190902679" name="CsBaseLanguage.structure.ArrayInitializer" flags="ng" index="3Uc4mD" />
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+        <child id="6843536562190767745" name="rankSpecifier" index="3UfBqZ" />
+      </concept>
+      <concept id="6843536562190767682" name="CsBaseLanguage.structure.RankSpecifier" flags="ng" index="3UfBpW" />
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="5xnAHgZvEYf">
+    <property role="3GE5qa" value="editor.BasicEditing.VariableDeclaration" />
+    <property role="TrG5h" value="Field_ArrayInitializer" />
+    <node concept="1qefOq" id="5xnAHgZvEYg" role="25YQCW">
+      <node concept="31KRIa" id="5xnAHgZvEYk" role="1qenE9">
+        <node concept="1ux1y" id="5xnAHgZvEYl" role="31KRJH">
+          <node concept="zF7EM" id="5xnAHgZvEYm" role="1ux1z">
+            <property role="TrG5h" value="foo" />
+            <node concept="2YC0sB" id="5xnAHgZvEYK" role="1qY_RL">
+              <node concept="LIFWc" id="5xnAHgZvEYM" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="0" />
+                <property role="p6zMs" value="0" />
+                <property role="LIFWd" value="Error" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="5xnAHgZvEYy" role="3SE38M">
+          <node concept="3UfM66" id="5xnAHgZvEYu" role="3UfBpY" />
+          <node concept="3UfBpW" id="5xnAHgZvEYz" role="3UfBqZ" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5xnAHgZvEYO" role="25YQFr">
+      <node concept="31KRIa" id="5xnAHgZvEYS" role="1qenE9">
+        <node concept="1ux1y" id="5xnAHgZvEYT" role="31KRJH">
+          <node concept="zF7EM" id="5xnAHgZvEYU" role="1ux1z">
+            <property role="TrG5h" value="foo" />
+            <node concept="3Uc4mD" id="5xnAHgZvEZb" role="1qY_RL" />
+          </node>
+        </node>
+        <node concept="3UfwP1" id="5xnAHgZvEYX" role="3SE38M">
+          <node concept="3UfM66" id="5xnAHgZvEYY" role="3UfBpY" />
+          <node concept="3UfBpW" id="5xnAHgZvEYZ" role="3UfBqZ" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="5xnAHgZvF4b" role="LjaKd">
+      <node concept="2TK7Tu" id="5xnAHgZvF4a" role="3cqZAp">
+        <property role="2TTd_B" value="{" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ImplicitVarDeclarations.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ImplicitVarDeclarations.mpsr
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
+        <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="6365726834694825977" name="CsBaseLanguage.structure.ImplicitLocalVariableDeclaration" flags="ng" index="1BvVOH">
+        <child id="6365726834695689697" name="variable" index="1BoGWP" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="5xnAHgZjgI6">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="structure" />
+    <property role="TrG5h" value="ImplicitVarDeclarations" />
+    <node concept="1qefOq" id="5xnAHgZjgMp" role="1SKRRt">
+      <node concept="1BvVOH" id="5xnAHgZjgMn" role="1qenE9">
+        <node concept="zF7EM" id="5xnAHgZjgMo" role="1BoGWP">
+          <property role="TrG5h" value="x" />
+          <node concept="3UcVBg" id="5xnAHgZjgO7" role="1qY_RL">
+            <property role="1pzoAX" value="42" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5xnAHgZjgPJ" role="1SKRRt">
+      <node concept="1BvVOH" id="5xnAHgZjgPK" role="1qenE9">
+        <node concept="zF7EM" id="5xnAHgZjgPL" role="1BoGWP">
+          <property role="TrG5h" value="x" />
+          <node concept="7CXmI" id="5xnAHgZjgS_" role="lGtFl">
+            <node concept="1TM$A" id="5xnAHgZjgSA" role="7EUXB">
+              <node concept="2PYRI3" id="5xnAHgZjgSB" role="3lydEf">
+                <ref role="39XzEq" to="avov:5xnAHgZglyy" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LocalVar_ArrayInitializer.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LocalVar_ArrayInitializer.mpsr
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
+        <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="1945218857511602457" name="CsBaseLanguage.structure.IVariableInitializer" flags="ngI" index="2YC0sB" />
+      <concept id="1945218857511318967" name="CsBaseLanguage.structure.LocalVariableDeclarationStatement" flags="ng" index="2YDbI9">
+        <child id="1945218857511318970" name="variableDeclarator" index="2YDbI4" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190902679" name="CsBaseLanguage.structure.ArrayInitializer" flags="ng" index="3Uc4mD" />
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+        <child id="6843536562190767745" name="rankSpecifier" index="3UfBqZ" />
+      </concept>
+      <concept id="6843536562190767682" name="CsBaseLanguage.structure.RankSpecifier" flags="ng" index="3UfBpW" />
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="5xnAHgZnjo9">
+    <property role="3GE5qa" value="editor.BasicEditing.VariableDeclaration" />
+    <property role="TrG5h" value="LocalVar_ArrayInitializer" />
+    <node concept="1qefOq" id="5xnAHgZnjot" role="25YQCW">
+      <node concept="2YDbI9" id="5xnAHgZnjo_" role="1qenE9">
+        <node concept="zF7EM" id="5xnAHgZnjoA" role="2YDbI4">
+          <property role="TrG5h" value="x" />
+          <node concept="2YC0sB" id="5xnAHgZnjoT" role="1qY_RL">
+            <node concept="LIFWc" id="5xnAHgZntLg" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Error" />
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="5xnAHgZnjoL" role="3SE38M">
+          <node concept="3UfM66" id="5xnAHgZnjoH" role="3UfBpY" />
+          <node concept="3UfBpW" id="5xnAHgZnjoM" role="3UfBqZ" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="5xnAHgZnjoX" role="25YQFr">
+      <node concept="2YDbI9" id="5xnAHgZnjp1" role="1qenE9">
+        <node concept="zF7EM" id="5xnAHgZnjp2" role="2YDbI4">
+          <property role="TrG5h" value="x" />
+          <node concept="3Uc4mD" id="5xnAHgZnyTo" role="1qY_RL">
+            <node concept="LIFWc" id="5xnAHgZn_sj" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="1" />
+              <property role="p6zMs" value="1" />
+              <property role="LIFWd" value="Constant_vp14gh_a0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="5xnAHgZnjp5" role="3SE38M">
+          <node concept="3UfM66" id="5xnAHgZnjp6" role="3UfBpY" />
+          <node concept="3UfBpW" id="5xnAHgZnjp7" role="3UfBqZ" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="5xnAHgZnjui" role="LjaKd">
+      <node concept="2TK7Tu" id="5xnAHgZnjuh" role="3cqZAp">
+        <property role="2TTd_B" value="{" />
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
Three more suggestions, most importantly support for implicitly typed (`var`) declarations. Also, the editor tests I added for array variables were giving errors about potentially endless loops while constructing the substitution menu. To get them to work, I had to remove the custom substitution menus for the `AmbiguousMemberReference` and `AmbiguousTypeReference` concepts. Since I'm not sure what these are for, is that okay?