### PR TITLE
Implement lambda expressions

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
@@ -11,13 +11,17 @@
   <imports>
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" />
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -31,7 +35,23 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -41,8 +61,37 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
@@ -58,9 +107,47 @@
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
         <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+        <child id="1205851242421" name="methodDeclaration" index="32lrUH" />
+      </concept>
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
       </concept>
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
       <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -70,6 +157,23 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
+        <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
+        <child id="1883223317721008709" name="body" index="Jncv$" />
+        <child id="1883223317721008711" name="variable" index="JncvA" />
+        <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
+      </concept>
+      <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
         <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
       </concept>
@@ -77,11 +181,31 @@
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1144195091934" name="jetbrains.mps.lang.smodel.structure.Node_IsRoleOperation" flags="nn" index="1BlSNk">
+        <reference id="1144195362400" name="conceptOfParent" index="1BmUXE" />
+        <reference id="1144195396777" name="linkInParent" index="1Bn3mz" />
+      </concept>
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
+      </concept>
+      <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
+        <child id="1140131861877" name="replacementNode" index="1P9ThW" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -106,6 +230,15 @@
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="2S6QgY" id="5nBCUOUfv_A">
@@ -284,6 +417,21 @@
         </node>
       </node>
     </node>
+    <node concept="2SaL7w" id="3M_w9wmKP64" role="2ZfVeh">
+      <node concept="3clFbS" id="3M_w9wmKP65" role="2VODD2">
+        <node concept="3clFbF" id="3M_w9wmKPpd" role="3cqZAp">
+          <node concept="3fqX7Q" id="3M_w9wmKPpb" role="3clFbG">
+            <node concept="2OqwBi" id="3M_w9wmKPZx" role="3fr31v">
+              <node concept="2Sf5sV" id="3M_w9wmKPpj" role="2Oq$k0" />
+              <node concept="1BlSNk" id="3M_w9wmKSlC" role="2OqNvi">
+                <ref role="1BmUXE" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+                <ref role="1Bn3mz" to="80bi:7HmXimPhQc_" resolve="parameters" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
   </node>
   <node concept="2S6QgY" id="p4z1jPjlIe">
     <property role="3GE5qa" value="Namespace" />
@@ -405,6 +553,495 @@
               </node>
               <node concept="3TrcHB" id="5xnAHh0dRjf" role="2OqNvi">
                 <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="1XmGakOXg0W">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="ExpressionToBlock" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="2S6ZIM" id="1XmGakOXg0X" role="2ZfVej">
+      <node concept="3clFbS" id="1XmGakOXg0Y" role="2VODD2">
+        <node concept="3clFbF" id="1XmGakOXghP" role="3cqZAp">
+          <node concept="Xl_RD" id="1XmGakOXghO" role="3clFbG">
+            <property role="Xl_RC" value="Convert to block body" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="1XmGakOXg0Z" role="2ZfgGD">
+      <node concept="3clFbS" id="1XmGakOXg10" role="2VODD2">
+        <node concept="3clFbF" id="1XmGakOXmgB" role="3cqZAp">
+          <node concept="2OqwBi" id="1XmGakOXm$e" role="3clFbG">
+            <node concept="2OqwBi" id="1XmGakOXmgV" role="2Oq$k0">
+              <node concept="2Sf5sV" id="1XmGakOXmgA" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1XmGakOXmyQ" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+              </node>
+            </node>
+            <node concept="1P9Npp" id="1XmGakOXmWf" role="2OqNvi">
+              <node concept="2pJPEk" id="1XmGakPF6dD" role="1P9ThW">
+                <node concept="2pJPED" id="1XmGakPF6dF" role="2pJPEn">
+                  <ref role="2pJxaS" to="80bi:6vAOG1ABcaM" resolve="Block" />
+                  <node concept="2pIpSj" id="1XmGakPF6ks" role="2pJxcM">
+                    <ref role="2pIpSl" to="80bi:6vAOG1ABcaN" resolve="statement" />
+                    <node concept="36be1Y" id="1XmGakPFagf" role="28nt2d">
+                      <node concept="2pJPED" id="30U1FYltPaA" role="36be1Z">
+                        <ref role="2pJxaS" to="80bi:1FYNzU$x4Fa" resolve="ReturnStatement" />
+                        <node concept="2pIpSj" id="30U1FYltPbe" role="2pJxcM">
+                          <ref role="2pIpSl" to="80bi:1FYNzU$x4Fb" resolve="expression" />
+                          <node concept="36biLy" id="30U1FYltPbL" role="28nt2d">
+                            <node concept="1PxgMI" id="30U1FYltZ3B" role="36biLW">
+                              <property role="1BlNFB" value="true" />
+                              <node concept="chp4Y" id="30U1FYltZ4A" role="3oSUPX">
+                                <ref role="cht4Q" to="80bi:5VT83U$LgKs" resolve="Expression" />
+                              </node>
+                              <node concept="2OqwBi" id="30U1FYltWyA" role="1m5AlR">
+                                <node concept="2Sf5sV" id="30U1FYltPch" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="30U1FYltYH0" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="1XmGakOXiOz" role="2ZfVeh">
+      <node concept="3clFbS" id="1XmGakOXiO$" role="2VODD2">
+        <node concept="3clFbF" id="1XmGakOXj3b" role="3cqZAp">
+          <node concept="2OqwBi" id="1XmGakOXlOQ" role="3clFbG">
+            <node concept="2OqwBi" id="1XmGakOXjvg" role="2Oq$k0">
+              <node concept="2Sf5sV" id="1XmGakOXj3a" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1XmGakOXl_W" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+              </node>
+            </node>
+            <node concept="1mIQ4w" id="1XmGakOXmbJ" role="2OqNvi">
+              <node concept="chp4Y" id="1XmGakOXme_" role="cj9EA">
+                <ref role="cht4Q" to="80bi:5VT83U$LgKs" resolve="Expression" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="1XmGakP62$g">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="BlockToExpression" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="2XrIbr" id="30U1FYlvT4k" role="32lrUH">
+      <property role="TrG5h" value="hasCompatibleStatements" />
+      <node concept="3clFbS" id="30U1FYlvT4m" role="3clF47">
+        <node concept="3clFbF" id="30U1FYlvTPb" role="3cqZAp">
+          <node concept="2OqwBi" id="30U1FYlwar5" role="3clFbG">
+            <node concept="2OqwBi" id="30U1FYlwar6" role="2Oq$k0">
+              <node concept="2OqwBi" id="30U1FYlwar7" role="2Oq$k0">
+                <node concept="37vLTw" id="30U1FYlwb06" role="2Oq$k0">
+                  <ref role="3cqZAo" node="30U1FYlvTLm" resolve="block" />
+                </node>
+                <node concept="3Tsc0h" id="30U1FYlwar9" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:6vAOG1ABcaN" resolve="statement" />
+                </node>
+              </node>
+              <node concept="3$u5V9" id="30U1FYlwara" role="2OqNvi">
+                <node concept="1bVj0M" id="30U1FYlwarb" role="23t8la">
+                  <node concept="3clFbS" id="30U1FYlwarc" role="1bW5cS">
+                    <node concept="3clFbF" id="30U1FYlward" role="3cqZAp">
+                      <node concept="2OqwBi" id="30U1FYlware" role="3clFbG">
+                        <node concept="37vLTw" id="30U1FYlwarf" role="2Oq$k0">
+                          <ref role="3cqZAo" node="30U1FYlwarh" resolve="it" />
+                        </node>
+                        <node concept="2yIwOk" id="30U1FYlwarg" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="30U1FYlwarh" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="30U1FYlwari" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2HxqBE" id="30U1FYlwarj" role="2OqNvi">
+              <node concept="1bVj0M" id="30U1FYlwark" role="23t8la">
+                <node concept="3clFbS" id="30U1FYlwarl" role="1bW5cS">
+                  <node concept="3clFbF" id="30U1FYlwarm" role="3cqZAp">
+                    <node concept="22lmx$" id="30U1FYlwarn" role="3clFbG">
+                      <node concept="2OqwBi" id="30U1FYlwaro" role="3uHU7w">
+                        <node concept="37vLTw" id="30U1FYlwarp" role="2Oq$k0">
+                          <ref role="3cqZAo" node="30U1FYlwarw" resolve="it" />
+                        </node>
+                        <node concept="2Zo12i" id="30U1FYlwarq" role="2OqNvi">
+                          <node concept="chp4Y" id="30U1FYlwarr" role="2Zo12j">
+                            <ref role="cht4Q" to="80bi:1FYNzU$x4Fa" resolve="ReturnStatement" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="30U1FYlwars" role="3uHU7B">
+                        <node concept="37vLTw" id="30U1FYlwart" role="2Oq$k0">
+                          <ref role="3cqZAo" node="30U1FYlwarw" resolve="it" />
+                        </node>
+                        <node concept="3O6GUB" id="30U1FYlwaru" role="2OqNvi">
+                          <node concept="chp4Y" id="30U1FYlwarv" role="3QVz_e">
+                            <ref role="cht4Q" to="80bi:6hv6i2_B6cm" resolve="Statement" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="30U1FYlwarw" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="30U1FYlwarx" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="30U1FYlvT4n" role="1B3o_S" />
+      <node concept="37vLTG" id="30U1FYlvTLm" role="3clF46">
+        <property role="TrG5h" value="block" />
+        <node concept="3Tqbb2" id="30U1FYlvTLl" role="1tU5fm">
+          <ref role="ehGHo" to="80bi:6vAOG1ABcaM" resolve="Block" />
+        </node>
+      </node>
+      <node concept="10P_77" id="30U1FYlw8Ba" role="3clF45" />
+    </node>
+    <node concept="2XrIbr" id="30U1FYlw7Rg" role="32lrUH">
+      <property role="TrG5h" value="getReturn" />
+      <node concept="3clFbS" id="30U1FYlw7Rh" role="3clF47">
+        <node concept="3clFbF" id="30U1FYlw7Ri" role="3cqZAp">
+          <node concept="2OqwBi" id="30U1FYlw7Rj" role="3clFbG">
+            <node concept="2OqwBi" id="30U1FYlw7Rk" role="2Oq$k0">
+              <node concept="2OqwBi" id="30U1FYlw7Rl" role="2Oq$k0">
+                <node concept="37vLTw" id="30U1FYlw7Rm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="30U1FYlw7Rs" resolve="block" />
+                </node>
+                <node concept="3Tsc0h" id="30U1FYlw7Rn" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:6vAOG1ABcaN" resolve="statement" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="30U1FYlw7Ro" role="2OqNvi">
+                <node concept="chp4Y" id="30U1FYlw7Rp" role="v3oSu">
+                  <ref role="cht4Q" to="80bi:1FYNzU$x4Fa" resolve="ReturnStatement" />
+                </node>
+              </node>
+            </node>
+            <node concept="1uHKPH" id="30U1FYlw7Rq" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="30U1FYlw7Rr" role="1B3o_S" />
+      <node concept="37vLTG" id="30U1FYlw7Rs" role="3clF46">
+        <property role="TrG5h" value="block" />
+        <node concept="3Tqbb2" id="30U1FYlw7Rt" role="1tU5fm">
+          <ref role="ehGHo" to="80bi:6vAOG1ABcaM" resolve="Block" />
+        </node>
+      </node>
+      <node concept="3Tqbb2" id="30U1FYlw7Ru" role="3clF45">
+        <ref role="ehGHo" to="80bi:1FYNzU$x4Fa" resolve="ReturnStatement" />
+      </node>
+    </node>
+    <node concept="2S6ZIM" id="1XmGakP62$h" role="2ZfVej">
+      <node concept="3clFbS" id="1XmGakP62$i" role="2VODD2">
+        <node concept="3clFbF" id="1XmGakP62Py" role="3cqZAp">
+          <node concept="Xl_RD" id="1XmGakP62Px" role="3clFbG">
+            <property role="Xl_RC" value="Convert to expression body" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="1XmGakP62$j" role="2ZfgGD">
+      <node concept="3clFbS" id="1XmGakP62$k" role="2VODD2">
+        <node concept="3clFbF" id="1XmGakP6pWP" role="3cqZAp">
+          <node concept="2OqwBi" id="1XmGakP6q9p" role="3clFbG">
+            <node concept="2OqwBi" id="1XmGakP7vOB" role="2Oq$k0">
+              <node concept="2Sf5sV" id="1XmGakP6pWO" role="2Oq$k0" />
+              <node concept="3TrEf2" id="1XmGakP7w6b" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+              </node>
+            </node>
+            <node concept="1P9Npp" id="1XmGakP6qEy" role="2OqNvi">
+              <node concept="2OqwBi" id="30U1FYlw7jP" role="1P9ThW">
+                <node concept="2OqwBi" id="30U1FYlw65E" role="2Oq$k0">
+                  <node concept="2WthIp" id="30U1FYlw65H" role="2Oq$k0" />
+                  <node concept="2XshWL" id="30U1FYlw65J" role="2OqNvi">
+                    <ref role="2WH_rO" node="30U1FYlw7Rg" resolve="returnStatement" />
+                    <node concept="1PxgMI" id="30U1FYlw6Vs" role="2XxRq1">
+                      <property role="1BlNFB" value="true" />
+                      <node concept="chp4Y" id="30U1FYlw6Yu" role="3oSUPX">
+                        <ref role="cht4Q" to="80bi:6vAOG1ABcaM" resolve="Block" />
+                      </node>
+                      <node concept="2OqwBi" id="30U1FYlw6lQ" role="1m5AlR">
+                        <node concept="2Sf5sV" id="30U1FYlw68n" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="30U1FYlw6Ci" role="2OqNvi">
+                          <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3TrEf2" id="30U1FYlw7MR" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:1FYNzU$x4Fb" resolve="expression" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="1XmGakP637p" role="2ZfVeh">
+      <node concept="3clFbS" id="1XmGakP637q" role="2VODD2">
+        <node concept="Jncv_" id="1XmGakP6sUR" role="3cqZAp">
+          <ref role="JncvD" to="80bi:6vAOG1ABcaM" resolve="Block" />
+          <node concept="2OqwBi" id="1XmGakP6teo" role="JncvB">
+            <node concept="2Sf5sV" id="1XmGakP6sXk" role="2Oq$k0" />
+            <node concept="3TrEf2" id="1XmGakP6tjr" role="2OqNvi">
+              <ref role="3Tt5mk" to="80bi:7HmXimPhNcb" resolve="body" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="1XmGakP6sUV" role="Jncv$">
+            <node concept="3cpWs6" id="30U1FYlwcSt" role="3cqZAp">
+              <node concept="1Wc70l" id="30U1FYlweK4" role="3cqZAk">
+                <node concept="2OqwBi" id="30U1FYlwga4" role="3uHU7w">
+                  <node concept="2OqwBi" id="30U1FYlweRT" role="2Oq$k0">
+                    <node concept="2WthIp" id="30U1FYlweRW" role="2Oq$k0" />
+                    <node concept="2XshWL" id="30U1FYlweRY" role="2OqNvi">
+                      <ref role="2WH_rO" node="30U1FYlw7Rg" resolve="returnStatement" />
+                      <node concept="Jnkvi" id="30U1FYlwf1K" role="2XxRq1">
+                        <ref role="1M0zk5" node="1XmGakP6sUX" resolve="block" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3x8VRR" id="30U1FYlwgKq" role="2OqNvi" />
+                </node>
+                <node concept="2OqwBi" id="30U1FYlwd6O" role="3uHU7B">
+                  <node concept="2WthIp" id="30U1FYlwd6R" role="2Oq$k0" />
+                  <node concept="2XshWL" id="30U1FYlwd6T" role="2OqNvi">
+                    <ref role="2WH_rO" node="30U1FYlvT4k" resolve="hasCompatibleStatements" />
+                    <node concept="Jnkvi" id="30U1FYlwdes" role="2XxRq1">
+                      <ref role="1M0zk5" node="1XmGakP6sUX" resolve="block" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="1XmGakP6sUX" role="JncvA">
+            <property role="TrG5h" value="block" />
+            <node concept="2jxLKc" id="1XmGakP6sUY" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="1XmGakP7gbV" role="3cqZAp">
+          <node concept="3clFbT" id="1XmGakP7gi9" role="3cqZAk" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="iSyfcvqAoV">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="MakeExplicit" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="2S6ZIM" id="iSyfcvqAoW" role="2ZfVej">
+      <node concept="3clFbS" id="iSyfcvqAoX" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcvqAGA" role="3cqZAp">
+          <node concept="Xl_RD" id="iSyfcvqAG_" role="3clFbG">
+            <property role="Xl_RC" value="Make all parameters explicit" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="iSyfcvqAoY" role="2ZfgGD">
+      <node concept="3clFbS" id="iSyfcvqAoZ" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcv_nDv" role="3cqZAp">
+          <node concept="2OqwBi" id="iSyfcv_z39" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcv_rCU" role="2Oq$k0">
+              <node concept="2OqwBi" id="iSyfcv_nNH" role="2Oq$k0">
+                <node concept="2Sf5sV" id="iSyfcv_nDu" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="iSyfcv_oxF" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:7HmXimPhQc_" resolve="parameters" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="iSyfcvA_6K" role="2OqNvi">
+                <node concept="chp4Y" id="iSyfcvA_bj" role="v3oSu">
+                  <ref role="cht4Q" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="iSyfcv_$LN" role="2OqNvi">
+              <node concept="1bVj0M" id="iSyfcv_$LP" role="23t8la">
+                <node concept="3clFbS" id="iSyfcv_$LQ" role="1bW5cS">
+                  <node concept="3cpWs8" id="iSyfcv_C1i" role="3cqZAp">
+                    <node concept="3cpWsn" id="iSyfcv_C1l" role="3cpWs9">
+                      <property role="TrG5h" value="param" />
+                      <node concept="3Tqbb2" id="iSyfcv_C1h" role="1tU5fm">
+                        <ref role="ehGHo" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                      </node>
+                      <node concept="2ShNRf" id="iSyfcv_CD9" role="33vP2m">
+                        <node concept="2fJWfE" id="iSyfcv_CTA" role="2ShVmc">
+                          <node concept="3Tqbb2" id="iSyfcv_CTC" role="3zrR0E">
+                            <ref role="ehGHo" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="iSyfcv_D9X" role="3cqZAp">
+                    <node concept="37vLTI" id="iSyfcv_GY3" role="3clFbG">
+                      <node concept="2OqwBi" id="iSyfcv_HlS" role="37vLTx">
+                        <node concept="37vLTw" id="iSyfcv_H4v" role="2Oq$k0">
+                          <ref role="3cqZAo" node="iSyfcv_$LR" resolve="it" />
+                        </node>
+                        <node concept="3TrcHB" id="iSyfcv_JtQ" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                      <node concept="2OqwBi" id="iSyfcv_Dvb" role="37vLTJ">
+                        <node concept="37vLTw" id="iSyfcv_D9V" role="2Oq$k0">
+                          <ref role="3cqZAo" node="iSyfcv_C1l" resolve="param" />
+                        </node>
+                        <node concept="3TrcHB" id="iSyfcv_DPW" role="2OqNvi">
+                          <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbF" id="iSyfcv_JUA" role="3cqZAp">
+                    <node concept="2OqwBi" id="iSyfcv_KgR" role="3clFbG">
+                      <node concept="37vLTw" id="iSyfcv_JZH" role="2Oq$k0">
+                        <ref role="3cqZAo" node="iSyfcv_$LR" resolve="it" />
+                      </node>
+                      <node concept="1P9Npp" id="iSyfcv_LI6" role="2OqNvi">
+                        <node concept="37vLTw" id="iSyfcv_LNl" role="1P9ThW">
+                          <ref role="3cqZAo" node="iSyfcv_C1l" resolve="param" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="iSyfcv_$LR" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="iSyfcv_$LS" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="iSyfcvqALA" role="2ZfVeh">
+      <node concept="3clFbS" id="iSyfcvqALB" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcvqB0X" role="3cqZAp">
+          <node concept="3fqX7Q" id="iSyfcwm9G7" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcwm9Ga" role="3fr31v">
+              <node concept="2Sf5sV" id="iSyfcwm9Gb" role="2Oq$k0" />
+              <node concept="2qgKlT" id="iSyfcwmdu6" role="2OqNvi">
+                <ref role="37wK5l" to="kvwr:iSyfcvcQVt" resolve="isExplicit" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="iSyfcv_Xws">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="MakeImplicit" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="2S6ZIM" id="iSyfcv_Xwt" role="2ZfVej">
+      <node concept="3clFbS" id="iSyfcv_Xwu" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcv_XNI" role="3cqZAp">
+          <node concept="Xl_RD" id="iSyfcv_XNH" role="3clFbG">
+            <property role="Xl_RC" value="Make all parameters implicit" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="iSyfcv_Xwv" role="2ZfgGD">
+      <node concept="3clFbS" id="iSyfcv_Xww" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcvAaoy" role="3cqZAp">
+          <node concept="2OqwBi" id="iSyfcvApVd" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcvAnkL" role="2Oq$k0">
+              <node concept="2OqwBi" id="iSyfcvAayK" role="2Oq$k0">
+                <node concept="2Sf5sV" id="iSyfcvAaox" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="iSyfcvAaNq" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:7HmXimPhQc_" resolve="parameters" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="iSyfcvApg6" role="2OqNvi">
+                <node concept="chp4Y" id="iSyfcvApiE" role="v3oSu">
+                  <ref role="cht4Q" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                </node>
+              </node>
+            </node>
+            <node concept="2es0OD" id="iSyfcvAraH" role="2OqNvi">
+              <node concept="1bVj0M" id="iSyfcvAraJ" role="23t8la">
+                <node concept="3clFbS" id="iSyfcvAraK" role="1bW5cS">
+                  <node concept="3clFbF" id="iSyfcvAriA" role="3cqZAp">
+                    <node concept="2OqwBi" id="iSyfcvArxY" role="3clFbG">
+                      <node concept="37vLTw" id="iSyfcvAri_" role="2Oq$k0">
+                        <ref role="3cqZAo" node="iSyfcvAraL" resolve="it" />
+                      </node>
+                      <node concept="1P9Npp" id="iSyfcvAsP4" role="2OqNvi">
+                        <node concept="2pJPEk" id="iSyfcvAsT2" role="1P9ThW">
+                          <node concept="2pJPED" id="iSyfcvAsT4" role="2pJPEn">
+                            <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                            <node concept="2pJxcG" id="iSyfcvAt0Q" role="2pJxcM">
+                              <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                              <node concept="WxPPo" id="iSyfcvAt4q" role="28ntcv">
+                                <node concept="2OqwBi" id="iSyfcvAtjL" role="WxPPp">
+                                  <node concept="37vLTw" id="iSyfcvAt4o" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="iSyfcvAraL" resolve="it" />
+                                  </node>
+                                  <node concept="3TrcHB" id="iSyfcvAuoI" role="2OqNvi">
+                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="iSyfcvAraL" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="iSyfcvAraM" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="iSyfcv_XPX" role="2ZfVeh">
+      <node concept="3clFbS" id="iSyfcv_XPY" role="2VODD2">
+        <node concept="3clFbF" id="iSyfcwmeK6" role="3cqZAp">
+          <node concept="3fqX7Q" id="iSyfcwmi$J" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcwmi$L" role="3fr31v">
+              <node concept="2Sf5sV" id="iSyfcwmi$M" role="2Oq$k0" />
+              <node concept="2qgKlT" id="iSyfcwmi$N" role="2OqNvi">
+                <ref role="37wK5l" to="kvwr:iSyfcwmhgE" resolve="isImplicit" />
               </node>
             </node>
           </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
