### PR TITLE
Implement await expressions

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
@@ -10,7 +10,7 @@
   </languages>
   <imports>
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" />
-    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" implicit="true" />
+    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -38,16 +38,25 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
     </language>
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
       <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
       <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795771125" name="jetbrains.mps.lang.intentions.structure.IsApplicableBlock" flags="in" index="2SaL7w" />
       <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
       <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
       <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
         <property id="2522969319638091386" name="isAvailableInChildNodes" index="2ZfUl0" />
+        <property id="2522969319638091385" name="isErrorIntention" index="2ZfUl3" />
         <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
       </concept>
     </language>
@@ -55,11 +64,21 @@
       <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
       </concept>
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -322,6 +341,71 @@
             </node>
             <node concept="2DeJg1" id="2H$QQEVkHn1" role="2OqNvi">
               <ref role="1A0vxQ" to="80bi:2H$QQEUtQI0" resolve="UsingAliasDirective" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="5xnAHh09yB3">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="MakeFunctionAsync" />
+    <property role="2ZfUl3" value="true" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="2S6ZIM" id="5xnAHh09yB4" role="2ZfVej">
+      <node concept="3clFbS" id="5xnAHh09yB5" role="2VODD2">
+        <node concept="3clFbF" id="5xnAHh09yXf" role="3cqZAp">
+          <node concept="Xl_RD" id="5xnAHh09yXe" role="3clFbG">
+            <property role="Xl_RC" value="Make enclosing function async" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="5xnAHh09yB6" role="2ZfgGD">
+      <node concept="3clFbS" id="5xnAHh09yB7" role="2VODD2">
+        <node concept="3clFbF" id="5xnAHh09$0n" role="3cqZAp">
+          <node concept="37vLTI" id="7HmXimRMxsZ" role="3clFbG">
+            <node concept="3clFbT" id="7HmXimRMxux" role="37vLTx">
+              <property role="3clFbU" value="true" />
+            </node>
+            <node concept="2OqwBi" id="5xnAHh09_oD" role="37vLTJ">
+              <node concept="2OqwBi" id="5xnAHh09$0F" role="2Oq$k0">
+                <node concept="2Sf5sV" id="5xnAHh09$0m" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="5xnAHh09_5q" role="2OqNvi">
+                  <node concept="1xMEDy" id="5xnAHh09_5s" role="1xVPHs">
+                    <node concept="chp4Y" id="5xnAHh09_6Q" role="ri$Ld">
+                      <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="7HmXimRMw2G" role="2OqNvi">
+                <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="5xnAHh0dOH8" role="2ZfVeh">
+      <node concept="3clFbS" id="5xnAHh0dOH9" role="2VODD2">
+        <node concept="3clFbF" id="5xnAHh0dPYn" role="3cqZAp">
+          <node concept="3fqX7Q" id="5xnAHh0dRj7" role="3clFbG">
+            <node concept="2OqwBi" id="5xnAHh0dRj9" role="3fr31v">
+              <node concept="2OqwBi" id="5xnAHh0dRja" role="2Oq$k0">
+                <node concept="2Sf5sV" id="5xnAHh0dRjb" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="5xnAHh0dRjc" role="2OqNvi">
+                  <node concept="1xMEDy" id="5xnAHh0dRjd" role="1xVPHs">
+                    <node concept="chp4Y" id="5xnAHh0dRje" role="ri$Ld">
+                      <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="5xnAHh0dRjf" role="2OqNvi">
+                <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+              </node>
             </node>
           </node>
         </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -8,7 +8,7 @@
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
-    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" implicit="true" />
+    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
@@ -62,6 +62,7 @@
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -80,6 +81,10 @@
       </concept>
       <concept id="1068581242869" name="jetbrains.mps.baseLanguage.structure.MinusExpression" flags="nn" index="3cpWsd" />
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
@@ -87,7 +92,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -98,7 +103,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
@@ -117,13 +122,17 @@
       <concept id="4303308395523096213" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childConcept" flags="ng" index="2DD5aU" />
       <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
         <reference id="1147467295099" name="applicableProperty" index="EomxK" />
+        <child id="1147468630220" name="propertyGetter" index="EtsB7" />
         <child id="1212097481299" name="propertyValidator" index="QCWH9" />
+        <child id="1152963095733" name="propertySetter" index="1LXaQT" />
       </concept>
+      <concept id="1147467790433" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyGetter" flags="in" index="Eqf_E" />
       <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
       <concept id="6738154313879680265" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childNode" flags="nn" index="2H4GUG" />
       <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
       <concept id="1163200368514" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSetHandler" flags="in" index="3k9gUc" />
       <concept id="1163200647017" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_referenceNode" flags="nn" index="3kakTB" />
+      <concept id="1152959968041" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertySetter" flags="in" index="1LLf8_" />
       <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
         <reference id="1213093996982" name="concept" index="1M2myG" />
         <child id="6702802731807532712" name="canBeParent" index="9SGkU" />
@@ -170,7 +179,9 @@
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
-      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt" />
+      <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
+        <reference id="1139877738879" name="concept" index="1A0vxQ" />
+      </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
@@ -216,7 +227,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -246,9 +257,11 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1171391069720" name="jetbrains.mps.baseLanguage.collections.structure.GetIndexOfOperation" flags="nn" index="2WmjW8" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="3055999550620853964" name="jetbrains.mps.baseLanguage.collections.structure.RemoveWhereOperation" flags="nn" index="1aUR6E" />
       <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
@@ -2564,6 +2577,140 @@
             <node concept="1mIQ4w" id="5xnAHgZmUXp" role="2OqNvi">
               <node concept="chp4Y" id="5xnAHgZmV0L" role="cj9EA">
                 <ref role="cht4Q" to="80bi:5VT83U$Mxwu" resolve="NewArrayTypeExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5xnAHh0xYvk">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <ref role="1M2myG" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="9S07l" id="5xnAHh0xYvl" role="9Vyp8">