@@ -101,6 +101,9 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -235,6 +238,7 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
@@ -1597,6 +1601,136 @@
     </node>
     <node concept="13hLZK" id="42EL3I6oFKc" role="13h7CW">
       <node concept="3clFbS" id="42EL3I6oFKd" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="7HmXimPF_y7">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="13h7C2" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="13i0hz" id="iSyfcvcioP" role="13h7CS">
+      <property role="TrG5h" value="isConsistent" />
+      <node concept="3Tm1VV" id="iSyfcvcioQ" role="1B3o_S" />
+      <node concept="10P_77" id="iSyfcvcirx" role="3clF45" />
+      <node concept="3clFbS" id="iSyfcvcioS" role="3clF47">
+        <node concept="3clFbF" id="iSyfcwpOGw" role="3cqZAp">
+          <node concept="22lmx$" id="iSyfcwpPWt" role="3clFbG">
+            <node concept="BsUDl" id="iSyfcwpPYR" role="3uHU7w">
+              <ref role="37wK5l" node="iSyfcwmhgE" resolve="isImplicit" />
+            </node>
+            <node concept="BsUDl" id="iSyfcwpOGb" role="3uHU7B">
+              <ref role="37wK5l" node="iSyfcvcQVt" resolve="isExplicit" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="iSyfcvcQVt" role="13h7CS">
+      <property role="TrG5h" value="isExplicit" />
+      <node concept="3Tm1VV" id="iSyfcwmcob" role="1B3o_S" />
+      <node concept="10P_77" id="iSyfcvcR2C" role="3clF45" />
+      <node concept="3clFbS" id="iSyfcvcQVw" role="3clF47">
+        <node concept="3clFbF" id="iSyfcvcR48" role="3cqZAp">
+          <node concept="2OqwBi" id="iSyfcvcV$d" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcvcRhN" role="2Oq$k0">
+              <node concept="13iPFW" id="iSyfcvcR47" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="iSyfcvcRZA" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:7HmXimPhQc_" resolve="parameters" />
+              </node>
+            </node>
+            <node concept="2HxqBE" id="iSyfcvcYzd" role="2OqNvi">
+              <node concept="1bVj0M" id="iSyfcvcYzf" role="23t8la">
+                <node concept="3clFbS" id="iSyfcvcYzg" role="1bW5cS">
+                  <node concept="3clFbF" id="iSyfcvcY_W" role="3cqZAp">
+                    <node concept="2OqwBi" id="iSyfcvEb4N" role="3clFbG">
+                      <node concept="37vLTw" id="iSyfcvEaK0" role="2Oq$k0">
+                        <ref role="3cqZAo" node="iSyfcvcYzh" resolve="it" />
+                      </node>
+                      <node concept="1mIQ4w" id="iSyfcvEc2k" role="2OqNvi">
+                        <node concept="chp4Y" id="iSyfcvEc9L" role="cj9EA">
+                          <ref role="cht4Q" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="iSyfcvcYzh" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="iSyfcvcYzi" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="iSyfcwmhgE" role="13h7CS">
+      <property role="TrG5h" value="isImplicit" />
+      <node concept="3Tm1VV" id="iSyfcwmhgF" role="1B3o_S" />
+      <node concept="10P_77" id="iSyfcwmhgG" role="3clF45" />
+      <node concept="3clFbS" id="iSyfcwmhgH" role="3clF47">
+        <node concept="3clFbF" id="iSyfcwmhgI" role="3cqZAp">
+          <node concept="2OqwBi" id="iSyfcwmhgJ" role="3clFbG">
+            <node concept="2OqwBi" id="iSyfcwmhgK" role="2Oq$k0">
+              <node concept="13iPFW" id="iSyfcwmhgL" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="iSyfcwmhgM" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:7HmXimPhQc_" resolve="parameters" />
+              </node>
+            </node>
+            <node concept="2HxqBE" id="iSyfcwmhgN" role="2OqNvi">
+              <node concept="1bVj0M" id="iSyfcwmhgO" role="23t8la">
+                <node concept="3clFbS" id="iSyfcwmhgP" role="1bW5cS">
+                  <node concept="3clFbF" id="iSyfcwmhgQ" role="3cqZAp">
+                    <node concept="2OqwBi" id="iSyfcwmhgR" role="3clFbG">
+                      <node concept="37vLTw" id="iSyfcwmhgS" role="2Oq$k0">
+                        <ref role="3cqZAo" node="iSyfcwmhgV" resolve="it" />
+                      </node>
+                      <node concept="1mIQ4w" id="iSyfcwmhgT" role="2OqNvi">
+                        <node concept="chp4Y" id="iSyfcwmhgU" role="cj9EA">
+                          <ref role="cht4Q" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="iSyfcwmhgV" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="iSyfcwmhgW" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="iSyfcw7Tst" role="13h7CS">
+      <property role="TrG5h" value="needsParentheses" />
+      <node concept="3Tm1VV" id="iSyfcw7Tsu" role="1B3o_S" />
+      <node concept="10P_77" id="iSyfcw7T$X" role="3clF45" />
+      <node concept="3clFbS" id="iSyfcw7Tsw" role="3clF47">
+        <node concept="3clFbF" id="7HmXimPF_OJ" role="3cqZAp">
+          <node concept="22lmx$" id="iSyfcvEiAB" role="3clFbG">
+            <node concept="BsUDl" id="iSyfcvEiDh" role="3uHU7B">
+              <ref role="37wK5l" node="iSyfcvcQVt" resolve="isExplicit" />
+            </node>
+            <node concept="3y3z36" id="7HmXimPFSp3" role="3uHU7w">
+              <node concept="2OqwBi" id="7HmXimPFDMi" role="3uHU7B">
+                <node concept="2OqwBi" id="7HmXimPFA0U" role="2Oq$k0">
+                  <node concept="13iPFW" id="7HmXimPF_OI" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="7HmXimPFAac" role="2OqNvi">
+                    <ref role="3TtcxE" to="80bi:7HmXimPhQc_" resolve="parameters" />
+                  </node>
+                </node>
+                <node concept="34oBXx" id="7HmXimPFHXq" role="2OqNvi" />
+              </node>
+              <node concept="3cmrfG" id="7HmXimPFObw" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="7HmXimPF_y8" role="13h7CW">
+      <node concept="3clFbS" id="7HmXimPF_y9" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -9,6 +9,7 @@
   </languages>
   <imports>
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
+    <import index="dorh" ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
@@ -34,6 +35,9 @@
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
@@ -2528,85 +2532,6 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="5xnAHgZmc2p">
-    <property role="3GE5qa" value="Initializers" />
-    <ref role="1M2myG" to="80bi:5VT83U$Mmmn" resolve="ArrayInitializer" />
-    <node concept="9S07l" id="5xnAHgZmc2q" role="9Vyp8">
-      <node concept="3clFbS" id="5xnAHgZmc2r" role="2VODD2">
-        <node concept="Jncv_" id="5xnAHgZme4v" role="3cqZAp">
-          <ref role="JncvD" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-          <node concept="nLn13" id="5xnAHgZme5f" role="JncvB" />
-          <node concept="3clFbS" id="5xnAHgZme4x" role="Jncv$">
-            <node concept="3cpWs6" id="5xnAHgZme91" role="3cqZAp">
-              <node concept="2OqwBi" id="5xnAHgZmhW2" role="3cqZAk">
-                <node concept="2OqwBi" id="5xnAHgZmfox" role="2Oq$k0">
-                  <node concept="2OqwBi" id="5xnAHgZmeSv" role="2Oq$k0">
-                    <node concept="2OqwBi" id="5xnAHgZmenm" role="2Oq$k0">
-                      <node concept="Jnkvi" id="5xnAHgZmea5" role="2Oq$k0">
-                        <ref role="1M0zk5" node="5xnAHgZme4y" resolve="declaration" />
-                      </node>
-                      <node concept="2Xjw5R" id="5xnAHgZmeCB" role="2OqNvi">
-                        <node concept="1xMEDy" id="5xnAHgZmeCD" role="1xVPHs">
-                          <node concept="chp4Y" id="5xnAHgZmeFK" role="ri$Ld">
-                            <ref role="cht4Q" to="80bi:5oHFRyIxp1s" resolve="IHaveType" />
-                          </node>
-                        </node>
-                        <node concept="1xIGOp" id="5xnAHgZmeK7" role="1xVPHs" />
-                      </node>
-                    </node>
-                    <node concept="3TrEf2" id="5xnAHgZmfb2" role="2OqNvi">
-                      <ref role="3Tt5mk" to="80bi:5oHFRyIxpPa" resolve="type" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="5xnAHgZmfAy" role="2OqNvi">
-                    <ref role="3TtcxE" to="80bi:5VT83U$LPq1" resolve="rankSpecifier" />
-                  </node>
-                </node>
-                <node concept="3GX2aA" id="5xnAHgZmjUf" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-          <node concept="JncvC" id="5xnAHgZme4y" role="JncvA">
-            <property role="TrG5h" value="declaration" />
-            <node concept="2jxLKc" id="5xnAHgZme4z" role="1tU5fm" />
-          </node>
-        </node>
-        <node concept="3cpWs6" id="5xnAHgZmjZ$" role="3cqZAp">
-          <node concept="2OqwBi" id="5xnAHgZmUF1" role="3cqZAk">
-            <node concept="nLn13" id="5xnAHgZmTqc" role="2Oq$k0" />
-            <node concept="1mIQ4w" id="5xnAHgZmUXp" role="2OqNvi">
-              <node concept="chp4Y" id="5xnAHgZmV0L" role="cj9EA">
-                <ref role="cht4Q" to="80bi:5VT83U$Mxwu" resolve="NewArrayTypeExpression" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="5xnAHh0xYvk">
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <ref role="1M2myG" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
-    <node concept="9S07l" id="5xnAHh0xYvl" role="9Vyp8">
-      <node concept="3clFbS" id="5xnAHh0xYvm" role="2VODD2">
-        <node concept="3clFbF" id="5xnAHh0xYHp" role="3cqZAp">
-          <node concept="2OqwBi" id="5xnAHh0xZHP" role="3clFbG">
-            <node concept="2OqwBi" id="5xnAHh0xYTW" role="2Oq$k0">
-              <node concept="nLn13" id="5xnAHh0xYHo" role="2Oq$k0" />
-              <node concept="2Xjw5R" id="5xnAHh0xZnh" role="2OqNvi">
-                <node concept="1xMEDy" id="5xnAHh0xZnj" role="1xVPHs">
-                  <node concept="chp4Y" id="5xnAHh0xZpJ" role="ri$Ld">
-                    <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3x8VRR" id="5xnAHh0y0vg" role="2OqNvi" />
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="1M2fIO" id="5xnAHh08MEU">
     <property role="3GE5qa" value="Class / Struct.Methods" />
     <ref role="1M2myG" to="80bi:6hv6i2_B6ci" resolve="MethodDeclaration" />
@@ -2710,6 +2635,109 @@
                       </node>
                     </node>
                   </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5xnAHh0xYvk">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <ref role="1M2myG" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="9S07l" id="5xnAHh0xYvl" role="9Vyp8">
+      <node concept="3clFbS" id="5xnAHh0xYvm" role="2VODD2">
+        <node concept="3clFbF" id="5xnAHh0xYHp" role="3cqZAp">
+          <node concept="2OqwBi" id="5xnAHh0xZHP" role="3clFbG">
+            <node concept="2OqwBi" id="5xnAHh0xYTW" role="2Oq$k0">
+              <node concept="nLn13" id="1XmGakPagCk" role="2Oq$k0" />
+              <node concept="2Xjw5R" id="5xnAHh0xZnh" role="2OqNvi">
+                <node concept="1xMEDy" id="5xnAHh0xZnj" role="1xVPHs">
+                  <node concept="chp4Y" id="5xnAHh0xZpJ" role="ri$Ld">
+                    <ref role="cht4Q" to="80bi:7HmXimRLOdX" resolve="ICanBeAsync" />
+                  </node>
+                </node>
+                <node concept="1xIGOp" id="1XmGakPagDX" role="1xVPHs" />
+              </node>
+            </node>
+            <node concept="3x8VRR" id="5xnAHh0y0vg" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="5xnAHgZmc2p">
+    <property role="3GE5qa" value="Initializers" />
+    <ref role="1M2myG" to="80bi:5VT83U$Mmmn" resolve="ArrayInitializer" />
+    <node concept="9S07l" id="5xnAHgZmc2q" role="9Vyp8">
+      <node concept="3clFbS" id="5xnAHgZmc2r" role="2VODD2">
+        <node concept="Jncv_" id="5xnAHgZme4v" role="3cqZAp">
+          <ref role="JncvD" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+          <node concept="nLn13" id="5xnAHgZme5f" role="JncvB" />
+          <node concept="3clFbS" id="5xnAHgZme4x" role="Jncv$">
+            <node concept="3cpWs6" id="5xnAHgZme91" role="3cqZAp">
+              <node concept="2OqwBi" id="5xnAHgZmhW2" role="3cqZAk">
+                <node concept="2OqwBi" id="5xnAHgZmfox" role="2Oq$k0">
+                  <node concept="2OqwBi" id="5xnAHgZmeSv" role="2Oq$k0">
+                    <node concept="2OqwBi" id="5xnAHgZmenm" role="2Oq$k0">
+                      <node concept="Jnkvi" id="5xnAHgZmea5" role="2Oq$k0">
+                        <ref role="1M0zk5" node="5xnAHgZme4y" resolve="declaration" />
+                      </node>
+                      <node concept="2Xjw5R" id="5xnAHgZmeCB" role="2OqNvi">
+                        <node concept="1xMEDy" id="5xnAHgZmeCD" role="1xVPHs">
+                          <node concept="chp4Y" id="5xnAHgZmeFK" role="ri$Ld">
+                            <ref role="cht4Q" to="80bi:5oHFRyIxp1s" resolve="IHaveType" />
+                          </node>
+                        </node>
+                        <node concept="1xIGOp" id="5xnAHgZmeK7" role="1xVPHs" />
+                      </node>
+                    </node>
+                    <node concept="3TrEf2" id="5xnAHgZmfb2" role="2OqNvi">
+                      <ref role="3Tt5mk" to="80bi:5oHFRyIxpPa" resolve="type" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="5xnAHgZmfAy" role="2OqNvi">
+                    <ref role="3TtcxE" to="80bi:5VT83U$LPq1" resolve="rankSpecifier" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="5xnAHgZmjUf" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="5xnAHgZme4y" role="JncvA">
+            <property role="TrG5h" value="declaration" />
+            <node concept="2jxLKc" id="5xnAHgZme4z" role="1tU5fm" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5xnAHgZmjZ$" role="3cqZAp">
+          <node concept="2OqwBi" id="5xnAHgZmUF1" role="3cqZAk">
+            <node concept="nLn13" id="5xnAHgZmTqc" role="2Oq$k0" />
+            <node concept="1mIQ4w" id="5xnAHgZmUXp" role="2OqNvi">
+              <node concept="chp4Y" id="5xnAHgZmV0L" role="cj9EA">
+                <ref role="cht4Q" to="80bi:5VT83U$Mxwu" resolve="NewArrayTypeExpression" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="iSyfcvANc2">
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <ref role="1M2myG" to="80bi:iSyfcvrmN2" resolve="Parameter" />
+    <node concept="EnEH3" id="iSyfcvANcZ" role="1MhHOB">
+      <ref role="EomxK" to="tpck:h0TrG11" resolve="name" />
+      <node concept="QB0g5" id="iSyfcvANd0" role="QCWH9">
+        <node concept="3clFbS" id="iSyfcvANd1" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcvANd2" role="3cqZAp">
+            <node concept="2OqwBi" id="iSyfcvANd3" role="3clFbG">
+              <node concept="1Wqviy" id="iSyfcvANd4" role="2Oq$k0" />
+              <node concept="liA8E" id="iSyfcvANd5" role="2OqNvi">
+                <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                <node concept="10M0yZ" id="iSyfcvANd6" role="37wK5m">
+                  <ref role="3cqZAo" to="dorh:5cm0BoTKIaF" resolve="identifier" />
+                  <ref role="1PxDUh" to="dorh:6H78krhSzlS" resolve="SubstitutionUtils" />
                 </node>
               </node>
             </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -13,6 +14,7 @@
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" implicit="true" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -46,12 +48,15 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="3459162043708467089" name="jetbrains.mps.lang.editor.structure.CellActionMap_CanExecuteFunction" flags="in" index="jK8Ss" />
+      <concept id="6089045305654894366" name="jetbrains.mps.lang.editor.structure.SubstituteMenuReference_Default" flags="ng" index="2kknPJ" />
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="784421273959492578" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_IncludeMenu" flags="ng" index="mvV$s">
+        <child id="784421273959492606" name="nodeFunction" index="mvV$0" />
         <child id="6718020819487784677" name="menuReference" index="A14EM" />
       </concept>
+      <concept id="784421273959493166" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_TargetNode" flags="ig" index="mvVNg" />
       <concept id="709996738298806197" name="jetbrains.mps.lang.editor.structure.QueryFunction_SeparatorText" flags="in" index="2o9xnK" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
@@ -67,6 +72,7 @@
       </concept>
       <concept id="8478191136882577348" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_CreatedNode" flags="ng" index="uqdCJ" />
       <concept id="8478191136882577194" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Select" flags="in" index="uqdF1" />
+      <concept id="1177335944525" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_SubstituteString" flags="in" index="uGdhv" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
       </concept>
@@ -137,10 +143,22 @@
         <child id="1136930944870" name="item" index="2QnnpI" />
       </concept>
       <concept id="8998492695583109601" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_CanSubstitute" flags="ig" index="16Na2f" />
+      <concept id="8998492695583125082" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_MatchingText" flags="ng" index="16NfWO">
+        <child id="8998492695583129244" name="query" index="16NeZM" />
+      </concept>
+      <concept id="8998492695583129971" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_DescriptionText" flags="ng" index="16NL0t">
+        <child id="8998492695583129972" name="query" index="16NL0q" />
+      </concept>
       <concept id="8998492695583129991" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_CanSubstitute" flags="ng" index="16NL3D">
         <child id="8998492695583129992" name="query" index="16NL3A" />
       </concept>
       <concept id="1154465273778" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_ParentNode" flags="nn" index="3bvxqY" />
+      <concept id="1896914160037421068" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_WrapSubstituteMenu" flags="ng" index="3c8P5G">
+        <child id="1896914160037421069" name="menuReference" index="3c8P5H" />
+        <child id="1896914160037423677" name="handler" index="3c8PHt" />
+      </concept>
+      <concept id="1896914160037423680" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_WrapperHandler" flags="ig" index="3c8PGw" />
+      <concept id="1896914160037437306" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_TransformationMenu_CreatedNode" flags="ng" index="3c8USq" />
       <concept id="1838685759388685703" name="jetbrains.mps.lang.editor.structure.TransformationFeature_DescriptionText" flags="ng" index="3cqGtN">
         <child id="1838685759388685704" name="query" index="3cqGtW" />
       </concept>
@@ -218,6 +236,12 @@
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
       <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
+      </concept>
+      <concept id="6684862045052272180" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_NodeToWrap" flags="ng" index="3N4pyC" />
+      <concept id="6684862045052059649" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_WrapperHandler" flags="ig" index="3N5aqt" />
+      <concept id="6684862045052059291" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Wrapper" flags="ng" index="3N5dw7">
+        <child id="6089045305655104958" name="reference" index="2klrvf" />
+        <child id="6684862045053873740" name="handler" index="3Na0zg" />
       </concept>
       <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
         <child id="1948540814633499358" name="editorContext" index="lBI5i" />
@@ -312,6 +336,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="1225271546410" name="jetbrains.mps.baseLanguage.structure.TrimOperation" flags="nn" index="17S1cR" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -392,6 +417,11 @@
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="1163670490218" name="jetbrains.mps.baseLanguage.structure.SwitchStatement" flags="nn" index="3KaCP$">
         <child id="1163670592366" name="defaultBlock" index="3Kb1Dw" />
         <child id="1163670766145" name="expression" index="3KbGdf" />
@@ -418,6 +448,29 @@
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
     </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+        <child id="1595412875168045827" name="initValue" index="28nt2d" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709752110" name="jetbrains.mps.lang.quotation.structure.NodeBuilderExpression" flags="nn" index="36biLy">