+      <node concept="3clFbS" id="5xnAHh0xYvm" role="2VODD2">
+        <node concept="3clFbF" id="5xnAHh0xYHp" role="3cqZAp">
+          <node concept="2OqwBi" id="5xnAHh0xZHP" role="3clFbG">
+            <node concept="2OqwBi" id="5xnAHh0xYTW" role="2Oq$k0">
+              <node concept="nLn13" id="5xnAHh0xYHo" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="5xnAHh0xZnh" role="2OqNvi">
+                <node concept="1xMEDy" id="5xnAHh0xZnj" role="1xVPHs">
+                  <node concept="chp4Y" id="5xnAHh0xZpJ" role="ri$Ld">
+                    <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5xnAHh0y0vg" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5xnAHh08MEU">
+    <property role="3GE5qa" value="Class / Struct.Methods" />
+    <ref role="1M2myG" to="80bi:6hv6i2_B6ci" resolve="MethodDeclaration" />
+    <node concept="EnEH3" id="5xnAHh08MFR" role="1MhHOB">
+      <ref role="EomxK" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+      <node concept="Eqf_E" id="5xnAHh08MHd" role="EtsB7">
+        <node concept="3clFbS" id="5xnAHh08MHe" role="2VODD2">
+          <node concept="3clFbF" id="5xnAHh0yClj" role="3cqZAp">
+            <node concept="2OqwBi" id="5xnAHh08R6t" role="3clFbG">
+              <node concept="2OqwBi" id="5xnAHh08NW4" role="2Oq$k0">
+                <node concept="EsrRn" id="5xnAHh08Nv5" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="5xnAHh08OGm" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:5oHFRyIxp1p" resolve="iModifier" />
+                </node>
+              </node>
+              <node concept="2HwmR7" id="5xnAHh08T17" role="2OqNvi">
+                <node concept="1bVj0M" id="5xnAHh08T19" role="23t8la">
+                  <node concept="3clFbS" id="5xnAHh08T1a" role="1bW5cS">
+                    <node concept="3clFbF" id="5xnAHh08T2y" role="3cqZAp">
+                      <node concept="2OqwBi" id="5xnAHh08Tf9" role="3clFbG">
+                        <node concept="37vLTw" id="5xnAHh08T2x" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5xnAHh08T1b" resolve="it" />
+                        </node>
+                        <node concept="1mIQ4w" id="5xnAHh08UM9" role="2OqNvi">
+                          <node concept="chp4Y" id="5xnAHh08URf" role="cj9EA">
+                            <ref role="cht4Q" to="80bi:3h4LMeIXQnf" resolve="Async" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="5xnAHh08T1b" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="5xnAHh08T1c" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1LLf8_" id="7HmXimRLOBj" role="1LXaQT">
+        <node concept="3clFbS" id="7HmXimRLOBk" role="2VODD2">
+          <node concept="3clFbJ" id="7HmXimRLTRx" role="3cqZAp">
+            <node concept="3eNFk2" id="7HmXimRM9kA" role="3eNLev">
+              <node concept="3fqX7Q" id="7HmXimRLUW4" role="3eO9$A">
+                <node concept="2OqwBi" id="7HmXimRLVdC" role="3fr31v">
+                  <node concept="EsrRn" id="7HmXimRLUWP" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7HmXimRLW1K" role="2OqNvi">
+                    <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="7HmXimRLTRz" role="3eOfB_">
+                <node concept="3clFbF" id="7HmXimRLWKK" role="3cqZAp">
+                  <node concept="2OqwBi" id="7HmXimRLZBn" role="3clFbG">
+                    <node concept="2OqwBi" id="7HmXimRLX1l" role="2Oq$k0">
+                      <node concept="EsrRn" id="7HmXimRLWKJ" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="7HmXimRLXr7" role="2OqNvi">
+                        <ref role="3TtcxE" to="80bi:5oHFRyIxp1p" resolve="iModifier" />
+                      </node>
+                    </node>
+                    <node concept="WFELt" id="7HmXimRM7R8" role="2OqNvi">
+                      <ref role="1A0vxQ" to="80bi:3h4LMeIXQnf" resolve="Async" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3fqX7Q" id="7HmXimRM9nv" role="3clFbw">
+              <node concept="1Wqviy" id="7HmXimRM9nx" role="3fr31v" />
+            </node>
+            <node concept="3clFbS" id="7HmXimRM9kC" role="3clFbx">
+              <node concept="3clFbF" id="7HmXimRM9qc" role="3cqZAp">
+                <node concept="2OqwBi" id="7HmXimRMiT8" role="3clFbG">
+                  <node concept="2OqwBi" id="7HmXimRM9EL" role="2Oq$k0">
+                    <node concept="EsrRn" id="7HmXimRM9qb" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="7HmXimRMauB" role="2OqNvi">
+                      <ref role="3TtcxE" to="80bi:5oHFRyIxp1p" resolve="iModifier" />
+                    </node>
+                  </node>
+                  <node concept="1aUR6E" id="7HmXimRMpPQ" role="2OqNvi">
+                    <node concept="1bVj0M" id="7HmXimRMpPS" role="23t8la">
+                      <node concept="3clFbS" id="7HmXimRMpPT" role="1bW5cS">
+                        <node concept="3clFbF" id="7HmXimRMq0k" role="3cqZAp">
+                          <node concept="2OqwBi" id="7HmXimRMrWU" role="3clFbG">
+                            <node concept="37vLTw" id="7HmXimRMq0j" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7HmXimRMpPU" resolve="it" />
+                            </node>
+                            <node concept="1mIQ4w" id="7HmXimRMt8P" role="2OqNvi">
+                              <node concept="chp4Y" id="7HmXimRMtfv" role="cj9EA">
+                                <ref role="cht4Q" to="80bi:3h4LMeIXQnf" resolve="Async" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="7HmXimRMpPU" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="7HmXimRMpPV" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -72,6 +72,7 @@
       </concept>
       <concept id="8329266386016608055" name="jetbrains.mps.lang.editor.structure.ApproveDelete_Operation" flags="ng" index="2xy62i">
         <child id="8329266386016685951" name="editorContext" index="2xHN3q" />
+        <child id="8979250711607012232" name="cellSelector" index="3a7HXU" />
       </concept>
       <concept id="6718020819487620876" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Default" flags="ng" index="A1WHr" />
       <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
@@ -102,6 +103,10 @@
       <concept id="1078938745671" name="jetbrains.mps.lang.editor.structure.EditorComponentDeclaration" flags="ig" index="PKFIW" />
       <concept id="1078939183254" name="jetbrains.mps.lang.editor.structure.CellModel_Component" flags="sg" stub="3162947552742194261" index="PMmxH">
         <reference id="1078939183255" name="editorComponent" index="PMmxG" />