+        <child id="8182547171709752112" name="expression" index="36biLW" />
+      </concept>
+    </language>
+    <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
+      <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
         <child id="4705942098322609813" name="member" index="21noJM" />
@@ -427,6 +480,9 @@
       </concept>
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
+      </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
@@ -445,16 +501,25 @@
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
+      <concept id="1145573345940" name="jetbrains.mps.lang.smodel.structure.Node_GetAllSiblingsOperation" flags="nn" index="2TvwIu" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
       <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -21279,23 +21344,21 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="5xnAHgZa2GI">
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
-    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
-      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
-        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
-      </node>
-      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
-      </node>
-      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+  <node concept="24kQdi" id="5xnAHgZZgy7">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="3EZMnI" id="5xnAHgZZg_B" role="2wV5jI">
+      <node concept="l2Vlx" id="5xnAHgZZg_C" role="2iSdaV" />
+      <node concept="3F0ifn" id="5xnAHgZZgBa" role="3EZMnx">
+        <property role="3F0ifm" value="await" />
+        <ref role="1ERwB7" node="5xnAHh0emj_" resolve="RemoveAwait" />
+        <node concept="2SqB2G" id="5xnAHh0uXTF" role="2SqHTX">
+          <property role="TrG5h" value="operator" />
         </node>
       </node>
-      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+      <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
+      </node>
     </node>
   </node>
   <node concept="1h_SRR" id="5xnAHh0emj_">
@@ -21337,22 +21400,570 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="5xnAHgZZgy7">
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
-    <node concept="3EZMnI" id="5xnAHgZZg_B" role="2wV5jI">
-      <node concept="l2Vlx" id="5xnAHgZZg_C" role="2iSdaV" />
-      <node concept="3F0ifn" id="5xnAHgZZgBa" role="3EZMnx">
-        <property role="3F0ifm" value="await" />
-        <ref role="1ERwB7" node="5xnAHh0emj_" resolve="RemoveAwait" />
-        <node concept="2SqB2G" id="5xnAHh0uXTF" role="2SqHTX">
-          <property role="TrG5h" value="operator" />
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="PMmxH" id="5xnAHgZa2La" role="3EZMnx">
+        <ref role="PMmxG" to="tpco:2wZex4PafBj" resolve="alias" />
+      </node>
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="variable" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7HmXimPhQcI">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="1XX52x" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="3F0A7n" id="7HmXimPhQcK" role="2wV5jI">
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+    </node>
+  </node>
+  <node concept="3ICUPy" id="7HmXimR0WHi">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="1Qtc8_" id="7HmXimR0WHl" role="IW6Ez">
+      <node concept="3cWJ9i" id="7HmXimR0WHs" role="1Qtc8$">
+        <node concept="CtIbL" id="7HmXimR0WHu" role="CtIbM">
+          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
+        </node>
+      </node>
+      <node concept="IWgqT" id="7HmXimR0WHX" role="1Qtc8A">
+        <node concept="1hCUdq" id="7HmXimR0WHY" role="1hCUd6">
+          <node concept="3clFbS" id="7HmXimR0WHZ" role="2VODD2">
+            <node concept="3clFbF" id="7HmXimR0WZw" role="3cqZAp">
+              <node concept="Xl_RD" id="7HmXimR0WZv" role="3clFbG">
+                <property role="Xl_RC" value="async" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="7HmXimR0WI0" role="IWgqQ">
+          <node concept="3clFbS" id="7HmXimR0WI1" role="2VODD2">
+            <node concept="3clFbF" id="7HmXimR7Jjv" role="3cqZAp">
+              <node concept="37vLTI" id="7HmXimR7MPB" role="3clFbG">
+                <node concept="3clFbT" id="7HmXimR7MQ3" role="37vLTx">
+                  <property role="3clFbU" value="true" />
+                </node>
+                <node concept="2OqwBi" id="7HmXimR7Jvf" role="37vLTJ">
+                  <node concept="7Obwk" id="7HmXimR7Jju" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7HmXimR7JYd" role="2OqNvi">
+                    <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="7HmXimR0X0N" role="2jiSrf">
+          <node concept="3clFbS" id="7HmXimR0X0O" role="2VODD2">
+            <node concept="3clFbF" id="7HmXimR0XgQ" role="3cqZAp">
+              <node concept="3fqX7Q" id="7HmXimR0Yel" role="3clFbG">
+                <node concept="2OqwBi" id="7HmXimR0Yen" role="3fr31v">
+                  <node concept="7Obwk" id="7HmXimR0Yeo" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="7HmXimR0Yep" role="2OqNvi">
+                    <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqGtN" id="7HmXimR10ir" role="2jZA2a">
+          <node concept="3cqJkl" id="7HmXimR10is" role="3cqGtW">
+            <node concept="3clFbS" id="7HmXimR10it" role="2VODD2">
+              <node concept="3clFbF" id="7HmXimR10kR" role="3cqZAp">
+                <node concept="Xl_RD" id="7HmXimR10kQ" role="3clFbG">
+                  <property role="Xl_RC" value="add async modifier" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
+    <node concept="22hDWg" id="7HmXimR11wF" role="22hAXT">
+      <property role="TrG5h" value="AddAsync" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7HmXimPhNct">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="1XX52x" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="3EZMnI" id="7HmXimPhNcv" role="2wV5jI">
+      <node concept="l2Vlx" id="7HmXimPhNcy" role="2iSdaV" />
+      <node concept="3F0ifn" id="7HmXimQbzWY" role="3EZMnx">
+        <property role="3F0ifm" value="async" />
+        <ref role="1ERwB7" node="7HmXimQhemy" resolve="RemoveAsync" />
+        <node concept="pkWqt" id="7HmXimQbzZ4" role="pqm2j">
+          <node concept="3clFbS" id="7HmXimQbzZ5" role="2VODD2">
+            <node concept="3clFbF" id="7HmXimQb_Ls" role="3cqZAp">
+              <node concept="2OqwBi" id="7HmXimQbAcB" role="3clFbG">
+                <node concept="pncrf" id="7HmXimQb_Lr" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7HmXimQbAI6" role="2OqNvi">
+                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2SqB2G" id="7HmXimQhgZA" role="2SqHTX">
+          <property role="TrG5h" value="async" />
+        </node>
+      </node>
+      <node concept="3F0ifn" id="1Y9XkgbOn6X" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="pkWqt" id="1Y9XkgbOn73" role="pqm2j">
+          <node concept="3clFbS" id="1Y9XkgbOn74" role="2VODD2">
+            <node concept="3clFbF" id="1Y9XkgbUV0e" role="3cqZAp">
+              <node concept="2OqwBi" id="1Y9XkgbUVp_" role="3clFbG">
+                <node concept="2OqwBi" id="1Y9XkgdMQFq" role="2Oq$k0">
+                  <node concept="pncrf" id="1Y9XkgbUV0d" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="1Y9XkgdMRto" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:7HmXimPhNc5" resolve="signature" />
+                  </node>
+                </node>
+                <node concept="2qgKlT" id="1Y9XkgbUVNf" role="2OqNvi">
+                  <ref role="37wK5l" to="kvwr:iSyfcw7Tst" resolve="needsParentheses" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="11LMrY" id="1Y9XkgbOLx4" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="A1WHu" id="1Y9XkgdUI25" role="3vIgyS">
+          <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="7HmXimPhQ7t" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:7HmXimPhNc5" resolve="signature" />
+        <node concept="3F0ifn" id="iSyfcuKXxG" role="2ruayu" />
+      </node>
+      <node concept="3F0ifn" id="1Y9XkgbOLuR" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="1Y9XkgbOLx1" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="pkWqt" id="1Y9XkgbOLyZ" role="pqm2j">
+          <node concept="3clFbS" id="1Y9XkgbOLz0" role="2VODD2">
+            <node concept="3clFbF" id="1Y9XkgbOL_Z" role="3cqZAp">
+              <node concept="22lmx$" id="iSyfcuOlN3" role="3clFbG">
+                <node concept="2OqwBi" id="1Y9XkgbOLXp" role="3uHU7w">
+                  <node concept="2OqwBi" id="1Y9XkgdQGuM" role="2Oq$k0">
+                    <node concept="pncrf" id="1Y9XkgbOL_Y" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="1Y9XkgdQHtO" role="2OqNvi">
+                      <ref role="3Tt5mk" to="80bi:7HmXimPhNc5" resolve="signature" />
+                    </node>
+                  </node>
+                  <node concept="2qgKlT" id="1Y9XkgbUURS" role="2OqNvi">
+                    <ref role="37wK5l" to="kvwr:iSyfcw7Tst" resolve="needsParentheses" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iSyfcuOm7E" role="3uHU7B">
+                  <node concept="2OqwBi" id="iSyfcuOm7F" role="2Oq$k0">
+                    <node concept="pncrf" id="iSyfcuOm7G" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="iSyfcuOm7H" role="2OqNvi">
+                      <ref role="3Tt5mk" to="80bi:7HmXimPhNc5" resolve="signature" />
+                    </node>
+                  </node>
+                  <node concept="3w_OXm" id="iSyfcuOm7I" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="7HmXimPhQbj" role="3EZMnx">
+        <property role="3F0ifm" value="=&gt;" />
+      </node>
+      <node concept="3F1sOY" id="7HmXimPhQ9n" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:7HmXimPhNcb" resolve="body" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="7HmXimPhQt3">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="1XX52x" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="3F2HdR" id="7HmXimPhQtc" role="2wV5jI">
+      <property role="2czwfO" value="," />
+      <ref role="1NtTu8" to="80bi:7HmXimPhQc_" resolve="parameters" />
+      <node concept="l2Vlx" id="7HmXimPhQte" role="2czzBx" />
+      <node concept="3F0ifn" id="7HmXimPwdwN" role="2czzBI">
+        <node concept="VPxyj" id="iSyfcvyupz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="iSyfcuX8Tw">
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <ref role="aqKnT" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+    <node concept="3N5dw7" id="iSyfcuX9_3" role="3ft7WO">
+      <node concept="3N5aqt" id="iSyfcuX9_4" role="3Na0zg">
+        <node concept="3clFbS" id="iSyfcuX9_5" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcuXabA" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcuX9Zk" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcuX9Zm" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                <node concept="2pIpSj" id="iSyfcuXa4o" role="2pJxcM">
+                  <ref role="2pIpSl" to="80bi:7yZ_CF2xDX3" resolve="type" />
+                  <node concept="2pJPED" id="iSyfcuXa5G" role="28nt2d">
+                    <ref role="2pJxaS" to="80bi:5VT83U$LMPZ" resolve="Type" />
+                    <node concept="2pIpSj" id="iSyfcuXa6z" role="2pJxcM">
+                      <ref role="2pIpSl" to="80bi:5VT83U$LPp0" resolve="nonArrayType" />
+                      <node concept="36biLy" id="iSyfcuXa70" role="28nt2d">
+                        <node concept="3N4pyC" id="iSyfcuXa8q" role="36biLW" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2kknPJ" id="iSyfcuX9_n" role="2klrvf">
+        <ref role="2ZyFGn" to="80bi:5_5a0KJX$kh" resolve="INonArrayType" />
+      </node>
+    </node>
+    <node concept="22hDWj" id="iSyfcuX8Ut" role="22hAXT" />
+  </node>
+  <node concept="22mcaB" id="7HmXimPUxXM">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="22hDWj" id="7HmXimPUxXN" role="22hAXT" />
+    <node concept="3eGOop" id="iSyfcvZjYg" role="3ft7WO">
+      <node concept="ucgPf" id="iSyfcvZjYi" role="3aKz83">
+        <node concept="3clFbS" id="iSyfcvZjYk" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcvZksF" role="3cqZAp">
+            <node concept="2ShNRf" id="iSyfcvZksD" role="3clFbG">
+              <node concept="2fJWfE" id="iSyfcvZkBU" role="2ShVmc">
+                <node concept="3Tqbb2" id="iSyfcvZkBW" role="3zrR0E">
+                  <ref role="ehGHo" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="upBMk" id="iSyfcvZkEE" role="upBLP">
+        <node concept="uqdF1" id="iSyfcvZkEF" role="upBLF">
+          <node concept="3clFbS" id="iSyfcvZkEG" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvZkHB" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcvZkUb" role="3clFbG">
+                <node concept="uqdCJ" id="iSyfcvZkHA" role="2Oq$k0" />
+                <node concept="1OKiuA" id="iSyfcvZlsD" role="2OqNvi">
+                  <node concept="1Q80Hx" id="iSyfcvZltL" role="lBI5i" />
+                  <node concept="2B6iha" id="iSyfcvZlBJ" role="lGT1i">
+                    <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3VyMlK" id="iSyfcvZk1l" role="3ft7WO" />
+    <node concept="3eGOop" id="7HmXimPUxXU" role="3ft7WO">
+      <node concept="ucgPf" id="7HmXimPUxXW" role="3aKz83">
+        <node concept="3clFbS" id="7HmXimPUxXY" role="2VODD2">
+          <node concept="3cpWs8" id="7HmXimPXrsj" role="3cqZAp">
+            <node concept="3cpWsn" id="7HmXimPXrsm" role="3cpWs9">
+              <property role="TrG5h" value="lambda" />
+              <node concept="3Tqbb2" id="7HmXimPXrsi" role="1tU5fm">
+                <ref role="ehGHo" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+              </node>
+              <node concept="2ShNRf" id="iSyfcvZk7y" role="33vP2m">
+                <node concept="2fJWfE" id="iSyfcvZkkv" role="2ShVmc">
+                  <node concept="3Tqbb2" id="iSyfcvZkkx" role="3zrR0E">
+                    <ref role="ehGHo" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7HmXimQbrPx" role="3cqZAp">
+            <node concept="37vLTI" id="7HmXimQbyP9" role="3clFbG">
+              <node concept="3clFbT" id="7HmXimQbyRZ" role="37vLTx">
+                <property role="3clFbU" value="true" />
+              </node>
+              <node concept="2OqwBi" id="7HmXimQbs3P" role="37vLTJ">
+                <node concept="37vLTw" id="7HmXimQbrPv" role="2Oq$k0">
+                  <ref role="3cqZAo" node="7HmXimPXrsm" resolve="lambda" />
+                </node>
+                <node concept="3TrcHB" id="7HmXimQbsyB" role="2OqNvi">
+                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="7HmXimPXtZ5" role="3cqZAp">
+            <node concept="37vLTw" id="7HmXimPXu6V" role="3cqZAk">
+              <ref role="3cqZAo" node="7HmXimPXrsm" resolve="lambda" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NfWO" id="7HmXimPUy18" role="upBLP">
+        <node concept="uGdhv" id="1Y9Xkge0yYw" role="16NeZM">
+          <node concept="3clFbS" id="1Y9Xkge0yYy" role="2VODD2">
+            <node concept="3clFbF" id="1Y9Xkge0zif" role="3cqZAp">
+              <node concept="3cpWs3" id="1Y9Xkge0$$H" role="3clFbG">
+                <node concept="2OqwBi" id="1Y9Xkge0_A3" role="3uHU7w">
+                  <node concept="35c_gC" id="1Y9Xkge0$_s" role="2Oq$k0">
+                    <ref role="35c_gD" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                  </node>
+                  <node concept="3n3YKJ" id="1Y9Xkge0B7S" role="2OqNvi" />
+                </node>
+                <node concept="Xl_RD" id="1Y9Xkge0zie" role="3uHU7B">
+                  <property role="Xl_RC" value="async " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NL0t" id="7HmXimPUy35" role="upBLP">
+        <node concept="uGdhv" id="1bWPTWUbCuM" role="16NL0q">
+          <node concept="3clFbS" id="1bWPTWUbCuO" role="2VODD2">
+            <node concept="3clFbF" id="1bWPTWUbCJx" role="3cqZAp">
+              <node concept="3cpWs3" id="1bWPTWUbEh8" role="3clFbG">
+                <node concept="2OqwBi" id="1bWPTWUbFl4" role="3uHU7w">
+                  <node concept="35c_gC" id="1bWPTWUbEhR" role="2Oq$k0">
+                    <ref role="35c_gD" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                  </node>
+                  <node concept="liA8E" id="1bWPTWUbGOU" role="2OqNvi">
+                    <ref role="37wK5l" to="c17a:~SAbstractConcept.getShortDescription()" resolve="getShortDescription" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="1bWPTWUbCJw" role="3uHU7B">
+                  <property role="Xl_RC" value="async " />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="upBMk" id="1bWPTWU8zR5" role="upBLP">
+        <node concept="uqdF1" id="1bWPTWU8zR7" role="upBLF">
+          <node concept="3clFbS" id="1bWPTWU8zR9" role="2VODD2">
+            <node concept="3clFbF" id="1bWPTWU8zUd" role="3cqZAp">
+              <node concept="2OqwBi" id="1bWPTWU8$6L" role="3clFbG">
+                <node concept="uqdCJ" id="1bWPTWU8zUc" role="2Oq$k0" />
+                <node concept="1OKiuA" id="1bWPTWU8Ai$" role="2OqNvi">
+                  <node concept="1Q80Hx" id="1bWPTWU8Akr" role="lBI5i" />
+                  <node concept="2B6iha" id="1bWPTWU8Amz" role="lGT1i">
+                    <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="7HmXimQhemy">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="RemoveAsync" />
+    <ref role="1h_SK9" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="1hA7zw" id="7HmXimQhemz" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove async modifier" />
+      <node concept="1hAIg9" id="7HmXimQhem$" role="1hA7z_">
+        <node concept="3clFbS" id="7HmXimQhem_" role="2VODD2">
+          <node concept="3clFbJ" id="7HmXimQhhSC" role="3cqZAp">
+            <node concept="3clFbS" id="7HmXimQhhT0" role="3clFbx">
+              <node concept="3cpWs6" id="7HmXimQhhWx" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="7HmXimQhfN5" role="3clFbw">
+              <node concept="0IXxy" id="7HmXimQhepk" role="2Oq$k0" />
+              <node concept="2xy62i" id="7HmXimQhgjP" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQhgk$" role="2xHN3q" />
+                <node concept="2TlHUq" id="7HmXimQhhgS" role="3a7HXU">
+                  <ref role="2TlMyj" node="7HmXimQhgZA" resolve="async" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7HmXimQhhZQ" role="3cqZAp">
+            <node concept="37vLTI" id="7HmXimQhlyi" role="3clFbG">
+              <node concept="3clFbT" id="7HmXimQhlyK" role="37vLTx" />
+              <node concept="2OqwBi" id="7HmXimQhibL" role="37vLTJ">
+                <node concept="0IXxy" id="7HmXimQhhZP" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7HmXimQhiES" role="2OqNvi">
+                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7HmXimQpfUQ" role="3cqZAp">
+            <node concept="2OqwBi" id="7HmXimQpg75" role="3clFbG">
+              <node concept="0IXxy" id="7HmXimQpfUP" role="2Oq$k0" />
+              <node concept="1OKiuA" id="7HmXimQpgC3" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQpgCH" role="lBI5i" />
+                <node concept="2B6iha" id="7HmXimQpgLt" role="lGT1i">
+                  <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="iSyfcuUaO9">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="22hDWj" id="iSyfcuUaP6" role="22hAXT" />
+    <node concept="3eGOop" id="iSyfcvd_1$" role="3ft7WO">
+      <node concept="16NL3D" id="iSyfcvd_6u" role="upBLP">
+        <node concept="16Na2f" id="iSyfcvd_6v" role="16NL3A">
+          <node concept="3clFbS" id="iSyfcvd_6w" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAR_" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcvdDfT" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdBzG" role="2Oq$k0" />
+                <node concept="liA8E" id="iSyfcvdEfR" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                  <node concept="10M0yZ" id="iSyfcvdBgr" role="37wK5m">
+                    <ref role="3cqZAo" node="5cm0BoTKIaF" resolve="identifier" />
+                    <ref role="1PxDUh" node="6H78krhSzlS" resolve="SubstitutionUtils" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NfWO" id="iSyfcvdEGh" role="upBLP">
+        <node concept="uGdhv" id="iSyfcvd_WF" role="16NeZM">
+          <node concept="3clFbS" id="iSyfcvd_WH" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAdP" role="3cqZAp">
+              <node concept="3K4zz7" id="iSyfcvdAdQ" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdAdR" role="3K4E3e" />
+                <node concept="Xl_RD" id="iSyfcvdAdS" role="3K4GZi">
+                  <property role="Xl_RC" value="&lt;name&gt;" />
+                </node>
+                <node concept="2OqwBi" id="iSyfcvdAdT" role="3K4Cdx">
+                  <node concept="ub8z3" id="iSyfcvdAdU" role="2Oq$k0" />
+                  <node concept="17RvpY" id="iSyfcvdAdV" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NL0t" id="iSyfcvd_VB" role="upBLP">
+        <node concept="2h3Zct" id="iSyfcvdERW" role="16NL0q">
+          <property role="2h4Kg1" value="add implicit parameter" />
+        </node>
+      </node>
+      <node concept="ucgPf" id="iSyfcvd_1_" role="3aKz83">
+        <node concept="3clFbS" id="iSyfcvd_1A" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcvdAwU" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcvdA$B" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcvdA$D" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                <node concept="2pJxcG" id="iSyfcvdAJg" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="ub8z3" id="iSyfcvdAN7" role="28ntcv" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="1XmGakPdCcn">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="1Qtc8_" id="1XmGakPdCTK" role="IW6Ez">
+      <node concept="aenpk" id="1XmGakPyjZS" role="1Qtc8A">
+        <node concept="mvV$s" id="1XmGakPsIwl" role="aenpr">
+          <node concept="A1WHu" id="1XmGakPsIyw" role="A14EM">
+            <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
+          </node>
+          <node concept="mvVNg" id="1XmGakPsIyy" role="mvV$0">
+            <node concept="3clFbS" id="1XmGakPsIyz" role="2VODD2">
+              <node concept="3clFbF" id="1XmGakPsIBg" role="3cqZAp">
+                <node concept="2OqwBi" id="1XmGakPsIQk" role="3clFbG">
+                  <node concept="7Obwk" id="1XmGakPsIBf" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="1XmGakPsJja" role="2OqNvi">
+                    <node concept="1xMEDy" id="1XmGakPsJjc" role="1xVPHs">
+                      <node concept="chp4Y" id="1XmGakPsJlI" role="ri$Ld">
+                        <ref role="cht4Q" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="1XmGakPyk0K" role="aenpu">
+          <node concept="3clFbS" id="1XmGakPyk0L" role="2VODD2">
+            <node concept="3clFbF" id="1XmGakPykgT" role="3cqZAp">
+              <node concept="2OqwBi" id="1XmGakPyrkp" role="3clFbG">
+                <node concept="2OqwBi" id="1XmGakPykFi" role="2Oq$k0">
+                  <node concept="7Obwk" id="1XmGakPykgS" role="2Oq$k0" />
+                  <node concept="2TvwIu" id="1XmGakPyl8H" role="2OqNvi" />
+                </node>
+                <node concept="1v1jN8" id="1XmGakPyu_9" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3c8P5G" id="iSyfcuX8bg" role="1Qtc8A">
+        <node concept="2kknPJ" id="iSyfcuX8fF" role="3c8P5H">
+          <ref role="2ZyFGn" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+        </node>
+        <node concept="3c8PGw" id="iSyfcuX8bj" role="3c8PHt">
+          <node concept="3clFbS" id="iSyfcuX8bl" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcuZZkQ" role="3cqZAp">
+              <node concept="37vLTI" id="iSyfcv02Kz" role="3clFbG">
+                <node concept="2OqwBi" id="iSyfcv02W$" role="37vLTx">
+                  <node concept="7Obwk" id="iSyfcv02Li" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcv03bD" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iSyfcuZZwd" role="37vLTJ">
+                  <node concept="3c8USq" id="iSyfcuZZkP" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcuZZJ9" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="iSyfcv03n3" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcv03ww" role="3clFbG">
+                <node concept="7Obwk" id="iSyfcw2bX7" role="2Oq$k0" />
+                <node concept="1P9Npp" id="iSyfcv03LP" role="2OqNvi">
+                  <node concept="3c8USq" id="iSyfcv03MP" role="1P9ThW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="1XmGakPdCTO" role="1Qtc8$">
+        <node concept="CtIbL" id="1XmGakPdCTQ" role="CtIbM">
+          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
+        </node>
+      </node>
+    </node>
+    <node concept="22hDWj" id="1XmGakPmOWV" role="22hAXT" />
   </node>
 </model>
 

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -200,6 +200,9 @@
     <node concept="PrWs8" id="1FYNzU$nHmq" role="PzmwI">
       <ref role="PrY4T" node="1FYNzU$nG$p" resolve="IVariableInitializer" />
     </node>
+    <node concept="PrWs8" id="7HmXimPhQcx" role="PzmwI">
+      <ref role="PrY4T" node="7HmXimPhNcs" resolve="IAnonymousFunctionBody" />
+    </node>
   </node>
   <node concept="1TIwiD" id="2HIntxMQ_98">
     <property role="EcuMT" value="3129541975290303048" />
@@ -1520,10 +1523,31 @@
         </node>
         <node concept="1PaTwC" id="2pqoNIAec8p" role="1PaQFQ">
           <node concept="3oM_SD" id="2pqoNIAec8o" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: block" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQci" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQcj" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQck" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQcl" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQcm" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPhQcn" role="1PaTwD">
+            <property role="3oM_SC" value="block" />
           </node>
         </node>
       </node>
+    </node>
+    <node concept="PrWs8" id="7HmXimPhQcv" role="PzmwI">
+      <ref role="PrY4T" node="7HmXimPhNcs" resolve="IAnonymousFunctionBody" />
     </node>
   </node>
   <node concept="1TIwiD" id="6vAOG1ABnEK">
@@ -2423,7 +2447,7 @@
     <property role="EcuMT" value="7232527154588476195" />
     <property role="TrG5h" value="FormalParameter" />
     <property role="3GE5qa" value="Class / Struct.Parameters" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="iSyfcvrmN2" resolve="Parameter" />
     <node concept="1TJgyj" id="6hv6i2_Bec$" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588476196" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -2442,12 +2466,6 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="type" />
       <ref role="20lvS9" node="5VT83U$LMPZ" resolve="Type" />
-    </node>
-    <node concept="PrWs8" id="6hv6i2_BecG" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-    <node concept="PrWs8" id="5dYLrgGkU0F" role="PzmwI">
-      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
     </node>
   </node>
   <node concept="1TIwiD" id="6hv6i2_B48E">
@@ -4868,7 +4886,25 @@
         </node>
         <node concept="1PaTwC" id="1dPlh42Z6hs" role="1PaQFQ">
           <node concept="3oM_SD" id="1dPlh42Z6hr" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: expression-statement" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN7Z" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN80" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN81" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN82" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN83" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbN84" role="1PaTwD">
+            <property role="3oM_SC" value="expression-statement" />
           </node>
         </node>
       </node>
@@ -17014,6 +17050,70 @@
       <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
     </node>
   </node>
+  <node concept="1TIwiD" id="5xnAHgZZgnF">
+    <property role="EcuMT" value="6365726834708776427" />
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="AwaitExpression" />
+    <property role="34LRSv" value="await" />
+    <property role="R4oN_" value="await expression" />
+    <ref role="1TJDcQ" node="5VT83U$LFpw" resolve="UnaryExpression" />
+    <node concept="PrWs8" id="5xnAHgZZgsT" role="PzmwI">
+      <ref role="PrY4T" node="1FYNzU$sHZz" resolve="IStatementExpression" />
+    </node>
+    <node concept="1TJgyj" id="5xnAHgZZgtR" role="1TKVEi">
+      <property role="IQ2ns" value="6365726834708776823" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="task" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5VT83U$LFpw" resolve="UnaryExpression" />
+    </node>
+    <node concept="3H0Qfr" id="5xnAHgZZgG4" role="lGtFl">
+      <node concept="1Pa9Pv" id="5xnAHgZZgG5" role="3H0Qfi">
+        <node concept="1PaTwC" id="5xnAHgZZgG6" role="1PaQFQ">
+          <node concept="3oM_SD" id="1XmGakPSWlj" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWnL" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWnU" role="1PaTwD">
+            <property role="3oM_SC" value="await" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWoy" role="1PaTwD">
+            <property role="3oM_SC" value="expression," />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWpb" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWtP" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="5xnAHgZZgLg" role="1PaTwD">
+            <property role="3oM_SC" value="§7.7.7" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWxX" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWy$" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakPSWyI" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PlHQZ" id="7HmXimRLOdX">
+    <property role="TrG5h" value="ICanBeAsync" />
+    <property role="EcuMT" value="8887560457008137085" />
+    <property role="3GE5qa" value="Modifiers" />
+    <node concept="1TJgyi" id="5xnAHh08MDV" role="1TKVEl">
+      <property role="IQ2nx" value="6365726834711276155" />
+      <property role="TrG5h" value="isAsync" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+  </node>
   <node concept="1TIwiD" id="5xnAHgZa2vT">
     <property role="EcuMT" value="6365726834694825977" />
     <property role="TrG5h" value="ImplicitLocalVariableDeclaration" />