+      </concept>
+      <concept id="4323500428121233431" name="jetbrains.mps.lang.editor.structure.EditorCellId" flags="ng" index="2SqB2G" />
+      <concept id="4323500428136740385" name="jetbrains.mps.lang.editor.structure.CellIdReferenceSelector" flags="ng" index="2TlHUq">
+        <reference id="4323500428136742952" name="id" index="2TlMyj" />
       </concept>
       <concept id="1186403694788" name="jetbrains.mps.lang.editor.structure.ColorStyleClassItem" flags="ln" index="VaVBg">
         <property id="1186403713874" name="color" index="Vb096" />
@@ -188,6 +193,7 @@
         <reference id="1081339532145" name="keyMap" index="34QXea" />
         <reference id="1139959269582" name="actionMap" index="1ERwB7" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
+        <child id="4323500428121274054" name="id" index="2SqHTX" />
         <child id="4202667662392416064" name="transformationMenu" index="3vIgyS" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
@@ -21106,25 +21112,6 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="5xnAHgZa2GI">
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
-    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
-      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      </node>
-      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
-      </node>
-      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
-    </node>
-  </node>
   <node concept="1h_SRR" id="2H$QQET29s8">
     <property role="3GE5qa" value="Namespace" />
     <property role="TrG5h" value="DeleteUsingDirective" />
@@ -21289,6 +21276,81 @@
       <node concept="l2Vlx" id="2H$QQEUtQIb" role="2iSdaV" />
       <node concept="A1WHr" id="2H$QQEUYLQG" role="3vIgyS">
         <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="5xnAHh0emj_">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="RemoveAwait" />
+    <ref role="1h_SK9" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="1hA7zw" id="5xnAHh0emjA" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="5xnAHh0emjB" role="1hA7z_">
+        <node concept="3clFbS" id="5xnAHh0emjC" role="2VODD2">
+          <node concept="3clFbJ" id="5xnAHh0hi42" role="3cqZAp">
+            <node concept="3clFbS" id="5xnAHh0hi44" role="3clFbx">
+              <node concept="3cpWs6" id="5xnAHh0hi_R" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="5xnAHh0hihq" role="3clFbw">
+              <node concept="0IXxy" id="5xnAHh0hi4W" role="2Oq$k0" />
+              <node concept="2xy62i" id="5xnAHh0hiy0" role="2OqNvi">
+                <node concept="1Q80Hx" id="5xnAHh0hiyA" role="2xHN3q" />
+                <node concept="2TlHUq" id="5xnAHh0k20P" role="3a7HXU">
+                  <ref role="2TlMyj" node="5xnAHh0uXTF" resolve="operator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5xnAHh0emme" role="3cqZAp">
+            <node concept="2OqwBi" id="5xnAHh0emyK" role="3clFbG">
+              <node concept="0IXxy" id="5xnAHh0emmd" role="2Oq$k0" />
+              <node concept="1P9Npp" id="5xnAHh0enmR" role="2OqNvi">
+                <node concept="2OqwBi" id="5xnAHh0en$J" role="1P9ThW">
+                  <node concept="0IXxy" id="5xnAHh0ennF" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5xnAHh0enRd" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:5xnAHgZZgtR" resolve="task" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5xnAHgZZgy7">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="3EZMnI" id="5xnAHgZZg_B" role="2wV5jI">
+      <node concept="l2Vlx" id="5xnAHgZZg_C" role="2iSdaV" />
+      <node concept="3F0ifn" id="5xnAHgZZgBa" role="3EZMnx">
+        <property role="3F0ifm" value="await" />
+        <ref role="1ERwB7" node="5xnAHh0emj_" resolve="RemoveAwait" />
+        <node concept="2SqB2G" id="5xnAHh0uXTF" role="2SqHTX">
+          <property role="TrG5h" value="operator" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -8,7 +8,7 @@
     <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
   </languages>
   <imports>
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
   </imports>
   <registry>
     <language id="a23383a3-9564-4399-8643-72063c6111dc" name="jetbrains.mps.LangDoc">
@@ -3905,6 +3905,9 @@
       <property role="20kJfa" value="body" />
       <ref role="20lvS9" node="1FYNzU$qtcf" resolve="MaybeEmptyBlock" />
     </node>
+    <node concept="PrWs8" id="7HmXimRLOdT" role="PzmwI">
+      <ref role="PrY4T" node="7HmXimRLOdX" resolve="ICanBeAsync" />
+    </node>
     <node concept="PrWs8" id="3h4LMeIQtvs" role="PzmwI">
       <ref role="PrY4T" node="3h4LMeIQtuQ" resolve="IFunctionHeader" />
     </node>
@@ -3943,7 +3946,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5THE" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5THF" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: method-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCM" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCN" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCO" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCP" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCQ" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHh08MCR" role="1PaTwD">
+            <property role="3oM_SC" value="method-declaration" />
           </node>
         </node>
       </node>
@@ -6328,6 +6349,7 @@
     <property role="EcuMT" value="1945218857514324579" />
     <property role="3GE5qa" value="Statements.Try" />
     <property role="TrG5h" value="OptionalGeneralCatch" />
+    <property role="34LRSv" value="catch" />
     <ref role="1TJDcQ" node="1FYNzU$y59t" resolve="CatchClause" />
     <node concept="1TJgyj" id="1FYNzU$y59B" role="1TKVEi">
       <property role="IQ2ns" value="1945218857514324583" />
@@ -6422,6 +6444,7 @@
     <property role="EcuMT" value="1945218857514324842" />
     <property role="3GE5qa" value="Statements.Try" />
     <property role="TrG5h" value="MandatoryGeneralCatch" />
+    <property role="34LRSv" value="catch" />
     <ref role="1TJDcQ" node="1FYNzU$y59t" resolve="CatchClause" />
     <node concept="1TJgyj" id="1FYNzU$y5dF" role="1TKVEi">
       <property role="IQ2ns" value="1945218857514324843" />
@@ -16884,6 +16907,113 @@
     <property role="34LRSv" value="set" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
   </node>
+  <node concept="1TIwiD" id="2H$QQEVkVn6">
+    <property role="EcuMT" value="3126865292757808582" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingNamespaceDirective" />
+    <property role="34LRSv" value="using" />
+    <property role="R4oN_" value="Using directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
+            <property role="3oM_SC" value="using-namespace-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098553" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jOVEuK">
+    <property role="EcuMT" value="451639884280407984" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="NamespaceContainer" />
+    <property role="R5$K7" value="true" />
+    <property role="R4oN_" value="Represents files and namespaces" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
+      <property role="IQ2ns" value="7232527154588292748" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="usingDirectives" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    </node>
+    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2H$QQEUtQI0">
+    <property role="EcuMT" value="3126865292743371648" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingAliasDirective" />
+    <property role="34LRSv" value="using alias" />
+    <property role="R4oN_" value="Using alias directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
+    </node>
+    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
+            <property role="3oM_SC" value="using-alias-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098556" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jNJogm">
+    <property role="EcuMT" value="451639884260410390" />
+    <property role="TrG5h" value="NamespaceReference" />
+    <property role="R4oN_" value="Reference to a namespace" />
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
+      <property role="IQ2ns" value="451639884260410769" />
+      <property role="20kJfa" value="referencedType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
+      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
+    </node>
+  </node>
   <node concept="1TIwiD" id="5xnAHgZa2vT">
     <property role="EcuMT" value="6365726834694825977" />
     <property role="TrG5h" value="ImplicitLocalVariableDeclaration" />
@@ -17127,111 +17257,68 @@
       <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
     </node>
   </node>
-  <node concept="1TIwiD" id="2H$QQEVkVn6">
-    <property role="EcuMT" value="3126865292757808582" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingNamespaceDirective" />
-    <property role="34LRSv" value="using" />
-    <property role="R4oN_" value="Using directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
+  <node concept="1TIwiD" id="5xnAHgZZgnF">
+    <property role="EcuMT" value="6365726834708776427" />
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="AwaitExpression" />
+    <property role="34LRSv" value="await" />
+    <property role="R4oN_" value="await expression" />
+    <ref role="1TJDcQ" node="5VT83U$LFpw" resolve="UnaryExpression" />
+    <node concept="PrWs8" id="5xnAHgZZgsT" role="PzmwI">
+      <ref role="PrY4T" node="1FYNzU$sHZz" resolve="IStatementExpression" />
+    </node>
+    <node concept="1TJgyj" id="5xnAHgZZgtR" role="1TKVEi">
+      <property role="IQ2ns" value="6365726834708776823" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="task" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5VT83U$LFpw" resolve="UnaryExpression" />
+    </node>
+    <node concept="3H0Qfr" id="5xnAHgZZgG4" role="lGtFl">
+      <node concept="1Pa9Pv" id="5xnAHgZZgG5" role="3H0Qfi">
+        <node concept="1PaTwC" id="5xnAHgZZgG6" role="1PaQFQ">
+          <node concept="3oM_SD" id="1XmGakPSWlj" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
           </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
+          <node concept="3oM_SD" id="1XmGakPSWnL" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
           </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
+          <node concept="3oM_SD" id="1XmGakPSWnU" role="1PaTwD">
+            <property role="3oM_SC" value="await" />
           </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
+          <node concept="3oM_SD" id="1XmGakPSWoy" role="1PaTwD">
+            <property role="3oM_SC" value="expression," />
           </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
-            <property role="3oM_SC" value="using-namespace-directive" />
+          <node concept="3oM_SD" id="1XmGakPSWpb" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWtP" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZZgLg" role="1PaTwD">
+            <property role="3oM_SC" value="§7.7.7" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWxX" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWy$" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWyI" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
           </node>
         </node>
       </node>
     </node>
-    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098553" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
-    </node>
   </node>
-  <node concept="1TIwiD" id="p4z1jOVEuK">
-    <property role="EcuMT" value="451639884280407984" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="NamespaceContainer" />
-    <property role="R5$K7" value="true" />
-    <property role="R4oN_" value="Represents files and namespaces" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
-    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588292748" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="usingDirectives" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    </node>
-    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="2H$QQEUtQI0">
-    <property role="EcuMT" value="3126865292743371648" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingAliasDirective" />
-    <property role="34LRSv" value="using alias" />
-    <property role="R4oN_" value="Using alias directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
-      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
-    </node>
-    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
-            <property role="3oM_SC" value="using-alias-directive" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098556" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="p4z1jNJogm">
-    <property role="EcuMT" value="451639884260410390" />
-    <property role="TrG5h" value="NamespaceReference" />
-    <property role="R4oN_" value="Reference to a namespace" />
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
-      <property role="IQ2ns" value="451639884260410769" />
-      <property role="20kJfa" value="referencedType" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
-      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
+  <node concept="PlHQZ" id="7HmXimRLOdX">
+    <property role="TrG5h" value="ICanBeAsync" />
+    <property role="EcuMT" value="8887560457008137085" />
+    <property role="3GE5qa" value="Modifiers" />
+    <node concept="1TJgyi" id="5xnAHh08MDV" role="1TKVEl">
+      <property role="IQ2nx" value="6365726834711276155" />
+      <property role="TrG5h" value="isAsync" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
@@ -6,10 +6,14 @@
     <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
   </languages>
   <imports>
-    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" implicit="true" />
+    <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="7485977462274819189" name="jetbrains.mps.baseLanguage.structure.FormatOperation" flags="ng" index="2cAKMz">
+        <child id="7485977462274819664" name="arguments" index="2cAKU6" />
+      </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -17,12 +21,42 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+        <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
@@ -48,7 +82,34 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+        <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
+      <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1154546920561" name="jetbrains.mps.lang.smodel.structure.OperationParm_ConceptList" flags="ng" index="3gmYPX">
+        <child id="1154546920563" name="concept" index="3gmYPZ" />
+      </concept>
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
+      </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
@@ -58,9 +119,27 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+        <property id="155656958578482949" name="value" index="3oM_SC" />
+      </concept>
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+        <child id="2535923850359271783" name="elements" index="1PaTwD" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1225727723840" name="jetbrains.mps.baseLanguage.collections.structure.FindFirstOperation" flags="nn" index="1z4cxt" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
     </language>
   </registry>
   <node concept="18kY7G" id="5QWEwg48iL4">
@@ -153,6 +232,187 @@
     <node concept="1YaCAy" id="5xnAHgZgi8I" role="1YuTPh">
       <property role="TrG5h" value="var" />
       <ref role="1YaFvo" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5xnAHh09lHo">