@@ -17257,68 +17357,335 @@
       <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
     </node>
   </node>
-  <node concept="1TIwiD" id="5xnAHgZZgnF">
-    <property role="EcuMT" value="6365726834708776427" />
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <property role="TrG5h" value="AwaitExpression" />
-    <property role="34LRSv" value="await" />
-    <property role="R4oN_" value="await expression" />
-    <ref role="1TJDcQ" node="5VT83U$LFpw" resolve="UnaryExpression" />
-    <node concept="PrWs8" id="5xnAHgZZgsT" role="PzmwI">
-      <ref role="PrY4T" node="1FYNzU$sHZz" resolve="IStatementExpression" />
-    </node>
-    <node concept="1TJgyj" id="5xnAHgZZgtR" role="1TKVEi">
-      <property role="IQ2ns" value="6365726834708776823" />
+  <node concept="1TIwiD" id="7HmXimPhQc$">
+    <property role="EcuMT" value="8887560456966202148" />
+    <property role="TrG5h" value="LambdaParameterList" />
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <node concept="1TJgyj" id="7HmXimPhQc_" role="1TKVEi">
+      <property role="IQ2ns" value="8887560456966202149" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="task" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="5VT83U$LFpw" resolve="UnaryExpression" />
+      <property role="20kJfa" value="parameters" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="iSyfcvrmN2" resolve="Parameter" />
     </node>
-    <node concept="3H0Qfr" id="5xnAHgZZgG4" role="lGtFl">
-      <node concept="1Pa9Pv" id="5xnAHgZZgG5" role="3H0Qfi">
-        <node concept="1PaTwC" id="5xnAHgZZgG6" role="1PaQFQ">
-          <node concept="3oM_SD" id="1XmGakPSWlj" role="1PaTwD">
+    <node concept="3H0Qfr" id="1XmGakOQtfp" role="lGtFl">
+      <node concept="1Pa9Pv" id="1XmGakOQtfq" role="3H0Qfi">
+        <node concept="1PaTwC" id="1XmGakOQtfr" role="1PaQFQ">
+          <node concept="3oM_SD" id="1XmGakOQtfX" role="1PaTwD">
             <property role="3oM_SC" value="Represents" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWnL" role="1PaTwD">
+          <node concept="3oM_SD" id="iSyfcvq$7C" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$7Q" role="1PaTwD">
+            <property role="3oM_SC" value="hybrid" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$dB" role="1PaTwD">
+            <property role="3oM_SC" value="explicit" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$eN" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$f4" role="1PaTwD">
+            <property role="3oM_SC" value="implicit" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$fO" role="1PaTwD">
+            <property role="3oM_SC" value="parameter" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$g_" role="1PaTwD">
+            <property role="3oM_SC" value="list" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$gT" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$he" role="1PaTwD">
+            <property role="3oM_SC" value="lambda" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$i2" role="1PaTwD">
+            <property role="3oM_SC" value="functions." />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7RbZ" role="1PaTwD">
+            <property role="3oM_SC" value="Mixing" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$Vm" role="1PaTwD">
             <property role="3oM_SC" value="the" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWnU" role="1PaTwD">
-            <property role="3oM_SC" value="await" />
+          <node concept="3oM_SD" id="iSyfcw7RmG" role="1PaTwD">
+            <property role="3oM_SC" value="two" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWoy" role="1PaTwD">
-            <property role="3oM_SC" value="expression," />
+          <node concept="3oM_SD" id="iSyfcw7Rng" role="1PaTwD">
+            <property role="3oM_SC" value="types" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWpb" role="1PaTwD">
+          <node concept="3oM_SD" id="iSyfcw7Rdr" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7RdW" role="1PaTwD">
+            <property role="3oM_SC" value="allowed" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7ReW" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7Rfv" role="1PaTwD">
+            <property role="3oM_SC" value="convenience," />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7Rjl" role="1PaTwD">
+            <property role="3oM_SC" value="but" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$EE" role="1PaTwD">
+            <property role="3oM_SC" value="marked" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$FC" role="1PaTwD">
+            <property role="3oM_SC" value="as" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$G9" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$H9" role="1PaTwD">
+            <property role="3oM_SC" value="error" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq$HG" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QHt" role="1PaTwD">
+            <property role="3oM_SC" value="intentions" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QI2" role="1PaTwD">
+            <property role="3oM_SC" value="are" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QJ6" role="1PaTwD">
+            <property role="3oM_SC" value="provided" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QKb" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QKN" role="1PaTwD">
+            <property role="3oM_SC" value="convert" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QRp" role="1PaTwD">
+            <property role="3oM_SC" value="them" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7QSZ" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7Rqh" role="1PaTwD">
+            <property role="3oM_SC" value="one" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7RsG" role="1PaTwD">
+            <property role="3oM_SC" value="type." />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOQtfZ" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+        </node>
+        <node concept="1PaTwC" id="iSyfcw7R4u" role="1PaQFQ">
+          <node concept="3oM_SD" id="iSyfcw7R4t" role="1PaTwD">
+            <property role="3oM_SC" value="" />
+          </node>
+        </node>
+        <node concept="1PaTwC" id="iSyfcw7R75" role="1PaQFQ">
+          <node concept="3oM_SD" id="iSyfcw7R74" role="1PaTwD">
+            <property role="3oM_SC" value="Corresponds" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcw7R2M" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq_bm" role="1PaTwD">
+            <property role="3oM_SC" value="both" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOQtgb" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOQtgf" role="1PaTwD">
+            <property role="3oM_SC" value="explicit-" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq_cY" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcvq_dF" role="1PaTwD">
+            <property role="3oM_SC" value="implicit-anonymous-function-parameter-list" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOQtgk" role="1PaTwD">
             <property role="3oM_SC" value="defined" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWtP" role="1PaTwD">
+          <node concept="3oM_SD" id="1XmGakOQtgq" role="1PaTwD">
             <property role="3oM_SC" value="in" />
           </node>
-          <node concept="3oM_SD" id="5xnAHgZZgLg" role="1PaTwD">
-            <property role="3oM_SC" value="§7.7.7" />
+          <node concept="3oM_SD" id="1XmGakOQtgx" role="1PaTwD">
+            <property role="3oM_SC" value="§7.15" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWxX" role="1PaTwD">
+          <node concept="3oM_SD" id="1XmGakOQtgD" role="1PaTwD">
             <property role="3oM_SC" value="of" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWy$" role="1PaTwD">
+          <node concept="3oM_SD" id="iSyfcvHox2" role="1PaTwD">
             <property role="3oM_SC" value="the" />
           </node>
-          <node concept="3oM_SD" id="1XmGakPSWyI" role="1PaTwD">
+          <node concept="3oM_SD" id="1XmGakOQthC" role="1PaTwD">
             <property role="3oM_SC" value="specification." />
           </node>
         </node>
       </node>
     </node>
   </node>
-  <node concept="PlHQZ" id="7HmXimRLOdX">
-    <property role="TrG5h" value="ICanBeAsync" />
-    <property role="EcuMT" value="8887560457008137085" />
-    <property role="3GE5qa" value="Modifiers" />
-    <node concept="1TJgyi" id="5xnAHh08MDV" role="1TKVEl">
-      <property role="IQ2nx" value="6365726834711276155" />
-      <property role="TrG5h" value="isAsync" />
-      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+  <node concept="1TIwiD" id="7HmXimPhQcC">
+    <property role="EcuMT" value="8887560456966202152" />
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="ImplicitParameter" />
+    <ref role="1TJDcQ" node="iSyfcvrmN2" resolve="Parameter" />
+    <node concept="3H0Qfr" id="7HmXimQVbJW" role="lGtFl">
+      <node concept="1Pa9Pv" id="7HmXimQVbJX" role="3H0Qfi">
+        <node concept="1PaTwC" id="7HmXimQVbJY" role="1PaQFQ">
+          <node concept="3oM_SD" id="7HmXimQVbJZ" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbL7" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="1Y9XkgabPX5" role="1PaTwD">
+            <property role="3oM_SC" value="implicitly-typed" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbLf" role="1PaTwD">
+            <property role="3oM_SC" value="parameter" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbLo" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbAQw" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="1bWPTWUbAQL" role="1PaTwD">
+            <property role="3oM_SC" value="lambda" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbLT" role="1PaTwD">
+            <property role="3oM_SC" value="expression." />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbNg" role="1PaTwD">
+            <property role="3oM_SC" value="Corresponds" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbNx" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimQVbNN" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1a_S" role="1PaTwD">
+            <property role="3oM_SC" value="implicit-anonymous-function-parameter" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1aA6" role="1PaTwD">
+            <property role="3oM_SC" value="from" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1aAl" role="1PaTwD">
+            <property role="3oM_SC" value="§7.15" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1aA_" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1aAQ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1aB8" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PlHQZ" id="7HmXimPhNcs">
+    <property role="EcuMT" value="8887560456966189852" />
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="IAnonymousFunctionBody" />
+    <node concept="3H0Qfr" id="7HmXimPLUG8" role="lGtFl">
+      <node concept="1Pa9Pv" id="7HmXimPLUG9" role="3H0Qfi">
+        <node concept="1PaTwC" id="7HmXimPLUGa" role="1PaQFQ">
+          <node concept="3oM_SD" id="7HmXimPLUJc" role="1PaTwD">
+            <property role="3oM_SC" value="Corresponds" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOLY4K" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="1XmGakOLY4U" role="1PaTwD">
+            <property role="3oM_SC" value="anonymous-function-body" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPLUK1" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcwg8eQ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimPLUKY" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7HmXimPhNc2">
+    <property role="EcuMT" value="8887560456966189826" />
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="LambdaExpression" />
+    <property role="34LRSv" value="() =&gt; &lt;body&gt;" />
+    <property role="R4oN_" value="lambda expression" />
+    <ref role="1TJDcQ" node="5VT83U$LgKs" resolve="Expression" />
+    <node concept="1TJgyj" id="7HmXimPhNc5" role="1TKVEi">
+      <property role="IQ2ns" value="8887560456966189829" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="signature" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="7HmXimPhQc$" resolve="LambdaParameterList" />
+    </node>
+    <node concept="1TJgyj" id="7HmXimPhNcb" role="1TKVEi">
+      <property role="IQ2ns" value="8887560456966189835" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="body" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="7HmXimPhNcs" resolve="IAnonymousFunctionBody" />
+    </node>
+    <node concept="3H0Qfr" id="7HmXimR0WBr" role="lGtFl">
+      <node concept="1Pa9Pv" id="7HmXimR0WBs" role="3H0Qfi">
+        <node concept="1PaTwC" id="7HmXimR0WBt" role="1PaQFQ">
+          <node concept="3oM_SD" id="7HmXimR0WBu" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimR4_R9" role="1PaTwD">
+            <property role="3oM_SC" value="lambda" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1az1" role="1PaTwD">
+            <property role="3oM_SC" value="expressions," />
+          </node>
+          <node concept="3oM_SD" id="7HmXimR4_Rr" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimR4_RN" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimR4_Sx" role="1PaTwD">
+            <property role="3oM_SC" value="§7.15" />
+          </node>
+          <node concept="3oM_SD" id="7HmXimR4_SE" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="iSyfcwm2Wz" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="1Y9Xkga1ayA" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="PrWs8" id="7HmXimRCGbw" role="PzmwI">
+      <ref role="PrY4T" node="7HmXimRLOdX" resolve="ICanBeAsync" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="iSyfcvrmN2">
+    <property role="TrG5h" value="Parameter" />
+    <property role="EcuMT" value="340172349652162055" />
+    <property role="R5$K7" value="true" />
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <node concept="PrWs8" id="iSyfcvrmTa" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="PrWs8" id="iSyfcvrmTc" role="PzmwI">
+      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
+    <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -48,6 +49,9 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
@@ -88,6 +92,7 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1173122760281" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorsOperation" flags="nn" index="z$bX8" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
@@ -186,52 +191,6 @@
     <node concept="1YaCAy" id="5QWEwg48iL7" role="1YuTPh">
       <property role="TrG5h" value="declarator" />
       <ref role="1YaFvo" to="80bi:6hv6i2_B48E" resolve="ConstantDeclarator" />
-    </node>
-  </node>
-  <node concept="18kY7G" id="5xnAHgZgi8F">
-    <property role="TrG5h" value="check_ImplicitLocalVariableDeclaration" />
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <node concept="3clFbS" id="5xnAHgZgi8G" role="18ibNy">
-      <node concept="3clFbJ" id="5xnAHgZgibI" role="3cqZAp">
-        <node concept="2OqwBi" id="5xnAHgZgl17" role="3clFbw">
-          <node concept="2OqwBi" id="5xnAHgZgktN" role="2Oq$k0">
-            <node concept="2OqwBi" id="5xnAHgZgio9" role="2Oq$k0">
-              <node concept="1YBJjd" id="5xnAHgZgics" role="2Oq$k0">
-                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
-              </node>
-              <node concept="3TrEf2" id="5xnAHgZgkgk" role="2OqNvi">
-                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
-              </node>
-            </node>
-            <node concept="3TrEf2" id="5xnAHgZgkNk" role="2OqNvi">
-              <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-            </node>
-          </node>
-          <node concept="3w_OXm" id="5xnAHgZgltq" role="2OqNvi" />
-        </node>
-        <node concept="3clFbS" id="5xnAHgZgibK" role="3clFbx">
-          <node concept="2MkqsV" id="5xnAHgZglyy" role="3cqZAp">
-            <node concept="Xl_RD" id="5xnAHgZglzg" role="2MkJ7o">
-              <property role="Xl_RC" value="An implicitly typed declaration must be initialized." />
-            </node>
-            <node concept="2OqwBi" id="5xnAHgZglOj" role="1urrMF">
-              <node concept="1YBJjd" id="5xnAHgZglEg" role="2Oq$k0">
-                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
-              </node>
-              <node concept="3TrEf2" id="5xnAHgZgmrI" role="2OqNvi">
-                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
-              </node>
-            </node>
-            <node concept="AMVWg" id="5xnAHgZgmvK" role="lGtFl">
-              <property role="TrG5h" value="VarMustBeInitialized" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1YaCAy" id="5xnAHgZgi8I" role="1YuTPh">
-      <property role="TrG5h" value="var" />
-      <ref role="1YaFvo" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
     </node>
   </node>
   <node concept="18kY7G" id="5xnAHh09lHo">
@@ -413,6 +372,84 @@
     <node concept="1YaCAy" id="5xnAHh09lHr" role="1YuTPh">
       <property role="TrG5h" value="await" />
       <ref role="1YaFvo" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5xnAHgZgi8F">