+    <property role="TrG5h" value="check_AwaitExpression" />
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <node concept="3clFbS" id="5xnAHh09lHp" role="18ibNy">
+      <node concept="3SKdUt" id="7HmXimP2_bS" role="3cqZAp">
+        <node concept="1PaTwC" id="7HmXimP2_bT" role="1aUNEU">
+          <node concept="3oM_SD" id="7HmXimP2_VQ" role="1PaTwD">
+            <property role="3oM_SC" value="TODO:" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_W2" role="1PaTwD">
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_d0" role="1PaTwD">
+            <property role="3oM_SC" value="should" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_Wf" role="1PaTwD">
+            <property role="3oM_SC" value="also" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_dl" role="1PaTwD">
+            <property role="3oM_SC" value="check" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_O_" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_Pv" role="1PaTwD">
+            <property role="3oM_SC" value="lock" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_PE" role="1PaTwD">
+            <property role="3oM_SC" value="blocks" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_PQ" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_Q3" role="1PaTwD">
+            <property role="3oM_SC" value="unsafe" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_Qh" role="1PaTwD">
+            <property role="3oM_SC" value="contexts," />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_Wr" role="1PaTwD">
+            <property role="3oM_SC" value="once" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_WC" role="1PaTwD">
+            <property role="3oM_SC" value="those" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_WQ" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimP2_X5" role="1PaTwD">
+            <property role="3oM_SC" value="implemented" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cpWs8" id="1XmGakPSUVn" role="3cqZAp">
+        <node concept="3cpWsn" id="1XmGakPSUVo" role="3cpWs9">
+          <property role="TrG5h" value="function" />
+          <node concept="3Tqbb2" id="1XmGakPSUVp" role="1tU5fm">
+            <ref role="ehGHo" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+          </node>
+          <node concept="2OqwBi" id="1XmGakPSUVq" role="33vP2m">
+            <node concept="1YBJjd" id="1XmGakPSUVr" role="2Oq$k0">
+              <ref role="1YBMHb" node="5xnAHh09lHr" resolve="await" />
+            </node>
+            <node concept="2Xjw5R" id="1XmGakPSUVs" role="2OqNvi">
+              <node concept="1xMEDy" id="1XmGakPSUVt" role="1xVPHs">
+                <node concept="chp4Y" id="1XmGakPSUVu" role="ri$Ld">
+                  <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbJ" id="1XmGakPSUVv" role="3cqZAp">
+        <node concept="3fqX7Q" id="1XmGakPSUVw" role="3clFbw">
+          <node concept="2OqwBi" id="1XmGakPSUVx" role="3fr31v">
+            <node concept="37vLTw" id="1XmGakPSUVy" role="2Oq$k0">
+              <ref role="3cqZAo" node="1XmGakPSUVo" resolve="function" />
+            </node>
+            <node concept="3TrcHB" id="1XmGakPSUVz" role="2OqNvi">
+              <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="1XmGakPSUV$" role="3clFbx">
+          <node concept="2MkqsV" id="1XmGakPSUV_" role="3cqZAp">
+            <node concept="1YBJjd" id="1XmGakPSUVA" role="1urrMF">
+              <ref role="1YBMHb" node="5xnAHh09lHr" resolve="await" />
+            </node>
+            <node concept="Xl_RD" id="1XmGakPSUVB" role="2MkJ7o">
+              <property role="Xl_RC" value="An await expression is only allowed in the body of an async function" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3clFbH" id="1XmGakPSUVC" role="3cqZAp" />
+      <node concept="3cpWs8" id="1XmGakP9cRE" role="3cqZAp">
+        <node concept="3cpWsn" id="1XmGakP9cRH" role="3cpWs9">
+          <property role="TrG5h" value="invalidBlock" />
+          <node concept="2OqwBi" id="1XmGakP9pw5" role="33vP2m">
+            <node concept="2OqwBi" id="1XmGakP9e10" role="2Oq$k0">
+              <node concept="37vLTw" id="1XmGakP9dPQ" role="2Oq$k0">
+                <ref role="3cqZAo" node="1XmGakPSUVo" resolve="function" />
+              </node>
+              <node concept="2Rf3mk" id="1XmGakP9elW" role="2OqNvi">
+                <node concept="3gmYPX" id="1XmGakPa9mY" role="1xVPHs">
+                  <node concept="3gn64h" id="1XmGakP9epz" role="3gmYPZ">
+                    <ref role="3gnhBz" to="80bi:1FYNzU$y59t" resolve="CatchClause" />
+                  </node>
+                  <node concept="3gn64h" id="1XmGakP9esZ" role="3gmYPZ">
+                    <ref role="3gnhBz" to="80bi:1FYNzU$y5eq" resolve="FinallyClause" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="1z4cxt" id="1XmGakP9E61" role="2OqNvi">
+              <node concept="1bVj0M" id="1XmGakP9E63" role="23t8la">
+                <node concept="3clFbS" id="1XmGakP9E64" role="1bW5cS">
+                  <node concept="3clFbF" id="1XmGakP9E65" role="3cqZAp">
+                    <node concept="2OqwBi" id="2zxOxSSjRpE" role="3clFbG">
+                      <node concept="2OqwBi" id="2zxOxSSjMyP" role="2Oq$k0">
+                        <node concept="1YBJjd" id="2zxOxSSjM2B" role="2Oq$k0">
+                          <ref role="1YBMHb" node="5xnAHh09lHr" resolve="await" />
+                        </node>
+                        <node concept="z$bX8" id="2zxOxSSjONX" role="2OqNvi" />
+                      </node>
+                      <node concept="3JPx81" id="2zxOxSSjUVf" role="2OqNvi">
+                        <node concept="37vLTw" id="2zxOxSSjUVN" role="25WWJ7">
+                          <ref role="3cqZAo" node="1XmGakP9E6c" resolve="it" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="1XmGakP9E6c" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="1XmGakP9E6d" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3Tqbb2" id="1XmGakP9EcY" role="1tU5fm" />
+        </node>
+      </node>
+      <node concept="3clFbJ" id="1XmGakP9eLy" role="3cqZAp">
+        <node concept="3clFbS" id="1XmGakP9eL$" role="3clFbx">
+          <node concept="2MkqsV" id="1XmGakPSUVD" role="3cqZAp">
+            <node concept="1YBJjd" id="1XmGakPSUVE" role="1urrMF">
+              <ref role="1YBMHb" node="5xnAHh09lHr" resolve="await" />
+            </node>
+            <node concept="2OqwBi" id="1XmGakPSUVF" role="2MkJ7o">
+              <node concept="Xl_RD" id="1XmGakPSUVG" role="2Oq$k0">
+                <property role="Xl_RC" value="An await expression is not allowed inside a %s block" />
+              </node>
+              <node concept="2cAKMz" id="1XmGakPSUVH" role="2OqNvi">
+                <node concept="2OqwBi" id="1XmGakPSUVI" role="2cAKU6">
+                  <node concept="2OqwBi" id="1XmGakPSUVJ" role="2Oq$k0">
+                    <node concept="37vLTw" id="1XmGakPSUVK" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1XmGakP9cRH" resolve="invalidBlock" />
+                    </node>
+                    <node concept="2yIwOk" id="1XmGakPSUVL" role="2OqNvi" />
+                  </node>
+                  <node concept="3n3YKJ" id="1XmGakPSUVM" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2OqwBi" id="1XmGakP9frN" role="3clFbw">
+          <node concept="37vLTw" id="1XmGakP9eMQ" role="2Oq$k0">
+            <ref role="3cqZAo" node="1XmGakP9cRH" resolve="invalidBlock" />
+          </node>
+          <node concept="3x8VRR" id="1XmGakP9Fgo" role="2OqNvi" />
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5xnAHh09lHr" role="1YuTPh">
+      <property role="TrG5h" value="await" />
+      <ref role="1YaFvo" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions.mpsr
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="1945218857514324570" name="CsBaseLanguage.structure.TryCatchFinallyStatement" flags="ng" index="2YtDL$">
+        <child id="1945218857514324576" name="catchClauses" index="2YtDLu" />
+        <child id="1945218857514324571" name="block" index="2YtDL_" />
+        <child id="1945218857514324919" name="finallyClause" index="2YtDQ9" />
+      </concept>
+      <concept id="1945218857514324762" name="CsBaseLanguage.structure.GeneralCatchClause" flags="ng" index="2YtDO$">
+        <child id="1945218857514324763" name="block" index="2YtDO_" />
+      </concept>
+      <concept id="1945218857514324842" name="CsBaseLanguage.structure.MandatoryGeneralCatch" flags="ng" index="2YtDPk">
+        <child id="1945218857514324845" name="generalCatch" index="2YtDPj" />
+      </concept>
+      <concept id="1945218857514324890" name="CsBaseLanguage.structure.FinallyClause" flags="ng" index="2YtDQ$">
+        <child id="1945218857514324891" name="block" index="2YtDQ_" />
+      </concept>
+      <concept id="1945218857512918966" name="CsBaseLanguage.structure.ExpressionStatement" flags="ng" index="2Yz168">
+        <child id="1945218857512918967" name="abstractStatementExpression" index="2Yz169" />
+      </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6365726834708776427" name="CsBaseLanguage.structure.AwaitExpression" flags="ng" index="1BEDWZ">
+        <child id="6365726834708776823" name="task" index="1BEDQz" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+      <concept id="6843536562191075794" name="CsBaseLanguage.structure.ArgumentsList" flags="ng" index="3UdiBG" />
+      <concept id="6843536562191075788" name="CsBaseLanguage.structure.FunctionCallExpression" flags="ng" index="3UdiBM">
+        <child id="6843536562191075791" name="argumentsList" index="3UdiBL" />
+        <child id="6843536562191075789" name="primaryExpression" index="3UdiBN" />
+      </concept>
+      <concept id="6531566641162929002" name="CsBaseLanguage.structure.MemberReference" flags="ng" index="1VUwCF">
+        <reference id="7783118190387115239" name="memberDeclaration" index="2aT8gA" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="5xnAHh0e4BP">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="structure" />
+    <property role="TrG5h" value="AwaitExpressions" />
+    <node concept="1qefOq" id="5xnAHh0e4Dg" role="1SKRRt">
+      <node concept="31KRCM" id="5xnAHh0e4Fc" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="5xnAHh0e4Fd" role="31KRCR">
+          <node concept="2YtDL$" id="5xnAHh0e5lR" role="1ux1N">
+            <node concept="1ux1M" id="5xnAHh0e5lT" role="2YtDL_">
+              <node concept="2Yz168" id="5xnAHh0e4K5" role="1ux1N">
+                <node concept="1BEDWZ" id="5xnAHh0e4KC" role="2Yz169">
+                  <node concept="3UdiBM" id="5xnAHh0e4Oy" role="1BEDQz">
+                    <node concept="1VUwCF" id="5xnAHh0e4Ny" role="3UdiBN">
+                      <ref role="2aT8gA" node="5xnAHh0e4Fc" resolve="method" />
+                    </node>
+                    <node concept="3UdiBG" id="5xnAHh0e4Oz" role="3UdiBL" />
+                  </node>
+                  <node concept="7CXmI" id="7HmXimOYDXA" role="lGtFl">
+                    <node concept="1TM$A" id="7HmXimOYDXB" role="7EUXB">
+                      <node concept="2PYRI3" id="1XmGakPZ7XZ" role="3lydEf">
+                        <ref role="39XzEq" to="avov:1XmGakPSUV_" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2YtDQ$" id="5xnAHh0e5tV" role="2YtDQ9">
+              <node concept="1ux1M" id="5xnAHh0e5tW" role="2YtDQ_">
+                <node concept="2Yz168" id="5xnAHh0e5Qt" role="1ux1N">
+                  <node concept="1BEDWZ" id="5xnAHh0e5Qu" role="2Yz169">
+                    <node concept="3UdiBM" id="5xnAHh0e5Qv" role="1BEDQz">
+                      <node concept="1VUwCF" id="5xnAHh0e5Qw" role="3UdiBN">
+                        <ref role="2aT8gA" node="5xnAHh0e4Fc" resolve="method" />
+                      </node>
+                      <node concept="3UdiBG" id="5xnAHh0e5Qx" role="3UdiBL" />
+                    </node>
+                    <node concept="7CXmI" id="5xnAHh0e5Qy" role="lGtFl">
+                      <node concept="1TM$A" id="5xnAHh0e5Qz" role="7EUXB" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2YtDPk" id="5xnAHh0e5An" role="2YtDLu">
+              <node concept="2YtDO$" id="5xnAHh0e5Ap" role="2YtDPj">
+                <node concept="1ux1M" id="5xnAHh0e5Ar" role="2YtDO_">
+                  <node concept="2Yz168" id="5xnAHh0e5H2" role="1ux1N">
+                    <node concept="1BEDWZ" id="5xnAHh0e5H_" role="2Yz169">
+                      <node concept="3UdiBM" id="5xnAHh0e5J9" role="1BEDQz">
+                        <node concept="1VUwCF" id="5xnAHh0e5IB" role="3UdiBN">
+                          <ref role="2aT8gA" node="5xnAHh0e4Fc" resolve="method" />
+                        </node>
+                        <node concept="3UdiBG" id="5xnAHh0e5Ja" role="3UdiBL" />
+                      </node>
+                      <node concept="7CXmI" id="7HmXimOYM53" role="lGtFl">
+                        <node concept="1TM$A" id="7HmXimOYM54" role="7EUXB" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="5xnAHh0e4Ff" role="1fIg$P" />
+        <node concept="1pH0Yj" id="5xnAHh0e4FO" role="3Sw9wT" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_Creation.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_Creation.mpsr
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="3766354144461809103" name="CsBaseLanguage.structure.Async" flags="ng" index="2qGUbG" />
+      <concept id="1945218857512918966" name="CsBaseLanguage.structure.ExpressionStatement" flags="ng" index="2Yz168">
+        <child id="1945218857512918967" name="abstractStatementExpression" index="2Yz169" />
+      </concept>
+      <concept id="1945218857512919011" name="CsBaseLanguage.structure.IStatementExpression" flags="ngI" index="2Yz17t" />
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6365726834708776427" name="CsBaseLanguage.structure.AwaitExpression" flags="ng" index="1BEDWZ">
+        <child id="6365726834708776823" name="task" index="1BEDQz" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+      <concept id="6209812394072707160" name="CsBaseLanguage.structure.IHaveModifiers" flags="ngI" index="3SE3Ww">
+        <child id="6209812394072707161" name="iModifier" index="3SE3Wx" />
+      </concept>
+      <concept id="6843536562190726752" name="CsBaseLanguage.structure.UnaryExpression" flags="ng" index="3UfTpu" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="7GmH_buLVhA">
+    <property role="3GE5qa" value="editor.BasicEditing.AwaitExpressions" />
+    <property role="TrG5h" value="AwaitExpressions_Creation" />
+    <node concept="1qefOq" id="7GmH_buLVsJ" role="25YQCW">
+      <node concept="31KRCM" id="7GmH_buLVsE" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="7GmH_buLVsF" role="31KRCR">
+          <node concept="2Yz168" id="7GmH_buM7VV" role="1ux1N">
+            <node concept="2Yz17t" id="7GmH_buM7VW" role="2Yz169">
+              <node concept="LIFWc" id="7GmH_buM7VZ" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="0" />
+                <property role="p6zMs" value="0" />
+                <property role="LIFWd" value="Error" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="7GmH_buLVsH" role="1fIg$P" />
+        <node concept="1pH0Yj" id="7GmH_buLVsQ" role="3Sw9wT" />
+        <node concept="2qGUbG" id="7GmH_buLVA8" role="3SE3Wx" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="7GmH_buLVFN" role="25YQFr">
+      <node concept="31KRCM" id="7GmH_buLVFR" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="7GmH_buLVFS" role="31KRCR">
+          <node concept="2Yz168" id="7GmH_buM7W1" role="1ux1N">
+            <node concept="1BEDWZ" id="7GmH_buM7W5" role="2Yz169">
+              <node concept="3UfTpu" id="7GmH_buM7W7" role="1BEDQz" />
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="7GmH_buLVFY" role="1fIg$P" />
+        <node concept="1pH0Yj" id="7GmH_buLVFZ" role="3Sw9wT" />
+        <node concept="2qGUbG" id="7GmH_buLVG0" role="3SE3Wx" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="7GmH_buLVPJ" role="LjaKd">
+      <node concept="2TK7Tu" id="7GmH_buLVPI" role="3cqZAp">
+        <property role="2TTd_B" value="await" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_MakeFunctionAsyncIntention.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_MakeFunctionAsyncIntention.mpsr
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="3766354144461809103" name="CsBaseLanguage.structure.Async" flags="ng" index="2qGUbG" />
+      <concept id="1945218857512918966" name="CsBaseLanguage.structure.ExpressionStatement" flags="ng" index="2Yz168">
+        <child id="1945218857512918967" name="abstractStatementExpression" index="2Yz169" />
+      </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6365726834708776427" name="CsBaseLanguage.structure.AwaitExpression" flags="ng" index="1BEDWZ">
+        <child id="6365726834708776823" name="task" index="1BEDQz" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+      <concept id="6209812394072707160" name="CsBaseLanguage.structure.IHaveModifiers" flags="ngI" index="3SE3Ww">
+        <child id="6209812394072707161" name="iModifier" index="3SE3Wx" />
+      </concept>
+      <concept id="6843536562191075794" name="CsBaseLanguage.structure.ArgumentsList" flags="ng" index="3UdiBG" />
+      <concept id="6843536562191075788" name="CsBaseLanguage.structure.FunctionCallExpression" flags="ng" index="3UdiBM">
+        <child id="6843536562191075791" name="argumentsList" index="3UdiBL" />
+        <child id="6843536562191075789" name="primaryExpression" index="3UdiBN" />
+      </concept>
+      <concept id="6531566641162929002" name="CsBaseLanguage.structure.MemberReference" flags="ng" index="1VUwCF">
+        <reference id="7783118190387115239" name="memberDeclaration" index="2aT8gA" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="5xnAHh0e5Se">
+    <property role="3GE5qa" value="editor.BasicEditing.AwaitExpressions" />
+    <property role="TrG5h" value="AwaitExpressions_MakeFunctionAsyncIntention" />
+    <node concept="1qefOq" id="5xnAHh0e5Wt" role="25YQCW">
+      <node concept="31KRCM" id="5xnAHh0e60T" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="5xnAHh0e60U" role="31KRCR">
+          <node concept="2Yz168" id="5xnAHh0e60X" role="1ux1N">
+            <node concept="1BEDWZ" id="5xnAHh0e60Y" role="2Yz169">
+              <node concept="3UdiBM" id="5xnAHh0e60Z" role="1BEDQz">
+                <node concept="1VUwCF" id="5xnAHh0e610" role="3UdiBN">
+                  <ref role="2aT8gA" node="5xnAHh0e60T" resolve="method" />
+                </node>
+                <node concept="3UdiBG" id="5xnAHh0e611" role="3UdiBL" />
+              </node>
+              <node concept="LIFWc" id="7HmXimP7dd5" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="5" />
+                <property role="p6zMs" value="5" />
+                <property role="LIFWd" value="operator" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="5xnAHh0e61n" role="1fIg$P" />
+        <node concept="1pH0Yj" id="5xnAHh0e61o" role="3Sw9wT" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5xnAHh0e6dg" role="25YQFr">
+      <node concept="31KRCM" id="5xnAHh0e6gQ" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="5xnAHh0e6gR" role="31KRCR">
+          <node concept="2Yz168" id="5xnAHh0e6gS" role="1ux1N">
+            <node concept="1BEDWZ" id="5xnAHh0e6gT" role="2Yz169">
+              <node concept="3UdiBM" id="5xnAHh0e6gU" role="1BEDQz">
+                <node concept="1VUwCF" id="5xnAHh0e6gV" role="3UdiBN">
+                  <ref role="2aT8gA" node="5xnAHh0e6gQ" resolve="method" />
+                </node>
+                <node concept="3UdiBG" id="5xnAHh0e6gW" role="3UdiBL" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="5xnAHh0e6gY" role="1fIg$P" />
+        <node concept="1pH0Yj" id="5xnAHh0e6gZ" role="3Sw9wT" />
+        <node concept="2qGUbG" id="5xnAHh0e6j4" role="3SE3Wx" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="5xnAHh0e6s8" role="LjaKd">
+      <node concept="1MFPAf" id="5xnAHh0e6s7" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:5xnAHh09yB3" resolve="MakeMethodAsync" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_RemoveAwaitAction.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/AwaitExpressions_RemoveAwaitAction.mpsr
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="3766354144461809103" name="CsBaseLanguage.structure.Async" flags="ng" index="2qGUbG" />
+      <concept id="1945218857512918966" name="CsBaseLanguage.structure.ExpressionStatement" flags="ng" index="2Yz168">
+        <child id="1945218857512918967" name="abstractStatementExpression" index="2Yz169" />
+      </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6365726834708776427" name="CsBaseLanguage.structure.AwaitExpression" flags="ng" index="1BEDWZ">
+        <child id="6365726834708776823" name="task" index="1BEDQz" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+      <concept id="6209812394072707160" name="CsBaseLanguage.structure.IHaveModifiers" flags="ngI" index="3SE3Ww">
+        <child id="6209812394072707161" name="iModifier" index="3SE3Wx" />
+      </concept>
+      <concept id="6843536562191075794" name="CsBaseLanguage.structure.ArgumentsList" flags="ng" index="3UdiBG" />
+      <concept id="6843536562191075788" name="CsBaseLanguage.structure.FunctionCallExpression" flags="ng" index="3UdiBM">
+        <child id="6843536562191075791" name="argumentsList" index="3UdiBL" />
+        <child id="6843536562191075789" name="primaryExpression" index="3UdiBN" />
+      </concept>
+      <concept id="6531566641162929002" name="CsBaseLanguage.structure.MemberReference" flags="ng" index="1VUwCF">
+        <reference id="7783118190387115239" name="memberDeclaration" index="2aT8gA" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="5xnAHh0e9vl">
+    <property role="3GE5qa" value="editor.BasicEditing.AwaitExpressions" />
+    <property role="TrG5h" value="AwaitExpressions_RemoveAwaitAction" />
+    <node concept="1qefOq" id="5xnAHh0e9vm" role="25YQCW">
+      <node concept="31KRCM" id="5xnAHh0yzic" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="5xnAHh0yzid" role="31KRCR">
+          <node concept="2Yz168" id="5xnAHh0yzie" role="1ux1N">
+            <node concept="1BEDWZ" id="5xnAHh0yzif" role="2Yz169">
+              <node concept="3UdiBM" id="5xnAHh0yzig" role="1BEDQz">
+                <node concept="1VUwCF" id="5xnAHh0yzih" role="3UdiBN">
+                  <ref role="2aT8gA" node="5xnAHh0yzic" resolve="method" />
+                </node>
+                <node concept="3UdiBG" id="5xnAHh0yzii" role="3UdiBL" />
+              </node>
+              <node concept="LIFWc" id="5xnAHh0yzi_" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="5" />
+                <property role="p6zMs" value="5" />
+                <property role="LIFWd" value="operator" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="5xnAHh0yzij" role="1fIg$P" />
+        <node concept="1pH0Yj" id="5xnAHh0yzik" role="3Sw9wT" />
+        <node concept="2qGUbG" id="5xnAHh0yzil" role="3SE3Wx" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="5xnAHh0e9vx" role="25YQFr">
+      <node concept="31KRCM" id="5xnAHh0yziB" role="1qenE9">
+        <property role="TrG5h" value="method" />
+        <node concept="1ux1M" id="5xnAHh0yziC" role="31KRCR">
+          <node concept="2Yz168" id="5xnAHh0yziD" role="1ux1N">
+            <node concept="3UdiBM" id="5xnAHh0yziF" role="2Yz169">
+              <node concept="1VUwCF" id="5xnAHh0yziG" role="3UdiBN">
+                <ref role="2aT8gA" node="5xnAHh0yziB" resolve="method" />
+              </node>
+              <node concept="3UdiBG" id="5xnAHh0yziH" role="3UdiBL" />
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1I" id="5xnAHh0yziI" role="1fIg$P" />
+        <node concept="1pH0Yj" id="5xnAHh0yziJ" role="3Sw9wT" />
+        <node concept="2qGUbG" id="5xnAHh0yziK" role="3SE3Wx" />
+      </node>
+    </node>
+    <node concept="3clFbS" id="5xnAHh0e9vG" role="LjaKd">
+      <node concept="3clFbF" id="5xnAHh0yjyU" role="3cqZAp">
+        <node concept="2YIFZM" id="5xnAHh0yjzf" role="3clFbG">
+          <ref role="37wK5l" to="tp6m:14TMHtHs1EN" resolve="runWithTwoStepDeletion" />
+          <ref role="1Pybhc" to="tp6m:5s44y2Lh6_5" resolve="EditorTestUtil" />
+          <node concept="1bVj0M" id="5xnAHh0yjBG" role="37wK5m">
+            <node concept="3clFbS" id="5xnAHh0yjBK" role="1bW5cS">
+              <node concept="2HxZob" id="5xnAHh0yjNF" role="3cqZAp">
+                <node concept="1iFQzN" id="5xnAHh0yjOx" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+              <node concept="2HxZob" id="5xnAHh0yjR_" role="3cqZAp">
+                <node concept="1iFQzN" id="5xnAHh0yjRA" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="5xnAHh0yjE_" role="37wK5m">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
Await expressions are constrained to require an ancestor of the new interface ICanBeAsync, which applies to methods and anonymous functions (yet to be implemented). For a better editing experience, the other constraints in the specification are instead handled by checking rules. An intention is provided to add the async modifier to the enclosing function if this is required, similar to the one found in C# IDEs.