+    <property role="TrG5h" value="check_ImplicitLocalVariableDeclaration" />
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <node concept="3clFbS" id="5xnAHgZgi8G" role="18ibNy">
+      <node concept="3clFbJ" id="5xnAHgZgibI" role="3cqZAp">
+        <node concept="2OqwBi" id="5xnAHgZgl17" role="3clFbw">
+          <node concept="2OqwBi" id="5xnAHgZgktN" role="2Oq$k0">
+            <node concept="2OqwBi" id="5xnAHgZgio9" role="2Oq$k0">
+              <node concept="1YBJjd" id="5xnAHgZgics" role="2Oq$k0">
+                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
+              </node>
+              <node concept="3TrEf2" id="5xnAHgZgkgk" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
+              </node>
+            </node>
+            <node concept="3TrEf2" id="5xnAHgZgkNk" role="2OqNvi">
+              <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+            </node>
+          </node>
+          <node concept="3w_OXm" id="5xnAHgZgltq" role="2OqNvi" />
+        </node>
+        <node concept="3clFbS" id="5xnAHgZgibK" role="3clFbx">
+          <node concept="2MkqsV" id="5xnAHgZglyy" role="3cqZAp">
+            <node concept="Xl_RD" id="5xnAHgZglzg" role="2MkJ7o">
+              <property role="Xl_RC" value="An implicitly typed declaration must be initialized." />
+            </node>
+            <node concept="2OqwBi" id="5xnAHgZglOj" role="1urrMF">
+              <node concept="1YBJjd" id="5xnAHgZglEg" role="2Oq$k0">
+                <ref role="1YBMHb" node="5xnAHgZgi8I" resolve="var" />
+              </node>
+              <node concept="3TrEf2" id="5xnAHgZgmrI" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:5xnAHgZdlnx" resolve="variable" />
+              </node>
+            </node>
+            <node concept="AMVWg" id="5xnAHgZgmvK" role="lGtFl">
+              <property role="TrG5h" value="VarMustBeInitialized" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5xnAHgZgi8I" role="1YuTPh">
+      <property role="TrG5h" value="var" />
+      <ref role="1YaFvo" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclaration" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="iSyfcv_hOs">
+    <property role="TrG5h" value="check_LambdaParameterList" />
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <node concept="3clFbS" id="iSyfcv_hOt" role="18ibNy">
+      <node concept="3clFbJ" id="iSyfcv_hTZ" role="3cqZAp">
+        <node concept="3clFbS" id="iSyfcv_hU1" role="3clFbx">
+          <node concept="2MkqsV" id="iSyfcv_j4M" role="3cqZAp">
+            <node concept="Xl_RD" id="iSyfcv_j5v" role="2MkJ7o">
+              <property role="Xl_RC" value="Inconsistent lambda parameter usage; parameter types must be all explicit or all implicit." />
+            </node>
+            <node concept="1YBJjd" id="iSyfcv_jef" role="1urrMF">
+              <ref role="1YBMHb" node="iSyfcv_hOv" resolve="parameters" />
+            </node>
+          </node>
+        </node>
+        <node concept="3fqX7Q" id="iSyfcv_hUG" role="3clFbw">
+          <node concept="2OqwBi" id="iSyfcv_i5D" role="3fr31v">
+            <node concept="1YBJjd" id="iSyfcv_hVq" role="2Oq$k0">
+              <ref role="1YBMHb" node="iSyfcv_hOv" resolve="parameters" />
+            </node>
+            <node concept="2qgKlT" id="iSyfcv_iZ5" role="2OqNvi">
+              <ref role="37wK5l" to="kvwr:iSyfcvcioP" resolve="isValid" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="iSyfcv_hOv" role="1YuTPh">
+      <property role="TrG5h" value="parameters" />
+      <ref role="1YaFvo" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_FromType.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_FromType.mpsr
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I">
+        <child id="7486903154347131567" name="formalParameter" index="1ux1J" />
+      </concept>
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="iSyfcwfJxL">
+    <property role="3GE5qa" value="editor.BasicEditing" />
+    <property role="TrG5h" value="FormalParameter_FromType" />
+    <node concept="1qefOq" id="iSyfcwfJxN" role="25YQCW">
+      <node concept="1ux1I" id="iSyfcwfJxM" role="1qenE9">
+        <node concept="LIFWc" id="iSyfcwfJxQ" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_vf51vu_a0a" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfJxT" role="25YQFr">
+      <node concept="1ux1I" id="iSyfcwfJxS" role="1qenE9">
+        <node concept="31KZC3" id="iSyfcwfMSH" role="1ux1J">
+          <property role="TrG5h" value="x" />
+          <node concept="3UfwP1" id="iSyfcwfMSI" role="2UegB9">
+            <node concept="3UfM66" id="iSyfcwfMSG" role="3UfBpY" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="iSyfcwfJBH" role="LjaKd">
+      <node concept="2TK7Tu" id="iSyfcwfJBG" role="3cqZAp">
+        <property role="2TTd_B" value="int x" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddAsyncFromLeftParen.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddAsyncFromLeftParen.mpsr
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="8887560457008137085" name="CsBaseLanguage.structure.ICanBeAsync" flags="ngI" index="3c$rpo">
+        <property id="6365726834711276155" name="isAsync" index="otb2J" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="iSyfcwf$h4">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_AddAsyncFromLeftParen" />
+    <node concept="1qefOq" id="iSyfcwf$h5" role="25YQCW">
+      <node concept="3e4soB" id="iSyfcwf$h6" role="1qenE9">
+        <node concept="3e4soT" id="iSyfcwf$h7" role="3e4soI" />
+        <node concept="3e4po1" id="iSyfcwf$h8" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwf$h9" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+          <node concept="3e4pod" id="iSyfcwf$l5" role="3e4po0">
+            <property role="TrG5h" value="y" />
+          </node>
+        </node>
+        <node concept="LIFWc" id="iSyfcwf$m4" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_vw4s8m_b0" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="iSyfcwf$hb" role="LjaKd">
+      <node concept="2TK7Tu" id="iSyfcwf$hc" role="3cqZAp">
+        <property role="2TTd_B" value=" async" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwf$hd" role="25YQFr">
+      <node concept="3e4soB" id="iSyfcwf$he" role="1qenE9">
+        <property role="otb2J" value="true" />
+        <node concept="3e4soT" id="iSyfcwf$hf" role="3e4soI" />
+        <node concept="3e4po1" id="iSyfcwf$hg" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwf$hh" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+          <node concept="3e4pod" id="iSyfcwf$nz" role="3e4po0">
+            <property role="TrG5h" value="y" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddAsyncFromParameter.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddAsyncFromParameter.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="8887560457008137085" name="CsBaseLanguage.structure.ICanBeAsync" flags="ngI" index="3c$rpo">
+        <property id="6365726834711276155" name="isAsync" index="otb2J" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGpqd">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_AddAsyncFromParameter" />
+    <node concept="1qefOq" id="1Y9XkgdGpqe" role="25YQCW">
+      <node concept="3e4soB" id="1Y9XkgdGpqo" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGpqp" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGpqr" role="3e4sow">
+          <node concept="3e4pod" id="1Y9XkgdGpqs" role="3e4po0">
+            <property role="TrG5h" value="x" />
+            <node concept="LIFWc" id="1Y9XkgdGpqB" role="lGtFl">
+              <property role="LIFWa" value="0" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="property_name" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1Y9XkgdGpqj" role="LjaKd">
+      <node concept="2TK7Tu" id="1Y9XkgdGpqk" role="3cqZAp">
+        <property role="2TTd_B" value=" async" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGpqn" role="25YQFr">
+      <node concept="3e4soB" id="1Y9XkgdGpqD" role="1qenE9">
+        <property role="otb2J" value="true" />
+        <node concept="3e4soT" id="1Y9XkgdGpqE" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGpqF" role="3e4sow">
+          <node concept="3e4pod" id="1Y9XkgdGpqG" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddImplicitParam.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_AddImplicitParam.mpsr
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGj1f">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_AddImplicitParam" />
+    <node concept="1qefOq" id="1Y9XkgdGj1g" role="25YQCW">
+      <node concept="3e4soB" id="1Y9XkgdGj1C" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGj1D" role="3e4soI" />
+        <node concept="3e4po1" id="iSyfcwf$3$" role="3e4sow">
+          <node concept="LIFWc" id="iSyfcwfD1J" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Constant_m5xx9y_a0a" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1Y9XkgdGj1k" role="LjaKd">
+      <node concept="2TK7Tu" id="1Y9XkgdGj1l" role="3cqZAp">
+        <property role="2TTd_B" value="xyz" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGj1q" role="25YQFr">
+      <node concept="3e4soB" id="1Y9XkgdGj1T" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGj1U" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGj27" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwf$5Y" role="3e4po0">
+            <property role="TrG5h" value="xyz" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_BlockToExpressionBody.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_BlockToExpressionBody.mpsr
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="592868908271422361" name="jetbrains.mps.lang.test.structure.IsIntentionApplicableExpression" flags="ng" index="2bRw2S">
+        <reference id="592868908271422362" name="intention" index="2bRw2V" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="1945218857514060490" name="CsBaseLanguage.structure.ReturnStatement" flags="ng" index="2YuCjO">
+        <child id="1945218857514060491" name="expression" index="2YuCjP" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="iSyfcwfQ9X">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_BlockToExpressionBody" />
+    <node concept="1qefOq" id="iSyfcwfQ9Y" role="25YQCW">
+      <node concept="3e4soB" id="iSyfcwfQa2" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQa3" role="3e4sow" />
+        <node concept="1ux1M" id="iSyfcwpAwz" role="3e4soI">
+          <node concept="2YuCjO" id="iSyfcwpAww" role="1ux1N">
+            <node concept="3UcVBg" id="iSyfcwpAwx" role="2YuCjP">
+              <property role="1pzoAX" value="42" />
+              <node concept="LIFWc" id="iSyfcwpAwy" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="2" />
+                <property role="p6zMs" value="2" />
+                <property role="LIFWd" value="property_value" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfQaa" role="25YQFr">
+      <node concept="3e4soB" id="iSyfcwfQab" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQac" role="3e4sow" />
+        <node concept="3UcVBg" id="iSyfcwfQaj" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="iSyfcwfQao" role="LjaKd">
+      <node concept="3vwNmj" id="30U1FYluJ9i" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluIVb" role="3vwVQn">
+          <ref role="2bRw2V" to="wux4:1XmGakP62$g" resolve="BlockToExpression" />
+        </node>
+      </node>
+      <node concept="3vFxKo" id="30U1FYluNru" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluNry" role="3vFALc">
+          <ref role="2bRw2V" to="wux4:1XmGakOXg0W" resolve="ExpressionToBlock" />
+        </node>
+      </node>
+      <node concept="1MFPAf" id="iSyfcwfQg6" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:1XmGakP62$g" resolve="BlockToExpression" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_CreateAsync.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_CreateAsync.mpsr
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
+        <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="8887560457008137085" name="CsBaseLanguage.structure.ICanBeAsync" flags="ngI" index="3c$rpo">
+        <property id="6365726834711276155" name="isAsync" index="otb2J" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+      <concept id="6843536562190617628" name="CsBaseLanguage.structure.Expression" flags="ng" index="3Uf2Ky" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGfz2">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_CreateAsync" />
+    <node concept="1qefOq" id="1Y9XkgdGfz3" role="25YQCW">
+      <node concept="zF7EM" id="1Y9XkgdGfz4" role="1qenE9">
+        <property role="TrG5h" value="x" />
+        <node concept="3Uf2Ky" id="1Y9XkgdGfz5" role="1qY_RL">
+          <node concept="LIFWc" id="1Y9XkgdGfz6" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Error" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1Y9XkgdGfz7" role="LjaKd">
+      <node concept="2TK7Tu" id="1Y9XkgdGfz8" role="3cqZAp">
+        <property role="2TTd_B" value="async () =&gt;" />
+      </node>
+      <node concept="2HxZob" id="1Y9XkgdGfz9" role="3cqZAp">
+        <node concept="1iFQzN" id="1Y9XkgdGfza" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="yd1bK" id="1Y9XkgdGfzb" role="3cqZAp">
+        <node concept="pLAjd" id="1Y9XkgdGfzc" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGfzd" role="25YQFr">
+      <node concept="zF7EM" id="1Y9XkgdGfze" role="1qenE9">
+        <property role="TrG5h" value="x" />
+        <node concept="3e4soB" id="1Y9XkgdGfzp" role="1qY_RL">
+          <property role="otb2J" value="true" />
+          <node concept="3e4soT" id="1Y9XkgdGfzs" role="3e4soI" />
+          <node concept="3e4po1" id="iSyfcwfvjJ" role="3e4sow">
+            <node concept="LIFWc" id="1bWPTWUbsF3" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Constant_m5xx9y_a0a" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_Creation.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_Creation.mpsr
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
+        <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+      <concept id="6843536562190617628" name="CsBaseLanguage.structure.Expression" flags="ng" index="3Uf2Ky" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1XmGakPNRRQ">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_Creation" />
+    <node concept="1qefOq" id="1XmGakPNRTY" role="25YQCW">
+      <node concept="zF7EM" id="1Y9Xkga60WP" role="1qenE9">
+        <property role="TrG5h" value="x" />
+        <node concept="3Uf2Ky" id="1Y9Xkga613Q" role="1qY_RL">
+          <node concept="LIFWc" id="1Y9Xkga615f" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Error" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1XmGakPNRUt" role="LjaKd">
+      <node concept="2TK7Tu" id="1XmGakPNS1i" role="3cqZAp">
+        <property role="2TTd_B" value="() =&gt;" />
+      </node>
+      <node concept="2HxZob" id="1Y9XkgdCRu$" role="3cqZAp">
+        <node concept="1iFQzN" id="1Y9XkgdCRuH" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="yd1bK" id="1Y9XkgdD5Z0" role="3cqZAp">
+        <node concept="pLAjd" id="1Y9XkgdD5Z2" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9Xkga4WgX" role="25YQFr">
+      <node concept="zF7EM" id="1Y9Xkga616C" role="1qenE9">
+        <property role="TrG5h" value="x" />
+        <node concept="3e4soB" id="iSyfcwflAt" role="1qY_RL">
+          <node concept="3e4po1" id="iSyfcwflAu" role="3e4sow">
+            <node concept="LIFWc" id="iSyfcwflBv" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="0" />
+              <property role="p6zMs" value="0" />
+              <property role="LIFWd" value="Constant_m5xx9y_a0a" />
+            </node>
+          </node>
+          <node concept="3e4soT" id="iSyfcwflAv" role="3e4soI" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_DeleteAsync.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_DeleteAsync.mpsr
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="8887560457008137085" name="CsBaseLanguage.structure.ICanBeAsync" flags="ngI" index="3c$rpo">
+        <property id="6365726834711276155" name="isAsync" index="otb2J" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGsBz">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_DeleteAsync" />
+    <node concept="1qefOq" id="1Y9XkgdGsB$" role="25YQCW">
+      <node concept="3e4soB" id="1Y9XkgdGsBH" role="1qenE9">
+        <property role="otb2J" value="true" />
+        <node concept="3e4soT" id="1Y9XkgdGsBI" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGsBJ" role="3e4sow">
+          <node concept="3e4pod" id="1Y9XkgdGsBK" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+        </node>
+        <node concept="LIFWc" id="1Y9XkgdGsBZ" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="5" />
+          <property role="p6zMs" value="5" />
+          <property role="LIFWd" value="async" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1Y9XkgdGsBE" role="LjaKd">
+      <node concept="3clFbF" id="1Y9XkgdGzaE" role="3cqZAp">
+        <node concept="2YIFZM" id="1Y9XkgdGzaV" role="3clFbG">
+          <ref role="37wK5l" to="tp6m:14TMHtHs1EN" resolve="runWithTwoStepDeletion" />
+          <ref role="1Pybhc" to="tp6m:5s44y2Lh6_5" resolve="EditorTestUtil" />
+          <node concept="1bVj0M" id="1Y9XkgdGzg5" role="37wK5m">
+            <node concept="3clFbS" id="1Y9XkgdGzg9" role="1bW5cS">
+              <node concept="2HxZob" id="1Y9XkgdGsNh" role="3cqZAp">
+                <node concept="1iFQzN" id="1Y9XkgdGsNl" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+              <node concept="2HxZob" id="1Y9XkgdGzlE" role="3cqZAp">
+                <node concept="1iFQzN" id="1Y9XkgdGzlF" role="3iKnsn">
+                  <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbT" id="1Y9XkgdGzfK" role="37wK5m">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGvWR" role="25YQFr">
+      <node concept="3e4soB" id="1Y9XkgdGsC1" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGsC2" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGsC3" role="3e4sow">
+          <node concept="3e4pod" id="1Y9XkgdGsC4" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_ExpressionToBlockBody.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_ExpressionToBlockBody.mpsr
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="592868908271422361" name="jetbrains.mps.lang.test.structure.IsIntentionApplicableExpression" flags="ng" index="2bRw2S">
+        <reference id="592868908271422362" name="intention" index="2bRw2V" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="1945218857514060490" name="CsBaseLanguage.structure.ReturnStatement" flags="ng" index="2YuCjO">
+        <child id="1945218857514060491" name="expression" index="2YuCjP" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="iSyfcwfQih">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_ExpressionToBlockBody" />
+    <node concept="1qefOq" id="iSyfcwfQii" role="25YQCW">
+      <node concept="3e4soB" id="iSyfcwfQio" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQip" role="3e4sow" />
+        <node concept="3UcVBg" id="iSyfcwfQis" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+          <node concept="LIFWc" id="iSyfcwfQiH" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="2" />
+            <property role="p6zMs" value="2" />
+            <property role="LIFWd" value="property_value" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="iSyfcwfQit" role="LjaKd">
+      <node concept="3vwNmj" id="30U1FYluJkn" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluJkT" role="3vwVQn">
+          <ref role="2bRw2V" to="wux4:1XmGakOXg0W" resolve="ExpressionToBlock" />
+        </node>
+      </node>
+      <node concept="3vFxKo" id="30U1FYluJte" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluJue" role="3vFALc">
+          <ref role="2bRw2V" to="wux4:1XmGakP62$g" resolve="BlockToExpression" />
+        </node>
+      </node>
+      <node concept="1MFPAf" id="iSyfcwfQiu" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:1XmGakOXg0W" resolve="ExpressionToBlock" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfQiJ" role="25YQFr">
+      <node concept="3e4soB" id="iSyfcwfQiK" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQiL" role="3e4sow" />
+        <node concept="1ux1M" id="iSyfcwpAvw" role="3e4soI">
+          <node concept="2YuCjO" id="iSyfcwpAvu" role="1ux1N">
+            <node concept="3UcVBg" id="iSyfcwpAvv" role="2YuCjP">
+              <property role="1pzoAX" value="42" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_MakeParametersExplicit.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_MakeParametersExplicit.mpsr
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="592868908271422361" name="jetbrains.mps.lang.test.structure.IsIntentionApplicableExpression" flags="ng" index="2bRw2S">
+        <reference id="592868908271422362" name="intention" index="2bRw2V" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+      <concept id="6432591675578008849" name="CsBaseLanguage.structure.INonArrayType" flags="ngI" index="1QGQOt" />
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGEm5">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_MakeParametersExplicit" />
+    <node concept="1qefOq" id="1Y9XkgdGEm6" role="25YQCW">
+      <node concept="3e4soB" id="1Y9XkgdGEm7" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGEm8" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGEm9" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwfzLV" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+          <node concept="3e4pod" id="iSyfcwfzMu" role="3e4po0">
+            <property role="TrG5h" value="y" />
+            <node concept="LIFWc" id="iSyfcwfzSd" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="1" />
+              <property role="p6zMs" value="1" />
+              <property role="LIFWd" value="property_name" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="1Y9XkgdGEmc" role="LjaKd">
+      <node concept="3vwNmj" id="30U1FYluNu_" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluNuD" role="3vwVQn">
+          <ref role="2bRw2V" to="wux4:iSyfcvqAoV" resolve="MakeExplicit" />
+        </node>
+      </node>
+      <node concept="3vFxKo" id="30U1FYluNxG" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluNxK" role="3vFALc">
+          <ref role="2bRw2V" to="wux4:iSyfcv_Xws" resolve="MakeImplicit" />
+        </node>
+      </node>
+      <node concept="1MFPAf" id="1Y9XkgdGEyF" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:iSyfcvqAoV" resolve="MakeAllExplicit" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGEmm" role="25YQFr">
+      <node concept="3e4soB" id="1Y9XkgdGEmn" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGEmo" role="3e4soI" />
+        <node concept="3e4po1" id="iSyfcwfzKX" role="3e4sow">
+          <node concept="31KZC3" id="iSyfcwfzQB" role="3e4po0">
+            <property role="TrG5h" value="x" />
+            <node concept="3UfwP1" id="iSyfcwfzQC" role="2UegB9">
+              <node concept="1QGQOt" id="iSyfcwfzQD" role="3UfBpY" />
+            </node>
+          </node>
+          <node concept="31KZC3" id="iSyfcwfzQE" role="3e4po0">
+            <property role="TrG5h" value="y" />
+            <node concept="3UfwP1" id="iSyfcwfzQF" role="2UegB9">
+              <node concept="1QGQOt" id="iSyfcwfzQG" role="3UfBpY" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_MakeParametersImplicit.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpression_MakeParametersImplicit.mpsr
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="592868908271422361" name="jetbrains.mps.lang.test.structure.IsIntentionApplicableExpression" flags="ng" index="2bRw2S">
+        <reference id="592868908271422362" name="intention" index="2bRw2V" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="8887560456966189852" name="CsBaseLanguage.structure.IAnonymousFunctionBody" flags="ngI" index="3e4soT" />
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="1Y9XkgdGRvR">
+    <property role="3GE5qa" value="editor.BasicEditing.LambdaExpression" />
+    <property role="TrG5h" value="LambdaExpression_MakeParametersImplicit" />
+    <node concept="3clFbS" id="1Y9XkgdGRvY" role="LjaKd">
+      <node concept="3vwNmj" id="30U1FYluNzm" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluNzq" role="3vwVQn">
+          <ref role="2bRw2V" to="wux4:iSyfcv_Xws" resolve="MakeImplicit" />
+        </node>
+      </node>
+      <node concept="3vFxKo" id="30U1FYluNS0" role="3cqZAp">
+        <node concept="2bRw2S" id="30U1FYluNS4" role="3vFALc">
+          <ref role="2bRw2V" to="wux4:iSyfcvqAoV" resolve="MakeExplicit" />
+        </node>
+      </node>
+      <node concept="1MFPAf" id="1Y9XkgdGREq" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:iSyfcv_Xws" resolve="MakeAllImplicit" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGRxH" role="25YQCW">
+      <node concept="3e4soB" id="1Y9XkgdGRxE" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGRxG" role="3e4soI" />
+        <node concept="3e4po1" id="iSyfcwfzB$" role="3e4sow">
+          <node concept="31KZC3" id="iSyfcwfzC5" role="3e4po0">
+            <property role="TrG5h" value="x" />
+            <node concept="3UfwP1" id="iSyfcwfzC6" role="2UegB9">
+              <node concept="3UfM66" id="iSyfcwfzC4" role="3UfBpY" />
+            </node>
+          </node>
+          <node concept="31KZC3" id="iSyfcwfzGx" role="3e4po0">
+            <property role="TrG5h" value="y" />
+            <node concept="3UfwP1" id="iSyfcwfzGy" role="2UegB9">
+              <node concept="3UfM66" id="iSyfcwfzGv" role="3UfBpY" />
+            </node>
+            <node concept="LIFWc" id="iSyfcwfzZh" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="1" />
+              <property role="p6zMs" value="1" />
+              <property role="LIFWd" value="property_name" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="1Y9XkgdGR$x" role="25YQFr">
+      <node concept="3e4soB" id="1Y9XkgdGR$y" role="1qenE9">
+        <node concept="3e4soT" id="1Y9XkgdGR$z" role="3e4soI" />
+        <node concept="3e4po1" id="1Y9XkgdGR$L" role="3e4sow">
+          <node concept="3e4pod" id="1Y9XkgdGR$M" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+          <node concept="3e4pod" id="iSyfcwfzHC" role="3e4po0">
+            <property role="TrG5h" value="y" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpressions.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/LambdaExpressions.mpsr
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="8887560457008137085" name="CsBaseLanguage.structure.ICanBeAsync" flags="ngI" index="3c$rpo">
+        <property id="6365726834711276155" name="isAsync" index="otb2J" />
+      </concept>
+      <concept id="8887560456966202148" name="CsBaseLanguage.structure.LambdaParameterList" flags="ng" index="3e4po1">
+        <child id="8887560456966202149" name="parameters" index="3e4po0" />
+      </concept>
+      <concept id="8887560456966202152" name="CsBaseLanguage.structure.ImplicitParameter" flags="ng" index="3e4pod" />
+      <concept id="8887560456966189826" name="CsBaseLanguage.structure.LambdaExpression" flags="ng" index="3e4soB">
+        <child id="8887560456966189829" name="signature" index="3e4sow" />
+        <child id="8887560456966189835" name="body" index="3e4soI" />
+      </concept>
+      <concept id="6365726834708776427" name="CsBaseLanguage.structure.AwaitExpression" flags="ng" index="1BEDWZ">
+        <child id="6365726834708776823" name="task" index="1BEDQz" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="iSyfcwfQ9K">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="structure" />
+    <property role="TrG5h" value="LambdaExpressions" />
+    <node concept="1qefOq" id="iSyfcwfQ9L" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwfQ9P" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQ9Q" role="3e4sow" />
+        <node concept="3UcVBg" id="iSyfcwfQ9V" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwg8dn" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwg8do" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwg8dp" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwg8ez" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+        </node>
+        <node concept="3UcVBg" id="iSyfcwg8dq" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwg8dV" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwg8dW" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwg8dX" role="3e4sow">
+          <node concept="31KZC3" id="iSyfcwg8eA" role="3e4po0">
+            <property role="TrG5h" value="y" />
+            <node concept="3UfwP1" id="iSyfcwg8eB" role="2UegB9">
+              <node concept="3UfM66" id="iSyfcwg8e_" role="3UfBpY" />
+            </node>
+          </node>
+        </node>
+        <node concept="3UcVBg" id="iSyfcwg8dY" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfQiZ" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwfQj0" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQj1" role="3e4sow">
+          <node concept="3e4pod" id="iSyfcwfQjb" role="3e4po0">
+            <property role="TrG5h" value="x" />
+          </node>
+          <node concept="31KZC3" id="iSyfcwfQji" role="3e4po0">
+            <property role="TrG5h" value="y" />
+            <node concept="3UfwP1" id="iSyfcwfQjj" role="2UegB9">
+              <node concept="3UfM66" id="iSyfcwfQjg" role="3UfBpY" />
+            </node>
+          </node>
+          <node concept="7CXmI" id="iSyfcwfQj$" role="lGtFl">
+            <node concept="1TM$A" id="iSyfcwfQj_" role="7EUXB">
+              <node concept="2PYRI3" id="iSyfcwfQjD" role="3lydEf">
+                <ref role="39XzEq" to="avov:iSyfcv_j4M" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UcVBg" id="iSyfcwfQj2" role="3e4soI">
+          <property role="1pzoAX" value="42" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfQkc" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwfQkd" role="1qenE9">
+        <property role="otb2J" value="true" />
+        <node concept="3e4po1" id="iSyfcwfQke" role="3e4sow" />
+        <node concept="1BEDWZ" id="iSyfcwfQkB" role="3e4soI">
+          <node concept="3UcVBg" id="iSyfcwfQkH" role="1BEDQz">
+            <property role="1pzoAX" value="42" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="iSyfcwfQl4" role="1SKRRt">
+      <node concept="3e4soB" id="iSyfcwfQl5" role="1qenE9">
+        <node concept="3e4po1" id="iSyfcwfQl6" role="3e4sow" />
+        <node concept="1BEDWZ" id="iSyfcwfQl7" role="3e4soI">
+          <node concept="3UcVBg" id="iSyfcwfQl8" role="1BEDQz">
+            <property role="1pzoAX" value="42" />
+          </node>
+          <node concept="7CXmI" id="iSyfcwfQly" role="lGtFl">
+            <node concept="1TM$A" id="iSyfcwfQlz" role="7EUXB">
+              <node concept="2PYRI3" id="iSyfcwfQl$" role="3lydEf">
+                <ref role="39XzEq" to="avov:1XmGakPSUV_" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/source_gen.caches/deps.cp
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/source_gen.caches/deps.cp
@@ -4,6 +4,7 @@
   <uses language="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" />
   <uses language="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" />
   <uses language="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" />
+  <uses language="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" />
   <uses language="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" />
   <uses language="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" />
   <uses language="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" />


### PR DESCRIPTION
The implementation deviates from the specification by allowing explicit and implicit parameters to be mixed for ease of editing. This is still marked as an error and intentions are provided to convert between the types. Lambdas can be created and manipulated in various ways:
- An async lambda can be created directly from the substitute menu or via a left transform on a regular lambda;
- An expression body can always be converted to a block body;
- A block body can be converted to an expression body if it contains only empty or return statements.

In addition, FormalParameters now have a substitution menu that allows easy creation from any INonArrayType.