### PR TITLE
Improve generic types

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/CsBaseLanguage.mpl
+++ b/CsBaseLanguage/languages/CsBaseLanguage/CsBaseLanguage.mpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<language namespace="CsBaseLanguage" uuid="d74e25c9-4d91-43b6-bad7-d18af7bf6674" languageVersion="3" moduleVersion="0">
+<language namespace="CsBaseLanguage" uuid="d74e25c9-4d91-43b6-bad7-d18af7bf6674" languageVersion="4" moduleVersion="0">
   <models>
     <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
@@ -15,6 +15,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:a23383a3-9564-4399-8643-72063c6111dc:jetbrains.mps.LangDoc" version="0" />
@@ -65,6 +66,7 @@
     <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="528ff3b9-5fc4-40dd-931f-c6ce3650640e(jetbrains.mps.lang.migration.runtime)" version="0" />

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.migration.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.migration.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:a910586b-a575-4ba4-913e-0af654e1c829(CsBaseLanguage.migration)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="90746344-04fd-4286-97d5-b46ae6a81709" name="jetbrains.mps.lang.migration" version="2" />
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
@@ -16,6 +17,9 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
     <import index="6f4m" ref="528ff3b9-5fc4-40dd-931f-c6ce3650640e/r:f69c3fa1-0e30-4980-84e2-190ae44e4c3d(jetbrains.mps.lang.migration.runtime/jetbrains.mps.lang.migration.runtime.base)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -24,6 +28,7 @@
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
@@ -35,6 +40,7 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <child id="1165602531693" name="superclass" index="1zkMxy" />
@@ -57,8 +63,13 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -80,6 +91,10 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -135,24 +150,46 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
+      <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
+        <child id="1144104376918" name="parameter" index="1xVPHs" />
+      </concept>
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
+      <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="2644386474301421077" name="jetbrains.mps.lang.smodel.structure.LinkIdRefExpression" flags="nn" index="359W_D">
         <reference id="2644386474301421078" name="conceptDeclaration" index="359W_E" />
         <reference id="2644386474301421079" name="linkDeclaration" index="359W_F" />
       </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
+      <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
+        <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
       <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
         <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
       <concept id="1140131837776" name="jetbrains.mps.lang.smodel.structure.Node_ReplaceWithAnotherOperation" flags="nn" index="1P9Npp">
         <child id="1140131861877" name="replacementNode" index="1P9ThW" />
       </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
+      </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -764,6 +801,202 @@
       <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
     </node>
     <node concept="3uibUv" id="4jo$K3ejo0h" role="1zkMxy">
+      <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
+    </node>
+  </node>
+  <node concept="3SyAh_" id="6u44Y77b001">
+    <property role="qMTe8" value="3" />
+    <property role="TrG5h" value="Migrate_GenericTypeParameterReferenceString" />
+    <node concept="3Tm1VV" id="6u44Y77b002" role="1B3o_S" />
+    <node concept="3tTeZs" id="6u44Y77b003" role="jymVt">
+      <property role="3tTeZt" value="&lt;no execute after&gt;" />
+      <ref role="3tTeZr" to="slm6:7ay_HjIMt1a" resolve="execute after" />
+    </node>
+    <node concept="3tTeZs" id="6u44Y77b004" role="jymVt">
+      <property role="3tTeZt" value="&lt;no required data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2FPTh" resolve="requires annotation data" />
+    </node>
+    <node concept="3tTeZs" id="6u44Y77b005" role="jymVt">
+      <property role="3tTeZt" value="&lt;no produced data&gt;" />
+      <ref role="3tTeZr" to="slm6:5TUCQr2C271" resolve="produces annotation data" />
+    </node>
+    <node concept="2tJIrI" id="6u44Y77b006" role="jymVt" />
+    <node concept="3tYpMH" id="6u44Y77b007" role="jymVt">
+      <property role="TrG5h" value="isRerunnable" />
+      <property role="3tYpME" value="true" />
+      <ref role="25KYV2" to="slm6:1JWcQ2VeWIs" resolve="isRerunnable" />
+      <node concept="3Tm1VV" id="6u44Y77b008" role="1B3o_S" />
+      <node concept="10P_77" id="6u44Y77b009" role="1tU5fm" />
+    </node>
+    <node concept="3tTeZs" id="6u44Y77bTi$" role="jymVt">
+      <property role="3tTeZt" value="&lt;description&gt;" />
+      <ref role="3tTeZr" to="slm6:1_lSsE3RFpE" resolve="description" />
+    </node>
+    <node concept="q3mfD" id="6u44Y77b00b" role="jymVt">
+      <property role="TrG5h" value="execute" />
+      <ref role="2VtyIY" to="slm6:4ubqdNOF9cA" resolve="execute" />
+      <node concept="3Tm1VV" id="6u44Y77b00d" role="1B3o_S" />
+      <node concept="3clFbS" id="6u44Y77b00f" role="3clF47">
+        <node concept="L3pyB" id="6u44Y77b0gb" role="3cqZAp">
+          <node concept="3clFbS" id="6u44Y77b0gc" role="L3pyw">
+            <node concept="3clFbF" id="6u44Y77b0oy" role="3cqZAp">
+              <node concept="2OqwBi" id="6u44Y77b1zo" role="3clFbG">
+                <node concept="qVDSY" id="6u44Y77b0ow" role="2Oq$k0">
+                  <node concept="chp4Y" id="6u44Y77b0qN" role="qVDSX">
+                    <ref role="cht4Q" to="80bi:1HkqSaCLgiU" resolve="GenericTypeParameterReferenceString" />
+                  </node>
+                  <node concept="1dO9Bo" id="6u44Y77b0tD" role="1dOa5D">
+                    <node concept="3Z_Q4n" id="6u44Y77b0wu" role="1dp2q7" />
+                  </node>
+                </node>
+                <node concept="2es0OD" id="6u44Y77b3qY" role="2OqNvi">
+                  <node concept="1bVj0M" id="6u44Y77b3r0" role="23t8la">
+                    <node concept="3clFbS" id="6u44Y77b3r1" role="1bW5cS">
+                      <node concept="3cpWs8" id="6u44Y77b4ni" role="3cqZAp">
+                        <node concept="3cpWsn" id="6u44Y77b4nl" role="3cpWs9">
+                          <property role="TrG5h" value="paramScope" />
+                          <node concept="2OqwBi" id="6u44Y77b617" role="33vP2m">
+                            <node concept="2OqwBi" id="6u44Y77b4HB" role="2Oq$k0">
+                              <node concept="37vLTw" id="6u44Y77b4AB" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u44Y77b3r2" resolve="node" />
+                              </node>
+                              <node concept="2Xjw5R" id="6u44Y77b5JL" role="2OqNvi">
+                                <node concept="1xMEDy" id="6u44Y77b5JN" role="1xVPHs">
+                                  <node concept="chp4Y" id="6u44Y77b5Oo" role="ri$Ld">
+                                    <ref role="cht4Q" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2qgKlT" id="6u44Y77b6eW" role="2OqNvi">
+                              <ref role="37wK5l" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+                              <node concept="35c_gC" id="6u44Y77b6op" role="37wK5m">
+                                <ref role="35c_gD" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+                              </node>
+                              <node concept="2OqwBi" id="6u44Y77b77j" role="37wK5m">
+                                <node concept="37vLTw" id="6u44Y77b6N3" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6u44Y77b3r2" resolve="node" />
+                                </node>
+                                <node concept="1mfA1w" id="6u44Y77b9hY" role="2OqNvi" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3uibUv" id="6u44Y77bLcr" role="1tU5fm">
+                            <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="6u44Y77bMlf" role="3cqZAp">
+                        <node concept="3clFbS" id="6u44Y77bMlh" role="3clFbx">
+                          <node concept="3cpWs6" id="6u44Y77bNqs" role="3cqZAp" />
+                        </node>
+                        <node concept="3clFbC" id="6u44Y77bMR_" role="3clFbw">
+                          <node concept="10Nm6u" id="6u44Y77bMSq" role="3uHU7w" />
+                          <node concept="37vLTw" id="6u44Y77bMq$" role="3uHU7B">
+                            <ref role="3cqZAo" node="6u44Y77b4nl" resolve="paramScope" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs8" id="6u44Y77bOA4" role="3cqZAp">
+                        <node concept="3cpWsn" id="6u44Y77bOA7" role="3cpWs9">
+                          <property role="TrG5h" value="param" />
+                          <node concept="3Tqbb2" id="6u44Y77bOA2" role="1tU5fm">
+                            <ref role="ehGHo" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+                          </node>
+                          <node concept="1PxgMI" id="6u44Y77bQnE" role="33vP2m">
+                            <property role="1BlNFB" value="true" />
+                            <node concept="chp4Y" id="6u44Y77bQEa" role="3oSUPX">
+                              <ref role="cht4Q" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+                            </node>
+                            <node concept="2OqwBi" id="6u44Y77bP2w" role="1m5AlR">
+                              <node concept="37vLTw" id="6u44Y77bONH" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u44Y77b4nl" resolve="paramScope" />
+                              </node>
+                              <node concept="liA8E" id="6u44Y77babo" role="2OqNvi">
+                                <ref role="37wK5l" to="o8zo:3fifI_xCtP3" resolve="resolve" />
+                                <node concept="2OqwBi" id="6u44Y77baEX" role="37wK5m">
+                                  <node concept="37vLTw" id="6u44Y77bard" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6u44Y77b3r2" resolve="node" />
+                                  </node>
+                                  <node concept="1mfA1w" id="6u44Y77bbQz" role="2OqNvi" />
+                                </node>
+                                <node concept="2OqwBi" id="6u44Y77bceI" role="37wK5m">
+                                  <node concept="37vLTw" id="6u44Y77bbWN" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6u44Y77b3r2" resolve="node" />
+                                  </node>
+                                  <node concept="3TrcHB" id="6u44Y77bcJE" role="2OqNvi">
+                                    <ref role="3TsBF5" to="80bi:1HkqSaCLgiY" resolve="referencedGenericTypeParameter" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbJ" id="6u44Y77bGlq" role="3cqZAp">
+                        <node concept="3clFbS" id="6u44Y77bGls" role="3clFbx">
+                          <node concept="3clFbF" id="6u44Y77bAI7" role="3cqZAp">
+                            <node concept="2OqwBi" id="6u44Y77bB1Q" role="3clFbG">
+                              <node concept="37vLTw" id="6u44Y77bAI6" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6u44Y77b3r2" resolve="it" />
+                              </node>
+                              <node concept="1P9Npp" id="6u44Y77bBZd" role="2OqNvi">
+                                <node concept="2pJPEk" id="6u44Y77bC41" role="1P9ThW">
+                                  <node concept="2pJPED" id="6u44Y77bC43" role="2pJPEn">
+                                    <ref role="2pJxaS" to="80bi:2wJFJXA1jc" resolve="GenericTypeParameterReference" />
+                                    <node concept="2pIpSj" id="6u44Y77bCnp" role="2pJxcM">
+                                      <ref role="2pIpSl" to="80bi:2wJFJXA1jf" resolve="typeParameter" />
+                                      <node concept="36biLy" id="6u44Y77bCrS" role="28nt2d">
+                                        <node concept="37vLTw" id="6u44Y77bHMn" role="36biLW">
+                                          <ref role="3cqZAo" node="6u44Y77bOA7" resolve="param" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="6u44Y77bGEn" role="3clFbw">
+                          <node concept="37vLTw" id="6u44Y77bGrH" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6u44Y77bOA7" resolve="param" />
+                          </node>
+                          <node concept="3x8VRR" id="6u44Y77bHsa" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gl6BB" id="6u44Y77b3r2" role="1bW2Oz">
+                      <property role="TrG5h" value="node" />
+                      <node concept="2jxLKc" id="6u44Y77b3r3" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="6u44Y77b0hi" role="L3pyr">
+            <ref role="3cqZAo" node="6u44Y77b00h" resolve="m" />
+          </node>
+        </node>
+      </node>
+      <node concept="ffn8J" id="6u44Y77b00h" role="3clF46">
+        <property role="TrG5h" value="m" />
+        <ref role="ffrpq" to="slm6:7fCCGqboj9J" resolve="m" />
+        <node concept="3uibUv" id="6u44Y77b00g" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+        </node>
+      </node>
+      <node concept="q3mfm" id="6u44Y77b00i" role="3clF45">
+        <ref role="q3mfh" to="slm6:4F5w8gPXEEe" />
+        <ref role="1QQUv3" node="6u44Y77b00b" resolve="execute" />
+      </node>
+    </node>
+    <node concept="3tTeZs" id="6u44Y77b00j" role="jymVt">
+      <property role="3tTeZt" value="&lt;no result checking&gt;" />
+      <ref role="3tTeZr" to="slm6:1JWcQ2VeXpD" resolve="check" />
+    </node>
+    <node concept="3uibUv" id="6u44Y77b00m" role="1zkMxy">
       <ref role="3uigEE" to="slm6:5TUCQr2ybBO" resolve="HasMigrationScriptReference" />
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
@@ -159,8 +159,12 @@
       </concept>
     </language>
     <language id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc">
+      <concept id="5858074156537516430" name="jetbrains.mps.baseLanguage.javadoc.structure.ReturnBlockDocTag" flags="ng" index="x79VA">
+        <property id="5858074156537516431" name="text" index="x79VB" />
+      </concept>
       <concept id="5349172909345501395" name="jetbrains.mps.baseLanguage.javadoc.structure.BaseDocComment" flags="ng" index="P$AiS">
         <child id="8465538089690331502" name="body" index="TZ5H$" />
+        <child id="5383422241790532083" name="tags" index="3nqlJM" />
       </concept>
       <concept id="5349172909345532724" name="jetbrains.mps.baseLanguage.javadoc.structure.MethodDocComment" flags="ng" index="P$JXv" />
       <concept id="8465538089690331500" name="jetbrains.mps.baseLanguage.javadoc.structure.CommentLine" flags="ng" index="TZ5HA">
@@ -187,6 +191,10 @@
         <child id="1138662048170" name="value" index="tz02z" />
       </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
+        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
+        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
+      </concept>
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
         <child id="1883223317721008709" name="body" index="Jncv$" />
@@ -217,6 +225,9 @@
       <concept id="5944356402132808754" name="jetbrains.mps.lang.smodel.structure.SubconceptCase" flags="ng" index="1_3QMl">
         <child id="1163670677455" name="concept" index="3Kbmr1" />
         <child id="1163670683720" name="body" index="3Kbo56" />
+      </concept>
+      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
+        <property id="1238684351431" name="asCast" index="1BlNFB" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -267,6 +278,7 @@
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="13h7C7" id="4oSbvdw7eTb">
@@ -1089,6 +1101,36 @@
     <node concept="13hLZK" id="27q4jmdX9tL" role="13h7CW">
       <node concept="3clFbS" id="27q4jmdX9tM" role="2VODD2" />
     </node>
+    <node concept="13i0hz" id="4tlNOo98hIL" role="13h7CS">
+      <property role="TrG5h" value="referencesGenericType" />
+      <ref role="13i0hy" node="4tlNOo9892p" resolve="referencesGenericType" />
+      <node concept="3Tm1VV" id="4tlNOo98hIM" role="1B3o_S" />
+      <node concept="3clFbS" id="4tlNOo98hIV" role="3clF47">
+        <node concept="3clFbF" id="4tlNOo98i3k" role="3cqZAp">
+          <node concept="2OqwBi" id="4tlNOo98oiS" role="3clFbG">
+            <node concept="2OqwBi" id="4tlNOo98kLe" role="2Oq$k0">
+              <node concept="1PxgMI" id="4tlNOo98jNH" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4tlNOo98kxD" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:5moKU4Y5oYr" resolve="IGenericTypeList" />
+                </node>
+                <node concept="2OqwBi" id="4tlNOo98ik1" role="1m5AlR">
+                  <node concept="13iPFW" id="4tlNOo98i3f" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4tlNOo98j98" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:27q4jmdWXhm" resolve="referencedType" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3Tsc0h" id="4tlNOo98kXh" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:5moKU4Y5slA" resolve="typeParameter" />
+              </node>
+            </node>
+            <node concept="3GX2aA" id="4tlNOo98sse" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="4tlNOo98hIW" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="27q4jmdX9uu">
     <property role="3GE5qa" value="References.TypeRelatedReferences" />
@@ -1346,6 +1388,29 @@
     </node>
     <node concept="13hLZK" id="27q4jmdX9uv" role="13h7CW">
       <node concept="3clFbS" id="27q4jmdX9uw" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="4tlNOo9892p" role="13h7CS">
+      <property role="TrG5h" value="referencesGenericType" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="4tlNOo9892q" role="1B3o_S" />
+      <node concept="10P_77" id="4tlNOo98aFO" role="3clF45" />
+      <node concept="3clFbS" id="4tlNOo9892s" role="3clF47">
+        <node concept="3clFbF" id="4tlNOo98aGo" role="3cqZAp">
+          <node concept="3clFbT" id="4tlNOo98aGn" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="4tlNOo98aHc" role="lGtFl">
+        <node concept="TZ5HA" id="4tlNOo98aHd" role="TZ5H$">
+          <node concept="1dT_AC" id="4tlNOo98aHe" role="1dT_Ay">
+            <property role="1dT_AB" value="Controls whether the AddGenericParameterListSection menu is applicable to this reference." />
+          </node>
+        </node>
+        <node concept="x79VA" id="4tlNOo98aHf" role="3nqlJM">
+          <property role="x79VB" value="True if this reference points to a generic type declaration." />
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="27q4jmdXa3v">
@@ -1654,6 +1719,26 @@
       <node concept="3clFbS" id="42EL3I6oFKd" role="2VODD2" />
     </node>
   </node>
+  <node concept="13h7C7" id="6u44Y79j8jC">
+    <property role="3GE5qa" value="Interface" />
+    <ref role="13h7C2" to="80bi:6hv6i2_Azc6" resolve="InterfaceDeclaration" />
+    <node concept="13hLZK" id="6u44Y79j8jD" role="13h7CW">
+      <node concept="3clFbS" id="6u44Y79j8jE" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6u44Y79j8k7" role="13h7CS">
+      <property role="TrG5h" value="isVarianceEnabled" />
+      <ref role="13i0hy" node="2wJFJYdLjy" resolve="isVarianceEnabled" />
+      <node concept="3Tm1VV" id="6u44Y79j8k8" role="1B3o_S" />
+      <node concept="3clFbS" id="6u44Y79j8kd" role="3clF47">
+        <node concept="3clFbF" id="6u44Y79j8Bw" role="3cqZAp">
+          <node concept="3clFbT" id="6u44Y79j8Bv" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="6u44Y79j8ke" role="3clF45" />
+    </node>
+  </node>
   <node concept="13h7C7" id="7HmXimPF_y7">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
     <ref role="13h7C2" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
@@ -1782,26 +1867,6 @@
     </node>
     <node concept="13hLZK" id="7HmXimPF_y8" role="13h7CW">
       <node concept="3clFbS" id="7HmXimPF_y9" role="2VODD2" />
-    </node>
-  </node>
-  <node concept="13h7C7" id="6u44Y79j8jC">
-    <property role="3GE5qa" value="Interface" />
-    <ref role="13h7C2" to="80bi:6hv6i2_Azc6" resolve="InterfaceDeclaration" />
-    <node concept="13hLZK" id="6u44Y79j8jD" role="13h7CW">
-      <node concept="3clFbS" id="6u44Y79j8jE" role="2VODD2" />
-    </node>
-    <node concept="13i0hz" id="6u44Y79j8k7" role="13h7CS">
-      <property role="TrG5h" value="isVarianceEnabled" />
-      <ref role="13i0hy" node="2wJFJYdLjy" resolve="isVarianceEnabled" />
-      <node concept="3Tm1VV" id="6u44Y79j8k8" role="1B3o_S" />
-      <node concept="3clFbS" id="6u44Y79j8kd" role="3clF47">
-        <node concept="3clFbF" id="6u44Y79j8Bw" role="3cqZAp">
-          <node concept="3clFbT" id="6u44Y79j8Bv" role="3clFbG">
-            <property role="3clFbU" value="true" />
-          </node>
-        </node>
-      </node>
-      <node concept="10P_77" id="6u44Y79j8ke" role="3clF45" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
@@ -645,43 +645,8 @@
   <node concept="13h7C7" id="7TfmMh1OG2E">
     <property role="3GE5qa" value="Generics" />
     <ref role="13h7C2" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
-    <node concept="13i0hz" id="2wJFJYcdAZ" role="13h7CS">
-      <property role="TrG5h" value="setVariance" />
-      <node concept="3Tm1VV" id="2wJFJYcdB0" role="1B3o_S" />
-      <node concept="3cqZAl" id="2wJFJYcdDK" role="3clF45" />
-      <node concept="3clFbS" id="2wJFJYcdB2" role="3clF47">
-        <node concept="3clFbF" id="2wJFJYcdEn" role="3cqZAp">
-          <node concept="37vLTI" id="2wJFJYceXv" role="3clFbG">
-            <node concept="37vLTw" id="2wJFJYdOX5" role="37vLTx">
-              <ref role="3cqZAo" node="2wJFJYdOyX" resolve="value" />
-            </node>
-            <node concept="2OqwBi" id="2wJFJYcdM7" role="37vLTJ">
-              <node concept="13iPFW" id="2wJFJYcdEl" role="2Oq$k0" />
-              <node concept="3TrcHB" id="2wJFJYceuF" role="2OqNvi">
-                <ref role="3TsBF5" to="80bi:7TfmMh1NVbn" resolve="isVarianceAnnotatable" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="2wJFJYdOyX" role="3clF46">
-        <property role="TrG5h" value="value" />
-        <node concept="10P_77" id="2wJFJYdOyW" role="1tU5fm" />
-      </node>
-    </node>
     <node concept="13hLZK" id="7TfmMh1OG2F" role="13h7CW">
       <node concept="3clFbS" id="7TfmMh1OG2G" role="2VODD2">
-        <node concept="3clFbF" id="7TfmMh1OG2Q" role="3cqZAp">
-          <node concept="37vLTI" id="7TfmMh1OHeU" role="3clFbG">
-            <node concept="3clFbT" id="7TfmMh1OHkX" role="37vLTx" />
-            <node concept="2OqwBi" id="7TfmMh1OGaI" role="37vLTJ">
-              <node concept="13iPFW" id="7TfmMh1OG2P" role="2Oq$k0" />
-              <node concept="3TrcHB" id="7TfmMh1OGy8" role="2OqNvi">
-                <ref role="3TsBF5" to="80bi:7TfmMh1NVbn" resolve="isVarianceAnnotatable" />
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3clFbF" id="1HkqSaCLTDC" role="3cqZAp">
           <node concept="2OqwBi" id="1HkqSaCLTVP" role="3clFbG">
             <node concept="2OqwBi" id="1HkqSaCLTMB" role="2Oq$k0">
@@ -777,9 +742,6 @@
         </node>
       </node>
     </node>
-    <node concept="13hLZK" id="2wJFJYdLjo" role="13h7CW">
-      <node concept="3clFbS" id="2wJFJYdLjp" role="2VODD2" />
-    </node>
     <node concept="13i0hz" id="6u44Y770led" role="13h7CS">
       <property role="TrG5h" value="getScope" />
       <ref role="13i0hy" to="tpcu:52_Geb4QDV$" resolve="getScope" />
@@ -841,6 +803,9 @@
       <node concept="3uibUv" id="6u44Y770les" role="3clF45">
         <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
       </node>
+    </node>
+    <node concept="13hLZK" id="2wJFJYdLjo" role="13h7CW">
+      <node concept="3clFbS" id="2wJFJYdLjp" role="2VODD2" />
     </node>
   </node>
   <node concept="13h7C7" id="6FfQk_SPz51">
@@ -1817,6 +1782,26 @@
     </node>
     <node concept="13hLZK" id="7HmXimPF_y8" role="13h7CW">
       <node concept="3clFbS" id="7HmXimPF_y9" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6u44Y79j8jC">
+    <property role="3GE5qa" value="Interface" />
+    <ref role="13h7C2" to="80bi:6hv6i2_Azc6" resolve="InterfaceDeclaration" />
+    <node concept="13hLZK" id="6u44Y79j8jD" role="13h7CW">
+      <node concept="3clFbS" id="6u44Y79j8jE" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6u44Y79j8k7" role="13h7CS">
+      <property role="TrG5h" value="isVarianceEnabled" />
+      <ref role="13i0hy" node="2wJFJYdLjy" resolve="isVarianceEnabled" />
+      <node concept="3Tm1VV" id="6u44Y79j8k8" role="1B3o_S" />
+      <node concept="3clFbS" id="6u44Y79j8kd" role="3clF47">
+        <node concept="3clFbF" id="6u44Y79j8Bw" role="3cqZAp">
+          <node concept="3clFbT" id="6u44Y79j8Bv" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="6u44Y79j8ke" role="3clF45" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
@@ -4,6 +4,7 @@
   <languages>
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="-1" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="d8f591ec-4d86-4af2-9f92-a9e93c803ffa" name="jetbrains.mps.lang.scopes" version="0" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
@@ -12,6 +13,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -28,7 +30,9 @@
         <property id="1225194472834" name="isAbstract" index="13i0iv" />
         <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
       </concept>
-      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5" />
+      <concept id="1225194628440" name="jetbrains.mps.lang.behavior.structure.SuperNodeExpression" flags="nn" index="13iAh5">
+        <reference id="5299096511375896640" name="superConcept" index="3eA5LN" />
+      </concept>
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -118,16 +122,19 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
@@ -163,6 +170,11 @@
         <property id="8970989240999019144" name="text" index="1dT_AB" />
       </concept>
     </language>
+    <language id="d8f591ec-4d86-4af2-9f92-a9e93c803ffa" name="jetbrains.mps.lang.scopes">
+      <concept id="8077936094962850237" name="jetbrains.mps.lang.scopes.structure.CompositeWithParentScopeExpression" flags="nn" index="iyS6D">
+        <child id="8077936094962969171" name="expr" index="iy797" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
         <reference id="4705942098322467736" name="decl" index="21nZrZ" />
@@ -187,12 +199,24 @@
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
+      </concept>
       <concept id="1139613262185" name="jetbrains.mps.lang.smodel.structure.Node_GetParentOperation" flags="nn" index="1mfA1w" />
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="5944356402132808749" name="jetbrains.mps.lang.smodel.structure.ConceptSwitchStatement" flags="nn" index="1_3QMa">
+        <child id="6039268229365417680" name="defaultBlock" index="1prKM_" />
+        <child id="5944356402132808753" name="case" index="1_3QMm" />
+        <child id="5944356402132808752" name="expression" index="1_3QMn" />
+      </concept>
+      <concept id="5944356402132808754" name="jetbrains.mps.lang.smodel.structure.SubconceptCase" flags="ng" index="1_3QMl">
+        <child id="1163670677455" name="concept" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -212,7 +236,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -755,6 +779,68 @@
     </node>
     <node concept="13hLZK" id="2wJFJYdLjo" role="13h7CW">
       <node concept="3clFbS" id="2wJFJYdLjp" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="6u44Y770led" role="13h7CS">
+      <property role="TrG5h" value="getScope" />
+      <ref role="13i0hy" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+      <node concept="3Tm1VV" id="6u44Y770lee" role="1B3o_S" />
+      <node concept="3clFbS" id="6u44Y770len" role="3clF47">
+        <node concept="1_3QMa" id="6u44Y770l_U" role="3cqZAp">
+          <node concept="37vLTw" id="6u44Y770lAL" role="1_3QMn">
+            <ref role="3cqZAo" node="6u44Y770leo" resolve="kind" />
+          </node>
+          <node concept="1_3QMl" id="6u44Y770lBx" role="1_3QMm">
+            <node concept="3gn64h" id="6u44Y770lBy" role="3Kbmr1">
+              <ref role="3gnhBz" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+            </node>
+            <node concept="3clFbS" id="6u44Y770lBz" role="3Kbo56">
+              <node concept="3cpWs6" id="6u44Y770lCX" role="3cqZAp">
+                <node concept="iyS6D" id="6u44Y770lI5" role="3cqZAk">
+                  <node concept="2YIFZM" id="6u44Y770lQX" role="iy797">
+                    <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+                    <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                    <node concept="2OqwBi" id="6u44Y770mag" role="37wK5m">
+                      <node concept="13iPFW" id="6u44Y770lSX" role="2Oq$k0" />
+                      <node concept="3Tsc0h" id="6u44Y770mwT" role="2OqNvi">
+                        <ref role="3TtcxE" to="80bi:5moKU4Y5slA" resolve="typeParameter" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="6u44Y770mWA" role="1prKM_">
+            <node concept="3cpWs6" id="6u44Y770n8x" role="3cqZAp">
+              <node concept="2OqwBi" id="6u44Y770lev" role="3cqZAk">
+                <node concept="13iAh5" id="6u44Y770lew" role="2Oq$k0">
+                  <ref role="3eA5LN" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
+                </node>
+                <node concept="2qgKlT" id="6u44Y770lex" role="2OqNvi">
+                  <ref role="37wK5l" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+                  <node concept="37vLTw" id="6u44Y770let" role="37wK5m">
+                    <ref role="3cqZAo" node="6u44Y770leo" resolve="kind" />
+                  </node>
+                  <node concept="37vLTw" id="6u44Y770leu" role="37wK5m">
+                    <ref role="3cqZAo" node="6u44Y770leq" resolve="child" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6u44Y770leo" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3bZ5Sz" id="6u44Y770lep" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="6u44Y770leq" role="3clF46">
+        <property role="TrG5h" value="child" />
+        <node concept="3Tqbb2" id="6u44Y770ler" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="6u44Y770les" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="6FfQk_SPz51">

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -10,10 +10,10 @@
   <imports>
     <import index="dorh" ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)" />
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
+    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -96,7 +96,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -107,7 +107,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
@@ -134,6 +134,9 @@
       <concept id="1147468365020" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_node" flags="nn" index="EsrRn" />
       <concept id="6738154313879680265" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_childNode" flags="nn" index="2H4GUG" />
       <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
+      <concept id="8401916545537438642" name="jetbrains.mps.lang.constraints.structure.InheritedNodeScopeFactory" flags="ng" index="1dDu$B">
+        <reference id="8401916545537438643" name="kind" index="1dDu$A" />
+      </concept>
       <concept id="1163200368514" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_ReferentSetHandler" flags="in" index="3k9gUc" />
       <concept id="1163200647017" name="jetbrains.mps.lang.constraints.structure.ConstraintFunctionParameter_referenceNode" flags="nn" index="3kakTB" />
       <concept id="1152959968041" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertySetter" flags="in" index="1LLf8_" />
@@ -147,6 +150,7 @@
       <concept id="1148687176410" name="jetbrains.mps.lang.constraints.structure.NodeReferentConstraint" flags="ng" index="1N5Pfh">
         <reference id="1148687202698" name="applicableLink" index="1N5Vy1" />
         <child id="1163203787401" name="referentSetHandler" index="3kmjI7" />
+        <child id="1148687345559" name="searchScopeFactory" index="1N6uqs" />
       </concept>
       <concept id="1153138554286" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_propertyValue" flags="nn" index="1Wqviy" />
     </language>
@@ -238,7 +242,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -2595,6 +2599,51 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="5e5Epz9FD0q">
+    <property role="3GE5qa" value="Statements.Yield" />
+    <ref role="1M2myG" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
+    <node concept="9S07l" id="5e5Epz9FD0r" role="9Vyp8">
+      <node concept="3clFbS" id="5e5Epz9FD0s" role="2VODD2">
+        <node concept="3SKdUt" id="5e5Epz9GqT_" role="3cqZAp">
+          <node concept="1PaTwC" id="5e5Epz9GqTA" role="1aUNEU">
+            <node concept="3oM_SD" id="5e5Epz9GqV5" role="1PaTwD">
+              <property role="3oM_SC" value="TODO:" />
+            </node>
+            <node concept="3oM_SD" id="5e5Epz9GqV8" role="1PaTwD">
+              <property role="3oM_SC" value="should" />
+            </node>
+            <node concept="3oM_SD" id="5e5Epz9GqVg" role="1PaTwD">
+              <property role="3oM_SC" value="include" />
+            </node>
+            <node concept="3oM_SD" id="5e5Epz9GqVp" role="1PaTwD">
+              <property role="3oM_SC" value="operator" />
+            </node>
+            <node concept="3oM_SD" id="1rlUUXHFZo3" role="1PaTwD">
+              <property role="3oM_SC" value="declarations" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5e5Epz9FDfA" role="3cqZAp">
+          <node concept="2OqwBi" id="5e5Epz9FYKe" role="3clFbG">
+            <node concept="2OqwBi" id="5e5Epz9FDNO" role="2Oq$k0">
+              <node concept="nLn13" id="5e5Epz9FDtt" role="2Oq$k0" />
+              <node concept="z$bX8" id="5e5Epz9FE91" role="2OqNvi">
+                <node concept="3gmYPX" id="5e5Epz9FWiq" role="1xVPHs">
+                  <node concept="3gn64h" id="5e5Epz9FWis" role="3gmYPZ">
+                    <ref role="3gnhBz" to="80bi:6hv6i2_B6ci" resolve="MethodDeclaration" />
+                  </node>
+                  <node concept="3gn64h" id="5e5Epz9FWjn" role="3gmYPZ">
+                    <ref role="3gnhBz" to="80bi:3zXINoFWW$0" resolve="AccessorDeclaration" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3GX2aA" id="5e5Epz9GusY" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
   <node concept="1M2fIO" id="5xnAHh0xYvk">
     <property role="3GE5qa" value="Expressions.Unary" />
     <ref role="1M2myG" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
@@ -2753,48 +2802,13 @@
       </node>
     </node>
   </node>
-  <node concept="1M2fIO" id="5e5Epz9FD0q">
-    <property role="3GE5qa" value="Statements.Yield" />
-    <ref role="1M2myG" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
-    <node concept="9S07l" id="5e5Epz9FD0r" role="9Vyp8">
-      <node concept="3clFbS" id="5e5Epz9FD0s" role="2VODD2">
-        <node concept="3SKdUt" id="5e5Epz9GqT_" role="3cqZAp">
-          <node concept="1PaTwC" id="5e5Epz9GqTA" role="1aUNEU">
-            <node concept="3oM_SD" id="5e5Epz9GqV5" role="1PaTwD">
-              <property role="3oM_SC" value="TODO:" />
-            </node>
-            <node concept="3oM_SD" id="5e5Epz9GqV8" role="1PaTwD">
-              <property role="3oM_SC" value="should" />
-            </node>
-            <node concept="3oM_SD" id="5e5Epz9GqVg" role="1PaTwD">
-              <property role="3oM_SC" value="include" />
-            </node>
-            <node concept="3oM_SD" id="5e5Epz9GqVp" role="1PaTwD">
-              <property role="3oM_SC" value="operator" />
-            </node>
-            <node concept="3oM_SD" id="1rlUUXHFZo3" role="1PaTwD">
-              <property role="3oM_SC" value="declarations" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="5e5Epz9FDfA" role="3cqZAp">
-          <node concept="2OqwBi" id="5e5Epz9FYKe" role="3clFbG">
-            <node concept="2OqwBi" id="5e5Epz9FDNO" role="2Oq$k0">
-              <node concept="nLn13" id="5e5Epz9FDtt" role="2Oq$k0" />
-              <node concept="z$bX8" id="5e5Epz9FE91" role="2OqNvi">
-                <node concept="3gmYPX" id="5e5Epz9FWiq" role="1xVPHs">
-                  <node concept="3gn64h" id="5e5Epz9FWis" role="3gmYPZ">
-                    <ref role="3gnhBz" to="80bi:6hv6i2_B6ci" resolve="MethodDeclaration" />
-                  </node>
-                  <node concept="3gn64h" id="5e5Epz9FWjn" role="3gmYPZ">
-                    <ref role="3gnhBz" to="80bi:3zXINoFWW$0" resolve="AccessorDeclaration" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3GX2aA" id="5e5Epz9GusY" role="2OqNvi" />
-          </node>
-        </node>
+  <node concept="1M2fIO" id="3rWl$6Gu5f">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1M2myG" to="80bi:2wJFJXA1jc" resolve="GenericTypeParameterReference" />
+    <node concept="1N5Pfh" id="3rWl$6Gu5g" role="1Mr941">
+      <ref role="1N5Vy1" to="80bi:2wJFJXA1jf" resolve="typeParameter" />
+      <node concept="1dDu$B" id="3rWl$6Gu76" role="1N6uqs">
+        <ref role="1dDu$A" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -8,9 +8,9 @@
     <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
   </languages>
   <imports>
-    <import index="dorh" ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)" />
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
+    <import index="dorh" ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
@@ -481,6 +481,30 @@
                     <property role="Xl_RC" value=" " />
                   </node>
                 </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="EnEH3" id="6u44Y79aMBM" role="1MhHOB">
+      <ref role="EomxK" to="80bi:7TfmMh1NVbn" resolve="isVarianceAnnotatable" />
+      <node concept="Eqf_E" id="6u44Y79aMEC" role="EtsB7">
+        <node concept="3clFbS" id="6u44Y79aMED" role="2VODD2">
+          <node concept="3clFbF" id="6u44Y79aNjq" role="3cqZAp">
+            <node concept="2OqwBi" id="6u44Y79aNPi" role="3clFbG">
+              <node concept="1PxgMI" id="4tlNOo8MpaS" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="4tlNOo8Mpdw" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:5moKU4Y5oYr" resolve="IGenericTypeList" />
+                </node>
+                <node concept="2OqwBi" id="6u44Y79aNn9" role="1m5AlR">
+                  <node concept="EsrRn" id="6u44Y79aNkp" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="4tlNOo8MoLK" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="6u44Y79aO1b" role="2OqNvi">
+                <ref role="37wK5l" to="kvwr:2wJFJYdLjy" resolve="isVarianceEnabled" />
               </node>
             </node>
           </node>
@@ -2543,6 +2567,16 @@
       </node>
     </node>
   </node>
+  <node concept="1M2fIO" id="3rWl$6Gu5f">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1M2myG" to="80bi:2wJFJXA1jc" resolve="GenericTypeParameterReference" />
+    <node concept="1N5Pfh" id="3rWl$6Gu5g" role="1Mr941">
+      <ref role="1N5Vy1" to="80bi:2wJFJXA1jf" resolve="typeParameter" />
+      <node concept="1dDu$B" id="3rWl$6Gu76" role="1N6uqs">
+        <ref role="1dDu$A" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+      </node>
+    </node>
+  </node>
   <node concept="1M2fIO" id="5xnAHgZmc2p">
     <property role="3GE5qa" value="Initializers" />
     <ref role="1M2myG" to="80bi:5VT83U$Mmmn" resolve="ArrayInitializer" />
@@ -2799,16 +2833,6 @@
             </node>
           </node>
         </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1M2fIO" id="3rWl$6Gu5f">
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="1M2myG" to="80bi:2wJFJXA1jc" resolve="GenericTypeParameterReference" />
-    <node concept="1N5Pfh" id="3rWl$6Gu5g" role="1Mr941">
-      <ref role="1N5Vy1" to="80bi:2wJFJXA1jf" resolve="typeParameter" />
-      <node concept="1dDu$B" id="3rWl$6Gu76" role="1N6uqs">
-        <ref role="1dDu$A" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
@@ -23,7 +24,7 @@
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -64,7 +65,7 @@
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1177327274449" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_pattern" flags="nn" index="ub8z3" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
-      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
+      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ngI" index="upBLQ">
         <child id="8478191136883534238" name="features" index="upBLP" />
       </concept>
       <concept id="8478191136883534207" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_Selection" flags="ng" index="upBMk">
@@ -128,10 +129,10 @@
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -188,10 +189,10 @@
       <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
         <property id="1225456424731" name="value" index="1iTho6" />
       </concept>
-      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ngI" index="1joUw2">
         <child id="8954657570916349207" name="features" index="2jZA2a" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
@@ -203,7 +204,7 @@
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
-      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
+      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ngI" index="3EoQpk">
         <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -223,7 +224,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
@@ -234,7 +235,7 @@
         <reference id="1173177718857" name="elementActionMap" index="APP_o" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="6684862045052272180" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_NodeToWrap" flags="ng" index="3N4pyC" />
@@ -388,7 +389,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -407,7 +408,7 @@
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
@@ -555,7 +556,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -21035,61 +21036,101 @@
       </node>
     </node>
   </node>
-  <node concept="3ICUPy" id="4qow2eZf3sX">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="aqKnT" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-    <node concept="1Qtc8_" id="4qow2eZf3w$" role="IW6Ez">
-      <node concept="3cWJ9i" id="4qow2eZf3xa" role="1Qtc8$">
-        <node concept="CtIbL" id="4qow2eZf3xc" role="CtIbM">
-          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+  <node concept="3ICUPy" id="p4z1jOxeUl">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="aqKnT" to="80bi:27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="22hDWj" id="p4z1jOxeUU" role="22hAXT" />
+    <node concept="1Qtc8_" id="p4z1jOxeVw" role="IW6Ez">
+      <node concept="3eGOoe" id="p4z1jOxeVQ" role="1Qtc8$" />
+      <node concept="3PzhKR" id="p4z1jOxeZ4" role="1Qtc8A">
+        <ref role="3PzhKQ" to="80bi:27q4jmdWXhm" resolve="referencedType" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="6t5IfhV7vpH">
+    <property role="3GE5qa" value="Statements" />
+    <ref role="1XX52x" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
+    <node concept="3EZMnI" id="6t5IfhV7vr9" role="2wV5jI">
+      <node concept="3EZMnI" id="6t5IfhVaxon" role="3EZMnx">
+        <ref role="1ERwB7" node="6t5IfhVaxwT" resolve="RemoveLock" />
+        <node concept="3F0ifn" id="6t5IfhV7vrH" role="3EZMnx">
+          <property role="3F0ifm" value="lock" />
+        </node>
+        <node concept="3F0ifn" id="6t5IfhV7vse" role="3EZMnx">
+          <property role="3F0ifm" value="(" />
+          <node concept="11LMrY" id="6t5IfhV7vw4" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="6t5IfhV7vD4" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:6t5IfhV7v$m" resolve="expression" />
+        </node>
+        <node concept="3F0ifn" id="6t5IfhV7vsJ" role="3EZMnx">
+          <property role="3F0ifm" value=")" />
+          <node concept="11L4FC" id="6t5IfhV7vxX" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="6t5IfhVaxt5" role="2iSdaV" />
+        <node concept="VPM3Z" id="6t5IfhVaxuZ" role="3F10Kt" />
+        <node concept="2SqB2G" id="6t5IfhVa$ha" role="2SqHTX">
+          <property role="TrG5h" value="lock" />
         </node>
       </node>
-      <node concept="IWgqT" id="4qow2eZf4SI" role="1Qtc8A">
-        <node concept="1hCUdq" id="4qow2eZf4SJ" role="1hCUd6">
-          <node concept="3clFbS" id="4qow2eZf4SK" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf5b3" role="3cqZAp">
-              <node concept="Xl_RD" id="4qow2eZf5b2" role="3clFbG">
-                <property role="Xl_RC" value="=" />
-              </node>
-            </node>
-          </node>
+      <node concept="3F1sOY" id="6t5IfhV7vEZ" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:6t5IfhV7vAf" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="6t5IfhV7vrc" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="5e5Epz9BuN1">
+    <property role="3GE5qa" value="Statements.Yield" />
+    <ref role="1XX52x" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
+    <node concept="3EZMnI" id="5e5Epz9BuN3" role="2wV5jI">
+      <node concept="3F0ifn" id="5e5Epz9BuN7" role="3EZMnx">
+        <property role="3F0ifm" value="yield" />
+        <ref role="1ERwB7" node="5e5Epz9BuNi" resolve="RemoveYield" />
+        <node concept="2SqB2G" id="5e5Epz9BuNh" role="2SqHTX">
+          <property role="TrG5h" value="yield" />
         </node>
-        <node concept="IWg2L" id="4qow2eZf4SL" role="IWgqQ">
-          <node concept="3clFbS" id="4qow2eZf4SM" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf8Vg" role="3cqZAp">
-              <node concept="2OqwBi" id="4qow2eZf9Z4" role="3clFbG">
-                <node concept="2OqwBi" id="4qow2eZf98M" role="2Oq$k0">
-                  <node concept="7Obwk" id="4qow2eZf8Vf" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4qow2eZf9Od" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                  </node>
+      </node>
+      <node concept="3F1sOY" id="5e5Epz9BuNc" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5e5Epz9BuN0" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="5e5Epz9BuN6" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="6v$Cp0meIXd">
+    <property role="3GE5qa" value="Statements.Using" />
+    <property role="TrG5h" value="RemoveUsing" />
+    <ref role="1h_SK9" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+    <node concept="1hA7zw" id="6v$Cp0meIYf" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="6v$Cp0meIYg" role="1hA7z_">
+        <node concept="3clFbS" id="6v$Cp0meIYh" role="2VODD2">
+          <node concept="3clFbJ" id="6v$Cp0meJ0l" role="3cqZAp">
+            <node concept="2OqwBi" id="6v$Cp0meJbF" role="3clFbw">
+              <node concept="0IXxy" id="6v$Cp0meJ0L" role="2Oq$k0" />
+              <node concept="2xy62i" id="6v$Cp0meJCJ" role="2OqNvi">
+                <node concept="1Q80Hx" id="6v$Cp0meJDz" role="2xHN3q" />
+                <node concept="2TlHUq" id="6v$Cp0meJED" role="3a7HXU">
+                  <ref role="2TlMyj" node="6v$Cp0meIYc" resolve="using" />
                 </node>
-                <node concept="zfrQC" id="4qow2eZfatu" role="2OqNvi" />
               </node>
             </node>
+            <node concept="3clFbS" id="6v$Cp0meJ0n" role="3clFbx">
+              <node concept="3cpWs6" id="6v$Cp0meJHP" role="3cqZAp" />
+            </node>
           </node>
-        </node>
-        <node concept="27VH4U" id="4qow2eZf5sj" role="2jiSrf">
-          <node concept="3clFbS" id="4qow2eZf5sk" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf5IZ" role="3cqZAp">
-              <node concept="2OqwBi" id="4qow2eZf87R" role="3clFbG">
-                <node concept="2OqwBi" id="4qow2eZf6ce" role="2Oq$k0">
-                  <node concept="7Obwk" id="4qow2eZf5IY" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4qow2eZf7$1" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+          <node concept="3clFbF" id="6v$Cp0meJMN" role="3cqZAp">
+            <node concept="2OqwBi" id="6v$Cp0meJPg" role="3clFbG">
+              <node concept="0IXxy" id="6v$Cp0meJMM" role="2Oq$k0" />
+              <node concept="1P9Npp" id="6v$Cp0meJSl" role="2OqNvi">
+                <node concept="2OqwBi" id="6v$Cp0meJUr" role="1P9ThW">
+                  <node concept="0IXxy" id="6v$Cp0meJSU" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6v$Cp0meK9V" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
                   </node>
-                </node>
-                <node concept="3w_OXm" id="4qow2eZf8$G" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cqGtN" id="4qow2eZh_l_" role="2jZA2a">
-          <node concept="3cqJkl" id="4qow2eZh_lA" role="3cqGtW">
-            <node concept="3clFbS" id="4qow2eZh_lB" role="2VODD2">
-              <node concept="3clFbF" id="4qow2eZh_Z1" role="3cqZAp">
-                <node concept="Xl_RD" id="4qow2eZhBj3" role="3clFbG">
-                  <property role="Xl_RC" value="add initializer" />
                 </node>
               </node>
             </node>
@@ -21097,15 +21138,21 @@
         </node>
       </node>
     </node>
-    <node concept="22hDWj" id="4qow2eZf3ty" role="22hAXT" />
   </node>
-  <node concept="PKFIW" id="5QWEwg3W_GX">
-    <property role="TrG5h" value="VariableNameComponent" />
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-    <node concept="3F0A7n" id="5QWEwg3W_GY" role="2wV5jI">
-      <property role="1cu_pB" value="gtguBGO/firstEditableCell" />
-      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclarationStatement" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="declaration" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
     </node>
   </node>
   <node concept="1h_SRR" id="6O4r_tdj4Zm">
@@ -21173,6 +21220,67 @@
               <node concept="3x8VRR" id="5QWEwg3AiZA" role="2OqNvi" />
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="iHtKXPjUmB">
+    <property role="3GE5qa" value="Statements.Using" />
+    <ref role="1XX52x" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+    <node concept="3EZMnI" id="iHtKXPjUmD" role="2wV5jI">
+      <node concept="3EZMnI" id="6v$Cp0meIXq" role="3EZMnx">
+        <ref role="1ERwB7" node="6v$Cp0meIXd" resolve="RemoveUsing" />
+        <node concept="VPM3Z" id="6v$Cp0meIXs" role="3F10Kt" />
+        <node concept="l2Vlx" id="6v$Cp0meIXv" role="2iSdaV" />
+        <node concept="3F0ifn" id="iHtKXPjUmK" role="3EZMnx">
+          <property role="3F0ifm" value="using" />
+        </node>
+        <node concept="3F0ifn" id="iHtKXPjUmQ" role="3EZMnx">
+          <property role="3F0ifm" value="(" />
+          <node concept="11LMrY" id="iHtKXPmRNF" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="iHtKXPjUn3" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:iHtKXPjUmm" resolve="resource" />
+        </node>
+        <node concept="3F0ifn" id="iHtKXPjUnd" role="3EZMnx">
+          <property role="3F0ifm" value=")" />
+          <node concept="11L4FC" id="iHtKXPmRNH" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="ljvvj" id="iHtKXPxrIg" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="A1WHu" id="6v$Cp0m9g23" role="3vIgyS">
+            <ref role="A1WHt" node="6v$Cp0m2OEi" resolve="InsertUsing" />
+          </node>
+        </node>
+        <node concept="2SqB2G" id="6v$Cp0meIYc" role="2SqHTX">
+          <property role="TrG5h" value="using" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="iHtKXPjUnw" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:iHtKXPjUmo" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="iHtKXPjUmG" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2H$QQEVkW1m">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
+    <node concept="3EZMnI" id="4tlNOobs7hd" role="2wV5jI">
+      <node concept="l2Vlx" id="4tlNOobs7he" role="2iSdaV" />
+      <node concept="PMmxH" id="2H$QQEV9$DZ" role="3EZMnx">
+        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      </node>
+      <node concept="3F1sOY" id="2H$QQEVqVMB" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:2H$QQEVtErT" resolve="reference" />
+      </node>
+      <node concept="3F0ifn" id="4tlNOobs7it" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="4tlNOobAZFd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
     </node>
@@ -21250,60 +21358,126 @@
       </node>
     </node>
   </node>
-  <node concept="PKFIW" id="p4z1jPbmlc">
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingDirectives" />
-    <ref role="1XX52x" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
-    <node concept="3F2HdR" id="p4z1jPms9B" role="2wV5jI">
-      <ref role="1NtTu8" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
-      <ref role="APP_o" node="2H$QQET29s8" resolve="DeleteUsingDirective" />
-      <node concept="2iRkQZ" id="p4z1jPms9D" role="2czzBx" />
-      <node concept="pkWqt" id="p4z1jPmB6p" role="pqm2j">
-        <node concept="3clFbS" id="p4z1jPmB6q" role="2VODD2">
-          <node concept="3clFbF" id="p4z1jPmB8K" role="3cqZAp">
-            <node concept="2OqwBi" id="p4z1jPmFaC" role="3clFbG">
-              <node concept="2OqwBi" id="p4z1jPmBy7" role="2Oq$k0">
-                <node concept="pncrf" id="p4z1jPmB8J" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="p4z1jPmBVu" role="2OqNvi">
-                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+  <node concept="1h_SRR" id="5e5Epz9BuNi">
+    <property role="3GE5qa" value="Statements.Yield" />
+    <property role="TrG5h" value="RemoveYield" />
+    <ref role="1h_SK9" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
+    <node concept="1hA7zw" id="5e5Epz9BuNj" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove yield" />
+      <node concept="1hAIg9" id="5e5Epz9BuNk" role="1hA7z_">
+        <node concept="3clFbS" id="5e5Epz9BuNl" role="2VODD2">
+          <node concept="3clFbJ" id="5e5Epz9BuPE" role="3cqZAp">
+            <node concept="2OqwBi" id="5e5Epz9Bv0X" role="3clFbw">
+              <node concept="0IXxy" id="5e5Epz9BuQ3" role="2Oq$k0" />
+              <node concept="2xy62i" id="5e5Epz9Bx67" role="2OqNvi">
+                <node concept="1Q80Hx" id="5e5Epz9Bx6T" role="2xHN3q" />
+                <node concept="2TlHUq" id="5e5Epz9Mzr3" role="3a7HXU">
+                  <ref role="2TlMyj" node="5e5Epz9BuNh" resolve="yield" />
                 </node>
               </node>
-              <node concept="3GX2aA" id="p4z1jPmLd9" role="2OqNvi" />
+            </node>
+            <node concept="3clFbS" id="5e5Epz9BuPG" role="3clFbx">
+              <node concept="3cpWs6" id="5e5Epz9Bxax" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="5e5Epz9BxdQ" role="3cqZAp">
+            <node concept="2OqwBi" id="5e5Epz9BxoZ" role="3clFbG">
+              <node concept="0IXxy" id="5e5Epz9BxdP" role="2Oq$k0" />
+              <node concept="1P9Npp" id="5e5Epz9BxOL" role="2OqNvi">
+                <node concept="2OqwBi" id="5e5Epz9By0k" role="1P9ThW">
+                  <node concept="0IXxy" id="5e5Epz9BxOP" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5e5Epz9Byr8" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:5e5Epz9BuN0" resolve="statement" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
       </node>
     </node>
   </node>
-  <node concept="3ICUPy" id="p4z1jOxeUl">
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="aqKnT" to="80bi:27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    <node concept="22hDWj" id="p4z1jOxeUU" role="22hAXT" />
-    <node concept="1Qtc8_" id="p4z1jOxeVw" role="IW6Ez">
-      <node concept="3eGOoe" id="p4z1jOxeVQ" role="1Qtc8$" />
-      <node concept="3PzhKR" id="p4z1jOxeZ4" role="1Qtc8A">
-        <ref role="3PzhKQ" to="80bi:27q4jmdWXhm" resolve="referencedType" />
+  <node concept="3ICUPy" id="1XmGakPdCcn">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="1Qtc8_" id="1XmGakPdCTK" role="IW6Ez">
+      <node concept="aenpk" id="1XmGakPyjZS" role="1Qtc8A">
+        <node concept="mvV$s" id="1XmGakPsIwl" role="aenpr">
+          <node concept="A1WHu" id="1XmGakPsIyw" role="A14EM">
+            <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
+          </node>
+          <node concept="mvVNg" id="1XmGakPsIyy" role="mvV$0">
+            <node concept="3clFbS" id="1XmGakPsIyz" role="2VODD2">
+              <node concept="3clFbF" id="1XmGakPsIBg" role="3cqZAp">
+                <node concept="2OqwBi" id="1XmGakPsIQk" role="3clFbG">
+                  <node concept="7Obwk" id="1XmGakPsIBf" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="1XmGakPsJja" role="2OqNvi">
+                    <node concept="1xMEDy" id="1XmGakPsJjc" role="1xVPHs">
+                      <node concept="chp4Y" id="1XmGakPsJlI" role="ri$Ld">
+                        <ref role="cht4Q" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="1XmGakPyk0K" role="aenpu">
+          <node concept="3clFbS" id="1XmGakPyk0L" role="2VODD2">
+            <node concept="3clFbF" id="1XmGakPykgT" role="3cqZAp">
+              <node concept="2OqwBi" id="1XmGakPyrkp" role="3clFbG">
+                <node concept="2OqwBi" id="1XmGakPykFi" role="2Oq$k0">
+                  <node concept="7Obwk" id="1XmGakPykgS" role="2Oq$k0" />
+                  <node concept="2TvwIu" id="1XmGakPyl8H" role="2OqNvi" />
+                </node>
+                <node concept="1v1jN8" id="1XmGakPyu_9" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="2H$QQEVkW1m">
-    <property role="3GE5qa" value="Namespace" />
-    <ref role="1XX52x" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
-    <node concept="3EZMnI" id="4tlNOobs7hd" role="2wV5jI">
-      <node concept="l2Vlx" id="4tlNOobs7he" role="2iSdaV" />
-      <node concept="PMmxH" id="2H$QQEV9$DZ" role="3EZMnx">
-        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      <node concept="3c8P5G" id="iSyfcuX8bg" role="1Qtc8A">
+        <node concept="2kknPJ" id="iSyfcuX8fF" role="3c8P5H">
+          <ref role="2ZyFGn" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+        </node>
+        <node concept="3c8PGw" id="iSyfcuX8bj" role="3c8PHt">
+          <node concept="3clFbS" id="iSyfcuX8bl" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcuZZkQ" role="3cqZAp">
+              <node concept="37vLTI" id="iSyfcv02Kz" role="3clFbG">
+                <node concept="2OqwBi" id="iSyfcv02W$" role="37vLTx">
+                  <node concept="7Obwk" id="iSyfcv02Li" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcv03bD" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iSyfcuZZwd" role="37vLTJ">
+                  <node concept="3c8USq" id="iSyfcuZZkP" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcuZZJ9" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="iSyfcv03n3" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcv03ww" role="3clFbG">
+                <node concept="7Obwk" id="iSyfcw2bX7" role="2Oq$k0" />
+                <node concept="1P9Npp" id="iSyfcv03LP" role="2OqNvi">
+                  <node concept="3c8USq" id="iSyfcv03MP" role="1P9ThW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
-      <node concept="3F1sOY" id="2H$QQEVqVMB" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:2H$QQEVtErT" resolve="reference" />
-      </node>
-      <node concept="3F0ifn" id="4tlNOobs7it" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="4tlNOobAZFd" role="3F10Kt">
-          <property role="VOm3f" value="true" />
+      <node concept="3cWJ9i" id="1XmGakPdCTO" role="1Qtc8$">
+        <node concept="CtIbL" id="1XmGakPdCTQ" role="CtIbM">
+          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
         </node>
       </node>
     </node>
+    <node concept="22hDWj" id="1XmGakPmOWV" role="22hAXT" />
   </node>
   <node concept="PKFIW" id="2H$QQEV9$DW">
     <property role="TrG5h" value="UsingKeyword" />
@@ -21316,193 +21490,47 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="2H$QQEUtQI6">
-    <property role="3GE5qa" value="Namespace" />
-    <ref role="1XX52x" to="80bi:2H$QQEUtQI0" resolve="UsingAliasDirective" />
-    <node concept="3EZMnI" id="2H$QQEUtQI8" role="2wV5jI">
-      <node concept="PMmxH" id="2H$QQEV9$ET" role="3EZMnx">
-        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
-      </node>
-      <node concept="3F0A7n" id="2H$QQEUtQIl" role="3EZMnx">
-        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-      </node>
-      <node concept="3F0ifn" id="2H$QQEUtQIt" role="3EZMnx">
-        <property role="3F0ifm" value="=" />
-      </node>
-      <node concept="3F1sOY" id="2H$QQEVkWIa" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:2H$QQEVtErW" resolve="reference" />
-      </node>
-      <node concept="3F0ifn" id="2H$QQEUtQIN" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="2H$QQEUYLQC" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="l2Vlx" id="2H$QQEUtQIb" role="2iSdaV" />
-      <node concept="A1WHr" id="2H$QQEUYLQG" role="3vIgyS">
-        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="5xnAHgZa2GI">
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclarationStatement" />
-    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
-      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="declaration" />
-      </node>
-      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="24kQdi" id="iHtKXPjUmB">
-    <property role="3GE5qa" value="Statements.Using" />
-    <ref role="1XX52x" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-    <node concept="3EZMnI" id="iHtKXPjUmD" role="2wV5jI">
-      <node concept="3EZMnI" id="6v$Cp0meIXq" role="3EZMnx">
-        <ref role="1ERwB7" node="6v$Cp0meIXd" resolve="RemoveUsing" />
-        <node concept="VPM3Z" id="6v$Cp0meIXs" role="3F10Kt" />
-        <node concept="l2Vlx" id="6v$Cp0meIXv" role="2iSdaV" />
-        <node concept="3F0ifn" id="iHtKXPjUmK" role="3EZMnx">
-          <property role="3F0ifm" value="using" />
-        </node>
-        <node concept="3F0ifn" id="iHtKXPjUmQ" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <node concept="11LMrY" id="iHtKXPmRNF" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="3F1sOY" id="iHtKXPjUn3" role="3EZMnx">
-          <ref role="1NtTu8" to="80bi:iHtKXPjUmm" resolve="resource" />
-        </node>
-        <node concept="3F0ifn" id="iHtKXPjUnd" role="3EZMnx">
-          <property role="3F0ifm" value=")" />
-          <node concept="11L4FC" id="iHtKXPmRNH" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="ljvvj" id="iHtKXPxrIg" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="A1WHu" id="6v$Cp0m9g23" role="3vIgyS">
-            <ref role="A1WHt" node="6v$Cp0m2OEi" resolve="InsertUsing" />
-          </node>
-        </node>
-        <node concept="2SqB2G" id="6v$Cp0meIYc" role="2SqHTX">
-          <property role="TrG5h" value="using" />
-        </node>
-      </node>
-      <node concept="3F1sOY" id="iHtKXPjUnw" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:iHtKXPjUmo" resolve="statement" />
-      </node>
-      <node concept="l2Vlx" id="iHtKXPjUmG" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="24kQdi" id="iHtKXPmS6n">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:iHtKXPmS6d" resolve="LocalVariableDeclaration" />
-    <node concept="3EZMnI" id="iHtKXPmS6p" role="2wV5jI">
-      <node concept="PMmxH" id="iHtKXPmS6w" role="3EZMnx">
-        <ref role="PMmxG" node="5oHFRyIxpOR" resolve="HaveTypeComponent" />
-      </node>
-      <node concept="3F2HdR" id="iHtKXPmS6_" role="3EZMnx">
-        <property role="2czwfO" value="," />
-        <ref role="1NtTu8" to="80bi:iHtKXPmS6l" resolve="variables" />
-        <node concept="l2Vlx" id="iHtKXPmS6B" role="2czzBx" />
-      </node>
-      <node concept="l2Vlx" id="iHtKXPmS6s" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="3ICUPy" id="6v$Cp0m2OEi">
-    <property role="3GE5qa" value="Statements.Using" />
-    <ref role="aqKnT" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-    <node concept="22hDWg" id="6v$Cp0m2OEj" role="22hAXT">
-      <property role="TrG5h" value="InsertUsing" />
-    </node>
-    <node concept="1Qtc8_" id="6v$Cp0m2OEl" role="IW6Ez">
-      <node concept="3cWJ9i" id="6v$Cp0m2OEs" role="1Qtc8$">
-        <node concept="CtIbL" id="6v$Cp0m2OEu" role="CtIbM">
-          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
-        </node>
-      </node>
-      <node concept="3c8P5G" id="6v$Cp0m6un2" role="1Qtc8A">
-        <node concept="2kknPJ" id="6v$Cp0m6unq" role="3c8P5H">
-          <ref role="2ZyFGn" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-        </node>
-        <node concept="3c8PGw" id="6v$Cp0m6un4" role="3c8PHt">
-          <node concept="3clFbS" id="6v$Cp0m6un5" role="2VODD2">
-            <node concept="3clFbF" id="6v$Cp0m6upF" role="3cqZAp">
-              <node concept="37vLTI" id="6v$Cp0m6wDh" role="3clFbG">
-                <node concept="2OqwBi" id="6v$Cp0m6u_q" role="37vLTJ">
-                  <node concept="3c8USq" id="6v$Cp0m6uqs" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6v$Cp0m6wrQ" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="6v$Cp0mbYLf" role="37vLTx">
-                  <node concept="2OqwBi" id="6v$Cp0m6xe6" role="2Oq$k0">
-                    <node concept="7Obwk" id="6v$Cp0m6x26" role="2Oq$k0" />
-                    <node concept="3TrEf2" id="6v$Cp0m6xDj" role="2OqNvi">
-                      <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
-                    </node>
-                  </node>
-                  <node concept="1$rogu" id="6v$Cp0mbZ0A" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="6v$Cp0m6xLb" role="3cqZAp">
-              <node concept="2OqwBi" id="6v$Cp0m6yIt" role="3clFbG">
-                <node concept="2OqwBi" id="6v$Cp0m6xWw" role="2Oq$k0">
-                  <node concept="7Obwk" id="6v$Cp0m6xLa" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6v$Cp0m6ymj" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
-                  </node>
-                </node>
-                <node concept="1P9Npp" id="6v$Cp0m6z9e" role="2OqNvi">
-                  <node concept="3c8USq" id="6v$Cp0m6za6" role="1P9ThW" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1h_SRR" id="6v$Cp0meIXd">
-    <property role="3GE5qa" value="Statements.Using" />
-    <property role="TrG5h" value="RemoveUsing" />
-    <ref role="1h_SK9" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-    <node concept="1hA7zw" id="6v$Cp0meIYf" role="1h_SK8">
+  <node concept="1h_SRR" id="7HmXimQhemy">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="RemoveAsync" />
+    <ref role="1h_SK9" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="1hA7zw" id="7HmXimQhemz" role="1h_SK8">
       <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="6v$Cp0meIYg" role="1hA7z_">
-        <node concept="3clFbS" id="6v$Cp0meIYh" role="2VODD2">
-          <node concept="3clFbJ" id="6v$Cp0meJ0l" role="3cqZAp">
-            <node concept="2OqwBi" id="6v$Cp0meJbF" role="3clFbw">
-              <node concept="0IXxy" id="6v$Cp0meJ0L" role="2Oq$k0" />
-              <node concept="2xy62i" id="6v$Cp0meJCJ" role="2OqNvi">
-                <node concept="1Q80Hx" id="6v$Cp0meJDz" role="2xHN3q" />
-                <node concept="2TlHUq" id="6v$Cp0meJED" role="3a7HXU">
-                  <ref role="2TlMyj" node="6v$Cp0meIYc" resolve="using" />
+      <property role="1hHO97" value="remove async modifier" />
+      <node concept="1hAIg9" id="7HmXimQhem$" role="1hA7z_">
+        <node concept="3clFbS" id="7HmXimQhem_" role="2VODD2">
+          <node concept="3clFbJ" id="7HmXimQhhSC" role="3cqZAp">
+            <node concept="3clFbS" id="7HmXimQhhT0" role="3clFbx">
+              <node concept="3cpWs6" id="7HmXimQhhWx" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="7HmXimQhfN5" role="3clFbw">
+              <node concept="0IXxy" id="7HmXimQhepk" role="2Oq$k0" />
+              <node concept="2xy62i" id="7HmXimQhgjP" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQhgk$" role="2xHN3q" />
+                <node concept="2TlHUq" id="7HmXimQhhgS" role="3a7HXU">
+                  <ref role="2TlMyj" node="7HmXimQhgZA" resolve="async" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="6v$Cp0meJ0n" role="3clFbx">
-              <node concept="3cpWs6" id="6v$Cp0meJHP" role="3cqZAp" />
+          </node>
+          <node concept="3clFbF" id="7HmXimQhhZQ" role="3cqZAp">
+            <node concept="37vLTI" id="7HmXimQhlyi" role="3clFbG">
+              <node concept="3clFbT" id="7HmXimQhlyK" role="37vLTx" />
+              <node concept="2OqwBi" id="7HmXimQhibL" role="37vLTJ">
+                <node concept="0IXxy" id="7HmXimQhhZP" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7HmXimQhiES" role="2OqNvi">
+                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                </node>
+              </node>
             </node>
           </node>
-          <node concept="3clFbF" id="6v$Cp0meJMN" role="3cqZAp">
-            <node concept="2OqwBi" id="6v$Cp0meJPg" role="3clFbG">
-              <node concept="0IXxy" id="6v$Cp0meJMM" role="2Oq$k0" />
-              <node concept="1P9Npp" id="6v$Cp0meJSl" role="2OqNvi">
-                <node concept="2OqwBi" id="6v$Cp0meJUr" role="1P9ThW">
-                  <node concept="0IXxy" id="6v$Cp0meJSU" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6v$Cp0meK9V" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
-                  </node>
+          <node concept="3clFbF" id="7HmXimQpfUQ" role="3cqZAp">
+            <node concept="2OqwBi" id="7HmXimQpg75" role="3clFbG">
+              <node concept="0IXxy" id="7HmXimQpfUP" role="2Oq$k0" />
+              <node concept="1OKiuA" id="7HmXimQpgC3" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQpgCH" role="lBI5i" />
+                <node concept="2B6iha" id="7HmXimQpgLt" role="lGT1i">
+                  <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
                 </node>
               </node>
             </node>
@@ -21517,6 +21545,78 @@
     <node concept="3F0A7n" id="7HmXimPhQcK" role="2wV5jI">
       <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
     </node>
+  </node>
+  <node concept="1h_SRR" id="5xnAHh0emj_">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="RemoveAwait" />
+    <ref role="1h_SK9" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="1hA7zw" id="5xnAHh0emjA" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="5xnAHh0emjB" role="1hA7z_">
+        <node concept="3clFbS" id="5xnAHh0emjC" role="2VODD2">
+          <node concept="3clFbJ" id="5xnAHh0hi42" role="3cqZAp">
+            <node concept="3clFbS" id="5xnAHh0hi44" role="3clFbx">
+              <node concept="3cpWs6" id="5xnAHh0hi_R" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="5xnAHh0hihq" role="3clFbw">
+              <node concept="0IXxy" id="5xnAHh0hi4W" role="2Oq$k0" />
+              <node concept="2xy62i" id="5xnAHh0hiy0" role="2OqNvi">
+                <node concept="1Q80Hx" id="5xnAHh0hiyA" role="2xHN3q" />
+                <node concept="2TlHUq" id="5xnAHh0k20P" role="3a7HXU">
+                  <ref role="2TlMyj" node="5xnAHh0uXTF" resolve="operator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5xnAHh0emme" role="3cqZAp">
+            <node concept="2OqwBi" id="5xnAHh0emyK" role="3clFbG">
+              <node concept="0IXxy" id="5xnAHh0emmd" role="2Oq$k0" />
+              <node concept="1P9Npp" id="5xnAHh0enmR" role="2OqNvi">
+                <node concept="2OqwBi" id="5xnAHh0en$J" role="1P9ThW">
+                  <node concept="0IXxy" id="5xnAHh0ennF" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5xnAHh0enRd" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:5xnAHgZZgtR" resolve="task" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="iSyfcuX8Tw">
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <ref role="aqKnT" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+    <node concept="3N5dw7" id="iSyfcuX9_3" role="3ft7WO">
+      <node concept="3N5aqt" id="iSyfcuX9_4" role="3Na0zg">
+        <node concept="3clFbS" id="iSyfcuX9_5" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcuXabA" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcuX9Zk" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcuX9Zm" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                <node concept="2pIpSj" id="iSyfcuXa4o" role="2pJxcM">
+                  <ref role="2pIpSl" to="80bi:7yZ_CF2xDX3" resolve="type" />
+                  <node concept="2pJPED" id="iSyfcuXa5G" role="28nt2d">
+                    <ref role="2pJxaS" to="80bi:5VT83U$LMPZ" resolve="Type" />
+                    <node concept="2pIpSj" id="iSyfcuXa6z" role="2pJxcM">
+                      <ref role="2pIpSl" to="80bi:5VT83U$LPp0" resolve="nonArrayType" />
+                      <node concept="36biLy" id="iSyfcuXa70" role="28nt2d">
+                        <node concept="3N4pyC" id="iSyfcuXa8q" role="36biLW" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2kknPJ" id="iSyfcuX9_n" role="2klrvf">
+        <ref role="2ZyFGn" to="80bi:5_5a0KJX$kh" resolve="INonArrayType" />
+      </node>
+    </node>
+    <node concept="22hDWj" id="iSyfcuX8Ut" role="22hAXT" />
   </node>
   <node concept="3ICUPy" id="7HmXimR0WHi">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -21584,6 +21684,50 @@
     <node concept="22hDWg" id="7HmXimR11wF" role="22hAXT">
       <property role="TrG5h" value="AddAsync" />
     </node>
+  </node>
+  <node concept="1h_SRR" id="6t5IfhVaxwT">
+    <property role="3GE5qa" value="Statements" />
+    <property role="TrG5h" value="RemoveLock" />
+    <ref role="1h_SK9" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
+    <node concept="1hA7zw" id="6t5IfhVaxyM" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="6t5IfhVaxyN" role="1hA7z_">
+        <node concept="3clFbS" id="6t5IfhVaxyO" role="2VODD2">
+          <node concept="3clFbJ" id="6t5IfhVa$XF" role="3cqZAp">
+            <node concept="3clFbS" id="6t5IfhVa$Y3" role="3clFbx">
+              <node concept="3cpWs6" id="6t5IfhVa_2q" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="6t5IfhVaxNo" role="3clFbw">
+              <node concept="0IXxy" id="6t5IfhVaxCp" role="2Oq$k0" />
+              <node concept="2xy62i" id="6t5IfhVazSW" role="2OqNvi">
+                <node concept="1Q80Hx" id="6t5IfhVazUu" role="2xHN3q" />
+                <node concept="2TlHUq" id="6t5IfhVa$jA" role="3a7HXU">
+                  <ref role="2TlMyj" node="6t5IfhVa$ha" resolve="lock" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6t5IfhVa_7w" role="3cqZAp">
+            <node concept="2OqwBi" id="6t5IfhVa_iD" role="3clFbG">
+              <node concept="0IXxy" id="6t5IfhVa_7v" role="2Oq$k0" />
+              <node concept="1P9Npp" id="6t5IfhVa_HJ" role="2OqNvi">
+                <node concept="2OqwBi" id="6t5IfhVa_Jk" role="1P9ThW">
+                  <node concept="0IXxy" id="6t5IfhVa_IK" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6t5IfhVaAbH" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:6t5IfhV7vAf" resolve="statement" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="6u44Y77QZVp">
+    <property role="3GE5qa" value="Generics" />
+    <ref role="aqKnT" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+    <node concept="22hDWj" id="6u44Y77QZVq" role="22hAXT" />
   </node>
   <node concept="24kQdi" id="7HmXimPhNct">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -21681,79 +21825,22 @@
       </node>
     </node>
   </node>
-  <node concept="1h_SRR" id="5xnAHh0emj_">
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <property role="TrG5h" value="RemoveAwait" />
-    <ref role="1h_SK9" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
-    <node concept="1hA7zw" id="5xnAHh0emjA" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="5xnAHh0emjB" role="1hA7z_">
-        <node concept="3clFbS" id="5xnAHh0emjC" role="2VODD2">
-          <node concept="3clFbJ" id="5xnAHh0hi42" role="3cqZAp">
-            <node concept="3clFbS" id="5xnAHh0hi44" role="3clFbx">
-              <node concept="3cpWs6" id="5xnAHh0hi_R" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="5xnAHh0hihq" role="3clFbw">
-              <node concept="0IXxy" id="5xnAHh0hi4W" role="2Oq$k0" />
-              <node concept="2xy62i" id="5xnAHh0hiy0" role="2OqNvi">
-                <node concept="1Q80Hx" id="5xnAHh0hiyA" role="2xHN3q" />
-                <node concept="2TlHUq" id="5xnAHh0k20P" role="3a7HXU">
-                  <ref role="2TlMyj" node="5xnAHh0uXTF" resolve="operator" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="5xnAHh0emme" role="3cqZAp">
-            <node concept="2OqwBi" id="5xnAHh0emyK" role="3clFbG">
-              <node concept="0IXxy" id="5xnAHh0emmd" role="2Oq$k0" />
-              <node concept="1P9Npp" id="5xnAHh0enmR" role="2OqNvi">
-                <node concept="2OqwBi" id="5xnAHh0en$J" role="1P9ThW">
-                  <node concept="0IXxy" id="5xnAHh0ennF" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5xnAHh0enRd" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:5xnAHgZZgtR" resolve="task" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="7HmXimPhQt3">
+  <node concept="22mcaB" id="iSyfcuUaO9">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="1XX52x" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
-    <node concept="3F2HdR" id="7HmXimPhQtc" role="2wV5jI">
-      <property role="2czwfO" value="," />
-      <ref role="1NtTu8" to="80bi:7HmXimPhQc_" resolve="parameters" />
-      <node concept="l2Vlx" id="7HmXimPhQte" role="2czzBx" />
-      <node concept="3F0ifn" id="7HmXimPwdwN" role="2czzBI">
-        <node concept="VPxyj" id="iSyfcvyupz" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="22mcaB" id="iSyfcuX8Tw">
-    <property role="3GE5qa" value="Class / Struct.Parameters" />
-    <ref role="aqKnT" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-    <node concept="3N5dw7" id="iSyfcuX9_3" role="3ft7WO">
-      <node concept="3N5aqt" id="iSyfcuX9_4" role="3Na0zg">
-        <node concept="3clFbS" id="iSyfcuX9_5" role="2VODD2">
-          <node concept="3clFbF" id="iSyfcuXabA" role="3cqZAp">
-            <node concept="2pJPEk" id="iSyfcuX9Zk" role="3clFbG">
-              <node concept="2pJPED" id="iSyfcuX9Zm" role="2pJPEn">
-                <ref role="2pJxaS" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-                <node concept="2pIpSj" id="iSyfcuXa4o" role="2pJxcM">
-                  <ref role="2pIpSl" to="80bi:7yZ_CF2xDX3" resolve="type" />
-                  <node concept="2pJPED" id="iSyfcuXa5G" role="28nt2d">
-                    <ref role="2pJxaS" to="80bi:5VT83U$LMPZ" resolve="Type" />
-                    <node concept="2pIpSj" id="iSyfcuXa6z" role="2pJxcM">
-                      <ref role="2pIpSl" to="80bi:5VT83U$LPp0" resolve="nonArrayType" />
-                      <node concept="36biLy" id="iSyfcuXa70" role="28nt2d">
-                        <node concept="3N4pyC" id="iSyfcuXa8q" role="36biLW" />
-                      </node>
-                    </node>
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="22hDWj" id="iSyfcuUaP6" role="22hAXT" />
+    <node concept="3eGOop" id="iSyfcvd_1$" role="3ft7WO">
+      <node concept="16NL3D" id="iSyfcvd_6u" role="upBLP">
+        <node concept="16Na2f" id="iSyfcvd_6v" role="16NL3A">
+          <node concept="3clFbS" id="iSyfcvd_6w" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAR_" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcvdDfT" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdBzG" role="2Oq$k0" />
+                <node concept="liA8E" id="iSyfcvdEfR" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                  <node concept="10M0yZ" id="iSyfcvdBgr" role="37wK5m">
+                    <ref role="3cqZAo" node="5cm0BoTKIaF" resolve="identifier" />
+                    <ref role="1PxDUh" node="6H78krhSzlS" resolve="SubstitutionUtils" />
                   </node>
                 </node>
               </node>
@@ -21761,11 +21848,45 @@
           </node>
         </node>
       </node>
-      <node concept="2kknPJ" id="iSyfcuX9_n" role="2klrvf">
-        <ref role="2ZyFGn" to="80bi:5_5a0KJX$kh" resolve="INonArrayType" />
+      <node concept="16NfWO" id="iSyfcvdEGh" role="upBLP">
+        <node concept="uGdhv" id="iSyfcvd_WF" role="16NeZM">
+          <node concept="3clFbS" id="iSyfcvd_WH" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAdP" role="3cqZAp">
+              <node concept="3K4zz7" id="iSyfcvdAdQ" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdAdR" role="3K4E3e" />
+                <node concept="Xl_RD" id="iSyfcvdAdS" role="3K4GZi">
+                  <property role="Xl_RC" value="&lt;name&gt;" />
+                </node>
+                <node concept="2OqwBi" id="iSyfcvdAdT" role="3K4Cdx">
+                  <node concept="ub8z3" id="iSyfcvdAdU" role="2Oq$k0" />
+                  <node concept="17RvpY" id="iSyfcvdAdV" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NL0t" id="iSyfcvd_VB" role="upBLP">
+        <node concept="2h3Zct" id="iSyfcvdERW" role="16NL0q">
+          <property role="2h4Kg1" value="add implicit parameter" />
+        </node>
+      </node>
+      <node concept="ucgPf" id="iSyfcvd_1_" role="3aKz83">
+        <node concept="3clFbS" id="iSyfcvd_1A" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcvdAwU" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcvdA$B" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcvdA$D" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                <node concept="2pJxcG" id="iSyfcvdAJg" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="ub8z3" id="iSyfcvdAN7" role="28ntcv" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
-    <node concept="22hDWj" id="iSyfcuX8Ut" role="22hAXT" />
   </node>
   <node concept="22mcaB" id="7HmXimPUxXM">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -21903,302 +22024,122 @@
       </node>
     </node>
   </node>
-  <node concept="1h_SRR" id="7HmXimQhemy">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <property role="TrG5h" value="RemoveAsync" />
-    <ref role="1h_SK9" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
-    <node concept="1hA7zw" id="7HmXimQhemz" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <property role="1hHO97" value="remove async modifier" />
-      <node concept="1hAIg9" id="7HmXimQhem$" role="1hA7z_">
-        <node concept="3clFbS" id="7HmXimQhem_" role="2VODD2">
-          <node concept="3clFbJ" id="7HmXimQhhSC" role="3cqZAp">
-            <node concept="3clFbS" id="7HmXimQhhT0" role="3clFbx">
-              <node concept="3cpWs6" id="7HmXimQhhWx" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="7HmXimQhfN5" role="3clFbw">
-              <node concept="0IXxy" id="7HmXimQhepk" role="2Oq$k0" />
-              <node concept="2xy62i" id="7HmXimQhgjP" role="2OqNvi">
-                <node concept="1Q80Hx" id="7HmXimQhgk$" role="2xHN3q" />
-                <node concept="2TlHUq" id="7HmXimQhhgS" role="3a7HXU">
-                  <ref role="2TlMyj" node="7HmXimQhgZA" resolve="async" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="7HmXimQhhZQ" role="3cqZAp">
-            <node concept="37vLTI" id="7HmXimQhlyi" role="3clFbG">
-              <node concept="3clFbT" id="7HmXimQhlyK" role="37vLTx" />
-              <node concept="2OqwBi" id="7HmXimQhibL" role="37vLTJ">
-                <node concept="0IXxy" id="7HmXimQhhZP" role="2Oq$k0" />
-                <node concept="3TrcHB" id="7HmXimQhiES" role="2OqNvi">
-                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="7HmXimQpfUQ" role="3cqZAp">
-            <node concept="2OqwBi" id="7HmXimQpg75" role="3clFbG">
-              <node concept="0IXxy" id="7HmXimQpfUP" role="2Oq$k0" />
-              <node concept="1OKiuA" id="7HmXimQpgC3" role="2OqNvi">
-                <node concept="1Q80Hx" id="7HmXimQpgCH" role="lBI5i" />
-                <node concept="2B6iha" id="7HmXimQpgLt" role="lGT1i">
-                  <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
-                </node>
-              </node>
-            </node>
-          </node>
+  <node concept="3ICUPy" id="6v$Cp0m2OEi">
+    <property role="3GE5qa" value="Statements.Using" />
+    <ref role="aqKnT" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+    <node concept="22hDWg" id="6v$Cp0m2OEj" role="22hAXT">
+      <property role="TrG5h" value="InsertUsing" />
+    </node>
+    <node concept="1Qtc8_" id="6v$Cp0m2OEl" role="IW6Ez">
+      <node concept="3cWJ9i" id="6v$Cp0m2OEs" role="1Qtc8$">
+        <node concept="CtIbL" id="6v$Cp0m2OEu" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
         </node>
       </node>
-    </node>
-  </node>
-  <node concept="22mcaB" id="iSyfcuUaO9">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-    <node concept="22hDWj" id="iSyfcuUaP6" role="22hAXT" />
-    <node concept="3eGOop" id="iSyfcvd_1$" role="3ft7WO">
-      <node concept="16NL3D" id="iSyfcvd_6u" role="upBLP">
-        <node concept="16Na2f" id="iSyfcvd_6v" role="16NL3A">
-          <node concept="3clFbS" id="iSyfcvd_6w" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcvdAR_" role="3cqZAp">
-              <node concept="2OqwBi" id="iSyfcvdDfT" role="3clFbG">
-                <node concept="ub8z3" id="iSyfcvdBzG" role="2Oq$k0" />
-                <node concept="liA8E" id="iSyfcvdEfR" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-                  <node concept="10M0yZ" id="iSyfcvdBgr" role="37wK5m">
-                    <ref role="3cqZAo" node="5cm0BoTKIaF" resolve="identifier" />
-                    <ref role="1PxDUh" node="6H78krhSzlS" resolve="SubstitutionUtils" />
+      <node concept="3c8P5G" id="6v$Cp0m6un2" role="1Qtc8A">
+        <node concept="2kknPJ" id="6v$Cp0m6unq" role="3c8P5H">
+          <ref role="2ZyFGn" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+        </node>
+        <node concept="3c8PGw" id="6v$Cp0m6un4" role="3c8PHt">
+          <node concept="3clFbS" id="6v$Cp0m6un5" role="2VODD2">
+            <node concept="3clFbF" id="6v$Cp0m6upF" role="3cqZAp">
+              <node concept="37vLTI" id="6v$Cp0m6wDh" role="3clFbG">
+                <node concept="2OqwBi" id="6v$Cp0m6u_q" role="37vLTJ">
+                  <node concept="3c8USq" id="6v$Cp0m6uqs" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6v$Cp0m6wrQ" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="16NfWO" id="iSyfcvdEGh" role="upBLP">
-        <node concept="uGdhv" id="iSyfcvd_WF" role="16NeZM">
-          <node concept="3clFbS" id="iSyfcvd_WH" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcvdAdP" role="3cqZAp">
-              <node concept="3K4zz7" id="iSyfcvdAdQ" role="3clFbG">
-                <node concept="ub8z3" id="iSyfcvdAdR" role="3K4E3e" />
-                <node concept="Xl_RD" id="iSyfcvdAdS" role="3K4GZi">
-                  <property role="Xl_RC" value="&lt;name&gt;" />
-                </node>
-                <node concept="2OqwBi" id="iSyfcvdAdT" role="3K4Cdx">
-                  <node concept="ub8z3" id="iSyfcvdAdU" role="2Oq$k0" />
-                  <node concept="17RvpY" id="iSyfcvdAdV" role="2OqNvi" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="16NL0t" id="iSyfcvd_VB" role="upBLP">
-        <node concept="2h3Zct" id="iSyfcvdERW" role="16NL0q">
-          <property role="2h4Kg1" value="add implicit parameter" />
-        </node>
-      </node>
-      <node concept="ucgPf" id="iSyfcvd_1_" role="3aKz83">
-        <node concept="3clFbS" id="iSyfcvd_1A" role="2VODD2">
-          <node concept="3clFbF" id="iSyfcvdAwU" role="3cqZAp">
-            <node concept="2pJPEk" id="iSyfcvdA$B" role="3clFbG">
-              <node concept="2pJPED" id="iSyfcvdA$D" role="2pJPEn">
-                <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-                <node concept="2pJxcG" id="iSyfcvdAJg" role="2pJxcM">
-                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
-                  <node concept="ub8z3" id="iSyfcvdAN7" role="28ntcv" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="3ICUPy" id="1XmGakPdCcn">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-    <node concept="1Qtc8_" id="1XmGakPdCTK" role="IW6Ez">
-      <node concept="aenpk" id="1XmGakPyjZS" role="1Qtc8A">
-        <node concept="mvV$s" id="1XmGakPsIwl" role="aenpr">
-          <node concept="A1WHu" id="1XmGakPsIyw" role="A14EM">
-            <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
-          </node>
-          <node concept="mvVNg" id="1XmGakPsIyy" role="mvV$0">
-            <node concept="3clFbS" id="1XmGakPsIyz" role="2VODD2">
-              <node concept="3clFbF" id="1XmGakPsIBg" role="3cqZAp">
-                <node concept="2OqwBi" id="1XmGakPsIQk" role="3clFbG">
-                  <node concept="7Obwk" id="1XmGakPsIBf" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="1XmGakPsJja" role="2OqNvi">
-                    <node concept="1xMEDy" id="1XmGakPsJjc" role="1xVPHs">
-                      <node concept="chp4Y" id="1XmGakPsJlI" role="ri$Ld">
-                        <ref role="cht4Q" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
-                      </node>
+                <node concept="2OqwBi" id="6v$Cp0mbYLf" role="37vLTx">
+                  <node concept="2OqwBi" id="6v$Cp0m6xe6" role="2Oq$k0">
+                    <node concept="7Obwk" id="6v$Cp0m6x26" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="6v$Cp0m6xDj" role="2OqNvi">
+                      <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
                     </node>
                   </node>
+                  <node concept="1$rogu" id="6v$Cp0mbZ0A" role="2OqNvi" />
                 </node>
               </node>
             </node>
-          </node>
-        </node>
-        <node concept="27VH4U" id="1XmGakPyk0K" role="aenpu">
-          <node concept="3clFbS" id="1XmGakPyk0L" role="2VODD2">
-            <node concept="3clFbF" id="1XmGakPykgT" role="3cqZAp">
-              <node concept="2OqwBi" id="1XmGakPyrkp" role="3clFbG">
-                <node concept="2OqwBi" id="1XmGakPykFi" role="2Oq$k0">
-                  <node concept="7Obwk" id="1XmGakPykgS" role="2Oq$k0" />
-                  <node concept="2TvwIu" id="1XmGakPyl8H" role="2OqNvi" />
-                </node>
-                <node concept="1v1jN8" id="1XmGakPyu_9" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3c8P5G" id="iSyfcuX8bg" role="1Qtc8A">
-        <node concept="2kknPJ" id="iSyfcuX8fF" role="3c8P5H">
-          <ref role="2ZyFGn" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-        </node>
-        <node concept="3c8PGw" id="iSyfcuX8bj" role="3c8PHt">
-          <node concept="3clFbS" id="iSyfcuX8bl" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcuZZkQ" role="3cqZAp">
-              <node concept="37vLTI" id="iSyfcv02Kz" role="3clFbG">
-                <node concept="2OqwBi" id="iSyfcv02W$" role="37vLTx">
-                  <node concept="7Obwk" id="iSyfcv02Li" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="iSyfcv03bD" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+            <node concept="3clFbF" id="6v$Cp0m6xLb" role="3cqZAp">
+              <node concept="2OqwBi" id="6v$Cp0m6yIt" role="3clFbG">
+                <node concept="2OqwBi" id="6v$Cp0m6xWw" role="2Oq$k0">
+                  <node concept="7Obwk" id="6v$Cp0m6xLa" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6v$Cp0m6ymj" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="iSyfcuZZwd" role="37vLTJ">
-                  <node concept="3c8USq" id="iSyfcuZZkP" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="iSyfcuZZJ9" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="iSyfcv03n3" role="3cqZAp">
-              <node concept="2OqwBi" id="iSyfcv03ww" role="3clFbG">
-                <node concept="7Obwk" id="iSyfcw2bX7" role="2Oq$k0" />
-                <node concept="1P9Npp" id="iSyfcv03LP" role="2OqNvi">
-                  <node concept="3c8USq" id="iSyfcv03MP" role="1P9ThW" />
+                <node concept="1P9Npp" id="6v$Cp0m6z9e" role="2OqNvi">
+                  <node concept="3c8USq" id="6v$Cp0m6za6" role="1P9ThW" />
                 </node>
               </node>
             </node>
           </node>
-        </node>
-      </node>
-      <node concept="3cWJ9i" id="1XmGakPdCTO" role="1Qtc8$">
-        <node concept="CtIbL" id="1XmGakPdCTQ" role="CtIbM">
-          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
         </node>
       </node>
     </node>
-    <node concept="22hDWj" id="1XmGakPmOWV" role="22hAXT" />
   </node>
-  <node concept="24kQdi" id="5xnAHgZZgy7">
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
-    <node concept="3EZMnI" id="5xnAHgZZg_B" role="2wV5jI">
-      <node concept="l2Vlx" id="5xnAHgZZg_C" role="2iSdaV" />
-      <node concept="3F0ifn" id="5xnAHgZZgBa" role="3EZMnx">
-        <property role="3F0ifm" value="await" />
-        <ref role="1ERwB7" node="5xnAHh0emj_" resolve="RemoveAwait" />
-        <node concept="2SqB2G" id="5xnAHh0uXTF" role="2SqHTX">
-          <property role="TrG5h" value="operator" />
-        </node>
-      </node>
-      <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="4jo$K3ejljC">
+  <node concept="24kQdi" id="iHtKXPmS6n">
     <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
-    <node concept="3EZMnI" id="4jo$K3ejlkA" role="2wV5jI">
-      <node concept="3F0ifn" id="4jo$K3ejKSa" role="3EZMnx">
-        <property role="3F0ifm" value="var" />
+    <ref role="1XX52x" to="80bi:iHtKXPmS6d" resolve="LocalVariableDeclaration" />
+    <node concept="3EZMnI" id="iHtKXPmS6p" role="2wV5jI">
+      <node concept="PMmxH" id="iHtKXPmS6w" role="3EZMnx">
+        <ref role="PMmxG" node="5oHFRyIxpOR" resolve="HaveTypeComponent" />
       </node>
-      <node concept="3F1sOY" id="4jo$K3ejlkI" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:4jo$K3ejllH" resolve="variable" />
+      <node concept="3F2HdR" id="iHtKXPmS6_" role="3EZMnx">
+        <property role="2czwfO" value="," />
+        <ref role="1NtTu8" to="80bi:iHtKXPmS6l" resolve="variables" />
+        <node concept="l2Vlx" id="iHtKXPmS6B" role="2czzBx" />
       </node>
-      <node concept="l2Vlx" id="4jo$K3ejlkD" role="2iSdaV" />
+      <node concept="l2Vlx" id="iHtKXPmS6s" role="2iSdaV" />
     </node>
   </node>
-  <node concept="1h_SRR" id="6t5IfhVaxwT">
-    <property role="3GE5qa" value="Statements" />
-    <property role="TrG5h" value="RemoveLock" />
-    <ref role="1h_SK9" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
-    <node concept="1hA7zw" id="6t5IfhVaxyM" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="6t5IfhVaxyN" role="1hA7z_">
-        <node concept="3clFbS" id="6t5IfhVaxyO" role="2VODD2">
-          <node concept="3clFbJ" id="6t5IfhVa$XF" role="3cqZAp">
-            <node concept="3clFbS" id="6t5IfhVa$Y3" role="3clFbx">
-              <node concept="3cpWs6" id="6t5IfhVa_2q" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="6t5IfhVaxNo" role="3clFbw">
-              <node concept="0IXxy" id="6t5IfhVaxCp" role="2Oq$k0" />
-              <node concept="2xy62i" id="6t5IfhVazSW" role="2OqNvi">
-                <node concept="1Q80Hx" id="6t5IfhVazUu" role="2xHN3q" />
-                <node concept="2TlHUq" id="6t5IfhVa$jA" role="3a7HXU">
-                  <ref role="2TlMyj" node="6t5IfhVa$ha" resolve="lock" />
+  <node concept="PKFIW" id="p4z1jPbmlc">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingDirectives" />
+    <ref role="1XX52x" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+    <node concept="3F2HdR" id="p4z1jPms9B" role="2wV5jI">
+      <ref role="1NtTu8" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+      <ref role="APP_o" node="2H$QQET29s8" resolve="DeleteUsingDirective" />
+      <node concept="2iRkQZ" id="p4z1jPms9D" role="2czzBx" />
+      <node concept="pkWqt" id="p4z1jPmB6p" role="pqm2j">
+        <node concept="3clFbS" id="p4z1jPmB6q" role="2VODD2">
+          <node concept="3clFbF" id="p4z1jPmB8K" role="3cqZAp">
+            <node concept="2OqwBi" id="p4z1jPmFaC" role="3clFbG">
+              <node concept="2OqwBi" id="p4z1jPmBy7" role="2Oq$k0">
+                <node concept="pncrf" id="p4z1jPmB8J" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="p4z1jPmBVu" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
                 </node>
               </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="6t5IfhVa_7w" role="3cqZAp">
-            <node concept="2OqwBi" id="6t5IfhVa_iD" role="3clFbG">
-              <node concept="0IXxy" id="6t5IfhVa_7v" role="2Oq$k0" />
-              <node concept="1P9Npp" id="6t5IfhVa_HJ" role="2OqNvi">
-                <node concept="2OqwBi" id="6t5IfhVa_Jk" role="1P9ThW">
-                  <node concept="0IXxy" id="6t5IfhVa_IK" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6t5IfhVaAbH" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:6t5IfhV7vAf" resolve="statement" />
-                  </node>
-                </node>
-              </node>
+              <node concept="3GX2aA" id="p4z1jPmLd9" role="2OqNvi" />
             </node>
           </node>
         </node>
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="6t5IfhV7vpH">
-    <property role="3GE5qa" value="Statements" />
-    <ref role="1XX52x" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
-    <node concept="3EZMnI" id="6t5IfhV7vr9" role="2wV5jI">
-      <node concept="3EZMnI" id="6t5IfhVaxon" role="3EZMnx">
-        <ref role="1ERwB7" node="6t5IfhVaxwT" resolve="RemoveLock" />
-        <node concept="3F0ifn" id="6t5IfhV7vrH" role="3EZMnx">
-          <property role="3F0ifm" value="lock" />
-        </node>
-        <node concept="3F0ifn" id="6t5IfhV7vse" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <node concept="11LMrY" id="6t5IfhV7vw4" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="3F1sOY" id="6t5IfhV7vD4" role="3EZMnx">
-          <ref role="1NtTu8" to="80bi:6t5IfhV7v$m" resolve="expression" />
-        </node>
-        <node concept="3F0ifn" id="6t5IfhV7vsJ" role="3EZMnx">
-          <property role="3F0ifm" value=")" />
-          <node concept="11L4FC" id="6t5IfhV7vxX" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="6t5IfhVaxt5" role="2iSdaV" />
-        <node concept="VPM3Z" id="6t5IfhVaxuZ" role="3F10Kt" />
-        <node concept="2SqB2G" id="6t5IfhVa$ha" role="2SqHTX">
-          <property role="TrG5h" value="lock" />
+  <node concept="24kQdi" id="7HmXimPhQt3">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="1XX52x" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="3F2HdR" id="7HmXimPhQtc" role="2wV5jI">
+      <property role="2czwfO" value="," />
+      <ref role="1NtTu8" to="80bi:7HmXimPhQc_" resolve="parameters" />
+      <node concept="l2Vlx" id="7HmXimPhQte" role="2czzBx" />
+      <node concept="3F0ifn" id="7HmXimPwdwN" role="2czzBI">
+        <node concept="VPxyj" id="iSyfcvyupz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
-      <node concept="3F1sOY" id="6t5IfhV7vEZ" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:6t5IfhV7vAf" resolve="statement" />
-      </node>
-      <node concept="l2Vlx" id="6t5IfhV7vrc" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="5QWEwg3W_GX">
+    <property role="TrG5h" value="VariableNameComponent" />
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="1XX52x" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+    <node concept="3F0A7n" id="5QWEwg3W_GY" role="2wV5jI">
+      <property role="1cu_pB" value="gtguBGO/firstEditableCell" />
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
     </node>
   </node>
   <node concept="3ICUPy" id="5e5Epz9GuHl">
@@ -22276,60 +22217,125 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="5e5Epz9BuN1">
-    <property role="3GE5qa" value="Statements.Yield" />
-    <ref role="1XX52x" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
-    <node concept="3EZMnI" id="5e5Epz9BuN3" role="2wV5jI">
-      <node concept="3F0ifn" id="5e5Epz9BuN7" role="3EZMnx">
-        <property role="3F0ifm" value="yield" />
-        <ref role="1ERwB7" node="5e5Epz9BuNi" resolve="RemoveYield" />
-        <node concept="2SqB2G" id="5e5Epz9BuNh" role="2SqHTX">
-          <property role="TrG5h" value="yield" />
+  <node concept="24kQdi" id="5xnAHgZZgy7">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="3EZMnI" id="5xnAHgZZg_B" role="2wV5jI">
+      <node concept="l2Vlx" id="5xnAHgZZg_C" role="2iSdaV" />
+      <node concept="3F0ifn" id="5xnAHgZZgBa" role="3EZMnx">
+        <property role="3F0ifm" value="await" />
+        <ref role="1ERwB7" node="5xnAHh0emj_" resolve="RemoveAwait" />
+        <node concept="2SqB2G" id="5xnAHh0uXTF" role="2SqHTX">
+          <property role="TrG5h" value="operator" />
         </node>
       </node>
-      <node concept="3F1sOY" id="5e5Epz9BuNc" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5e5Epz9BuN0" resolve="statement" />
+      <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
       </node>
-      <node concept="l2Vlx" id="5e5Epz9BuN6" role="2iSdaV" />
     </node>
   </node>
-  <node concept="1h_SRR" id="5e5Epz9BuNi">
-    <property role="3GE5qa" value="Statements.Yield" />
-    <property role="TrG5h" value="RemoveYield" />
-    <ref role="1h_SK9" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
-    <node concept="1hA7zw" id="5e5Epz9BuNj" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <property role="1hHO97" value="remove yield" />
-      <node concept="1hAIg9" id="5e5Epz9BuNk" role="1hA7z_">
-        <node concept="3clFbS" id="5e5Epz9BuNl" role="2VODD2">
-          <node concept="3clFbJ" id="5e5Epz9BuPE" role="3cqZAp">
-            <node concept="2OqwBi" id="5e5Epz9Bv0X" role="3clFbw">
-              <node concept="0IXxy" id="5e5Epz9BuQ3" role="2Oq$k0" />
-              <node concept="2xy62i" id="5e5Epz9Bx67" role="2OqNvi">
-                <node concept="1Q80Hx" id="5e5Epz9Bx6T" role="2xHN3q" />
-                <node concept="2TlHUq" id="5e5Epz9Mzr3" role="3a7HXU">
-                  <ref role="2TlMyj" node="5e5Epz9BuNh" resolve="yield" />
-                </node>
+  <node concept="3ICUPy" id="4qow2eZf3sX">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="aqKnT" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+    <node concept="1Qtc8_" id="4qow2eZf3w$" role="IW6Ez">
+      <node concept="3cWJ9i" id="4qow2eZf3xa" role="1Qtc8$">
+        <node concept="CtIbL" id="4qow2eZf3xc" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+      <node concept="IWgqT" id="4qow2eZf4SI" role="1Qtc8A">
+        <node concept="1hCUdq" id="4qow2eZf4SJ" role="1hCUd6">
+          <node concept="3clFbS" id="4qow2eZf4SK" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf5b3" role="3cqZAp">
+              <node concept="Xl_RD" id="4qow2eZf5b2" role="3clFbG">
+                <property role="Xl_RC" value="=" />
               </node>
             </node>
-            <node concept="3clFbS" id="5e5Epz9BuPG" role="3clFbx">
-              <node concept="3cpWs6" id="5e5Epz9Bxax" role="3cqZAp" />
+          </node>
+        </node>
+        <node concept="IWg2L" id="4qow2eZf4SL" role="IWgqQ">
+          <node concept="3clFbS" id="4qow2eZf4SM" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf8Vg" role="3cqZAp">
+              <node concept="2OqwBi" id="4qow2eZf9Z4" role="3clFbG">
+                <node concept="2OqwBi" id="4qow2eZf98M" role="2Oq$k0">
+                  <node concept="7Obwk" id="4qow2eZf8Vf" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4qow2eZf9Od" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                  </node>
+                </node>
+                <node concept="zfrQC" id="4qow2eZfatu" role="2OqNvi" />
+              </node>
             </node>
           </node>
-          <node concept="3clFbF" id="5e5Epz9BxdQ" role="3cqZAp">
-            <node concept="2OqwBi" id="5e5Epz9BxoZ" role="3clFbG">
-              <node concept="0IXxy" id="5e5Epz9BxdP" role="2Oq$k0" />
-              <node concept="1P9Npp" id="5e5Epz9BxOL" role="2OqNvi">
-                <node concept="2OqwBi" id="5e5Epz9By0k" role="1P9ThW">
-                  <node concept="0IXxy" id="5e5Epz9BxOP" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5e5Epz9Byr8" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:5e5Epz9BuN0" resolve="statement" />
+        </node>
+        <node concept="27VH4U" id="4qow2eZf5sj" role="2jiSrf">
+          <node concept="3clFbS" id="4qow2eZf5sk" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf5IZ" role="3cqZAp">
+              <node concept="2OqwBi" id="4qow2eZf87R" role="3clFbG">
+                <node concept="2OqwBi" id="4qow2eZf6ce" role="2Oq$k0">
+                  <node concept="7Obwk" id="4qow2eZf5IY" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4qow2eZf7$1" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
                   </node>
+                </node>
+                <node concept="3w_OXm" id="4qow2eZf8$G" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqGtN" id="4qow2eZh_l_" role="2jZA2a">
+          <node concept="3cqJkl" id="4qow2eZh_lA" role="3cqGtW">
+            <node concept="3clFbS" id="4qow2eZh_lB" role="2VODD2">
+              <node concept="3clFbF" id="4qow2eZh_Z1" role="3cqZAp">
+                <node concept="Xl_RD" id="4qow2eZhBj3" role="3clFbG">
+                  <property role="Xl_RC" value="add initializer" />
                 </node>
               </node>
             </node>
           </node>
         </node>
+      </node>
+    </node>
+    <node concept="22hDWj" id="4qow2eZf3ty" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="4jo$K3ejljC">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="1XX52x" to="80bi:4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="4jo$K3ejlkA" role="2wV5jI">
+      <node concept="3F0ifn" id="4jo$K3ejKSa" role="3EZMnx">
+        <property role="3F0ifm" value="var" />
+      </node>
+      <node concept="3F1sOY" id="4jo$K3ejlkI" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:4jo$K3ejllH" resolve="variable" />
+      </node>
+      <node concept="l2Vlx" id="4jo$K3ejlkD" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="2H$QQEUtQI6">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:2H$QQEUtQI0" resolve="UsingAliasDirective" />
+    <node concept="3EZMnI" id="2H$QQEUtQI8" role="2wV5jI">
+      <node concept="PMmxH" id="2H$QQEV9$ET" role="3EZMnx">
+        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      </node>
+      <node concept="3F0A7n" id="2H$QQEUtQIl" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="2H$QQEUtQIt" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+      </node>
+      <node concept="3F1sOY" id="2H$QQEVkWIa" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:2H$QQEVtErW" resolve="reference" />
+      </node>
+      <node concept="3F0ifn" id="2H$QQEUtQIN" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="2H$QQEUYLQC" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="2H$QQEUtQIb" role="2iSdaV" />
+      <node concept="A1WHr" id="2H$QQEUYLQG" role="3vIgyS">
+        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -23,7 +23,7 @@
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -64,7 +64,7 @@
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1177327274449" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_pattern" flags="nn" index="ub8z3" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
-      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
+      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ngI" index="upBLQ">
         <child id="8478191136883534238" name="features" index="upBLP" />
       </concept>
       <concept id="8478191136883534207" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_Selection" flags="ng" index="upBMk">
@@ -128,10 +128,10 @@
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -188,10 +188,10 @@
       <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
         <property id="1225456424731" name="value" index="1iTho6" />
       </concept>
-      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ngI" index="1joUw2">
         <child id="8954657570916349207" name="features" index="2jZA2a" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
@@ -203,7 +203,7 @@
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
-      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
+      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ngI" index="3EoQpk">
         <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -223,7 +223,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
@@ -234,7 +234,7 @@
         <reference id="1173177718857" name="elementActionMap" index="APP_o" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="6684862045052272180" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_NodeToWrap" flags="ng" index="3N4pyC" />
@@ -388,7 +388,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -407,7 +407,7 @@
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
@@ -555,7 +555,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -1430,6 +1430,9 @@
             </node>
           </node>
         </node>
+        <node concept="11L4FC" id="4tlNOoapzE5" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="x$3LfZbRRC" role="3EZMnx">
         <node concept="A1WHu" id="x$3LfZdqpP" role="3vIgyS">
@@ -1576,6 +1579,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="11L4FC" id="4tlNOoap$D0" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
       <node concept="3F0ifn" id="6tzy5CC2Yek" role="3EZMnx">
@@ -1773,6 +1779,9 @@
             </node>
           </node>
         </node>
+        <node concept="11L4FC" id="4tlNOoap$1q" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="6tzy5CC1zJa" role="3EZMnx">
         <property role="3F0ifm" value="(" />
@@ -1888,6 +1897,9 @@
             </node>
           </node>
         </node>
+        <node concept="11L4FC" id="4tlNOoap_kS" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0ifn" id="6tzy5CC4eIb" role="3EZMnx">
         <node concept="A1WHu" id="6tzy5CC4eIc" role="3vIgyS">
@@ -1991,6 +2003,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="11L4FC" id="4tlNOoapzfT" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
       <node concept="3F0ifn" id="3x25Ph9He3S" role="3EZMnx">
@@ -3865,6 +3880,9 @@
               </node>
             </node>
           </node>
+        </node>
+        <node concept="11L4FC" id="4tlNOoap$XH" role="3F10Kt">
+          <property role="VOm3f" value="true" />
         </node>
       </node>
       <node concept="3F0ifn" id="6tzy5CC0Q0$" role="3EZMnx">
@@ -7219,6 +7237,17 @@
               </node>
             </node>
           </node>
+          <node concept="3cqGtN" id="4tlNOo9be0$" role="2jZA2a">
+            <node concept="3cqJkl" id="4tlNOo9be0_" role="3cqGtW">
+              <node concept="3clFbS" id="4tlNOo9be0A" role="2VODD2">
+                <node concept="3clFbF" id="4tlNOo9be0B" role="3cqZAp">
+                  <node concept="Xl_RD" id="4tlNOo9be0C" role="3clFbG">
+                    <property role="Xl_RC" value="add type parameters" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
         <node concept="27VH4U" id="2vo5eZuETNg" role="aenpu">
           <node concept="3clFbS" id="2vo5eZuETNh" role="2VODD2">
@@ -7548,14 +7577,22 @@
         <node concept="27VH4U" id="27q4jmdX0yT" role="aenpu">
           <node concept="3clFbS" id="27q4jmdX0yU" role="2VODD2">
             <node concept="3clFbF" id="27q4jmdX0yV" role="3cqZAp">
-              <node concept="2OqwBi" id="27q4jmdX0yW" role="3clFbG">
-                <node concept="2OqwBi" id="27q4jmdX0yX" role="2Oq$k0">
-                  <node concept="7Obwk" id="27q4jmdX0yY" role="2Oq$k0" />
-                  <node concept="3Tsc0h" id="27q4jmdX0yZ" role="2OqNvi">
-                    <ref role="3TtcxE" to="80bi:27q4jmdWYWP" resolve="genericTypeParameters" />
+              <node concept="1Wc70l" id="4tlNOo98gj7" role="3clFbG">
+                <node concept="2OqwBi" id="4tlNOo98gJH" role="3uHU7w">
+                  <node concept="7Obwk" id="4tlNOo98gkR" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="4tlNOo98hmr" role="2OqNvi">
+                    <ref role="37wK5l" to="kvwr:4tlNOo9892p" resolve="referencesGenericType" />
                   </node>
                 </node>
-                <node concept="1v1jN8" id="27q4jmdX0z0" role="2OqNvi" />
+                <node concept="2OqwBi" id="27q4jmdX0yW" role="3uHU7B">
+                  <node concept="2OqwBi" id="27q4jmdX0yX" role="2Oq$k0">
+                    <node concept="7Obwk" id="27q4jmdX0yY" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="27q4jmdX0yZ" role="2OqNvi">
+                      <ref role="3TtcxE" to="80bi:27q4jmdWYWP" resolve="genericTypeParameters" />
+                    </node>
+                  </node>
+                  <node concept="1v1jN8" id="27q4jmdX0z0" role="2OqNvi" />
+                </node>
               </node>
             </node>
           </node>
@@ -7581,6 +7618,17 @@
                     </node>
                   </node>
                   <node concept="WFELt" id="27q4jmdX0zd" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cqGtN" id="4tlNOo98cvc" role="2jZA2a">
+            <node concept="3cqJkl" id="4tlNOo98cvd" role="3cqGtW">
+              <node concept="3clFbS" id="4tlNOo98cve" role="2VODD2">
+                <node concept="3clFbF" id="4tlNOo98cKH" role="3cqZAp">
+                  <node concept="Xl_RD" id="4tlNOo98cKG" role="3clFbG">
+                    <property role="Xl_RC" value="add type parameters" />
+                  </node>
                 </node>
               </node>
             </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)">
   <persistence version="9" />
-  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
@@ -24,7 +23,7 @@
       <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784074" name="jetbrains.mps.lang.editor.structure.MenuTypeNamed" flags="ng" index="22hDWg" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
-      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ngI" index="22mbnS">
+      <concept id="2000375450116454183" name="jetbrains.mps.lang.editor.structure.ISubstituteMenu" flags="ng" index="22mbnS">
         <child id="414384289274416996" name="parts" index="3ft7WO" />
       </concept>
       <concept id="2000375450116423800" name="jetbrains.mps.lang.editor.structure.SubstituteMenu" flags="ng" index="22mcaB" />
@@ -65,7 +64,7 @@
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1177327274449" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_pattern" flags="nn" index="ub8z3" />
       <concept id="1177327570013" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Substitute" flags="in" index="ucgPf" />
-      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ngI" index="upBLQ">
+      <concept id="8478191136883534237" name="jetbrains.mps.lang.editor.structure.IExtensibleSubstituteMenuPart" flags="ng" index="upBLQ">
         <child id="8478191136883534238" name="features" index="upBLP" />
       </concept>
       <concept id="8478191136883534207" name="jetbrains.mps.lang.editor.structure.SubstituteFeature_Selection" flags="ng" index="upBMk">
@@ -129,10 +128,10 @@
       </concept>
       <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
       <concept id="1186414928363" name="jetbrains.mps.lang.editor.structure.SelectableStyleSheetItem" flags="ln" index="VPM3Z" />
-      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ngI" index="2Z_bC8">
+      <concept id="1630016958697718209" name="jetbrains.mps.lang.editor.structure.IMenuReference_Default" flags="ng" index="2Z_bC8">
         <reference id="1630016958698373342" name="concept" index="2ZyFGn" />
       </concept>
-      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
       </concept>
@@ -189,10 +188,10 @@
       <concept id="1225456267680" name="jetbrains.mps.lang.editor.structure.RGBColor" flags="ng" index="1iSF2X">
         <property id="1225456424731" name="value" index="1iTho6" />
       </concept>
-      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ngI" index="1joUw2">
+      <concept id="7291101478617127464" name="jetbrains.mps.lang.editor.structure.IExtensibleTransformationMenuPart" flags="ng" index="1joUw2">
         <child id="8954657570916349207" name="features" index="2jZA2a" />
       </concept>
-      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ngI" index="1k5N5V">
+      <concept id="1381004262292414836" name="jetbrains.mps.lang.editor.structure.ICellStyle" flags="ng" index="1k5N5V">
         <reference id="1381004262292426837" name="parentStyleClass" index="1k5W1q" />
       </concept>
       <concept id="7580468736840446506" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_model" flags="nn" index="1rpKSd" />
@@ -204,7 +203,7 @@
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
-      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ngI" index="3EoQpk">
+      <concept id="7991336459489871999" name="jetbrains.mps.lang.editor.structure.IOutputConceptSubstituteMenuPart" flags="ng" index="3EoQpk">
         <reference id="7991336459489872009" name="outputConcept" index="3EoQqy" />
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
@@ -224,7 +223,7 @@
         <property id="1073389577007" name="text" index="3F0ifm" />
       </concept>
       <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
-      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
       <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
@@ -235,7 +234,7 @@
         <reference id="1173177718857" name="elementActionMap" index="APP_o" />
       </concept>
       <concept id="5624877018226900666" name="jetbrains.mps.lang.editor.structure.TransformationMenu" flags="ng" index="3ICUPy" />
-      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ngI" index="3INCJE">
+      <concept id="5624877018228267058" name="jetbrains.mps.lang.editor.structure.ITransformationMenu" flags="ng" index="3INCJE">
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="6684862045052272180" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_SubstituteMenu_NodeToWrap" flags="ng" index="3N4pyC" />
@@ -389,7 +388,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -408,7 +407,7 @@
       <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
@@ -556,7 +555,7 @@
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -6662,6 +6661,7 @@
           </node>
         </node>
       </node>
+      <node concept="2iRfu4" id="1HkqSaCLqlM" role="2iSdaV" />
       <node concept="3F0ifn" id="6WVfcZlRzRX" role="3EZMnx">
         <property role="3F0ifm" value="&gt;" />
         <node concept="11L4FC" id="6WVfcZlT2td" role="3F10Kt">
@@ -6697,7 +6697,6 @@
           <ref role="A1WHt" node="4KhT7h9ly6Z" resolve="AddMemberTypeOnDotAfterGenericParameterList" />
         </node>
       </node>
-      <node concept="2iRfu4" id="1HkqSaCLqlM" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="5nBCUOUgxPa">
@@ -6971,6 +6970,7 @@
           </node>
         </node>
       </node>
+      <node concept="2iRfu4" id="27q4jmdX2DT" role="2iSdaV" />
       <node concept="3F0ifn" id="27q4jmdX2Dv" role="3EZMnx">
         <property role="3F0ifm" value="&gt;" />
         <node concept="11L4FC" id="27q4jmdX2Dw" role="3F10Kt">
@@ -7006,7 +7006,6 @@
           <ref role="A1WHt" node="4KhT7h9ly6Z" resolve="AddMemberTypeOnDotAfterGenericParameterList" />
         </node>
       </node>
-      <node concept="2iRfu4" id="27q4jmdX2DT" role="2iSdaV" />
     </node>
   </node>
   <node concept="PKFIW" id="27q4jmdWZQF">
@@ -7208,25 +7207,14 @@
           <node concept="IWg2L" id="2vo5eZuESDx" role="IWgqQ">
             <node concept="3clFbS" id="2vo5eZuESDy" role="2VODD2">
               <node concept="3clFbF" id="2vo5eZuF1ne" role="3cqZAp">
-                <node concept="2OqwBi" id="2wJFJYcn44" role="3clFbG">
-                  <node concept="2OqwBi" id="2vo5eZuF5Ux" role="2Oq$k0">
-                    <node concept="2OqwBi" id="2vo5eZuF1ye" role="2Oq$k0">
-                      <node concept="7Obwk" id="2vo5eZuF1nd" role="2Oq$k0" />
-                      <node concept="3Tsc0h" id="2vo5eZuF1WS" role="2OqNvi">
-                        <ref role="3TtcxE" to="80bi:5moKU4Y5slA" resolve="typeParameter" />
-                      </node>
-                    </node>
-                    <node concept="WFELt" id="2vo5eZuF9Vp" role="2OqNvi" />
-                  </node>
-                  <node concept="2qgKlT" id="2wJFJYd3BB" role="2OqNvi">
-                    <ref role="37wK5l" to="kvwr:2wJFJYcdAZ" resolve="setVariance" />
-                    <node concept="2OqwBi" id="2wJFJYdSF5" role="37wK5m">
-                      <node concept="7Obwk" id="2wJFJYdScU" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="2wJFJYdTtk" role="2OqNvi">
-                        <ref role="37wK5l" to="kvwr:2wJFJYdLjy" resolve="isVarianceEnabled" />
-                      </node>
+                <node concept="2OqwBi" id="2vo5eZuF5Ux" role="3clFbG">
+                  <node concept="2OqwBi" id="2vo5eZuF1ye" role="2Oq$k0">
+                    <node concept="7Obwk" id="2vo5eZuF1nd" role="2Oq$k0" />
+                    <node concept="3Tsc0h" id="2vo5eZuF1WS" role="2OqNvi">
+                      <ref role="3TtcxE" to="80bi:5moKU4Y5slA" resolve="typeParameter" />
                     </node>
                   </node>
+                  <node concept="WFELt" id="2vo5eZuF9Vp" role="2OqNvi" />
                 </node>
               </node>
             </node>
@@ -21036,254 +21024,10 @@
       </node>
     </node>
   </node>
-  <node concept="3ICUPy" id="p4z1jOxeUl">
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="aqKnT" to="80bi:27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    <node concept="22hDWj" id="p4z1jOxeUU" role="22hAXT" />
-    <node concept="1Qtc8_" id="p4z1jOxeVw" role="IW6Ez">
-      <node concept="3eGOoe" id="p4z1jOxeVQ" role="1Qtc8$" />
-      <node concept="3PzhKR" id="p4z1jOxeZ4" role="1Qtc8A">
-        <ref role="3PzhKQ" to="80bi:27q4jmdWXhm" resolve="referencedType" />
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="6t5IfhV7vpH">
-    <property role="3GE5qa" value="Statements" />
-    <ref role="1XX52x" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
-    <node concept="3EZMnI" id="6t5IfhV7vr9" role="2wV5jI">
-      <node concept="3EZMnI" id="6t5IfhVaxon" role="3EZMnx">
-        <ref role="1ERwB7" node="6t5IfhVaxwT" resolve="RemoveLock" />
-        <node concept="3F0ifn" id="6t5IfhV7vrH" role="3EZMnx">
-          <property role="3F0ifm" value="lock" />
-        </node>
-        <node concept="3F0ifn" id="6t5IfhV7vse" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <node concept="11LMrY" id="6t5IfhV7vw4" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="3F1sOY" id="6t5IfhV7vD4" role="3EZMnx">
-          <ref role="1NtTu8" to="80bi:6t5IfhV7v$m" resolve="expression" />
-        </node>
-        <node concept="3F0ifn" id="6t5IfhV7vsJ" role="3EZMnx">
-          <property role="3F0ifm" value=")" />
-          <node concept="11L4FC" id="6t5IfhV7vxX" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="l2Vlx" id="6t5IfhVaxt5" role="2iSdaV" />
-        <node concept="VPM3Z" id="6t5IfhVaxuZ" role="3F10Kt" />
-        <node concept="2SqB2G" id="6t5IfhVa$ha" role="2SqHTX">
-          <property role="TrG5h" value="lock" />
-        </node>
-      </node>
-      <node concept="3F1sOY" id="6t5IfhV7vEZ" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:6t5IfhV7vAf" resolve="statement" />
-      </node>
-      <node concept="l2Vlx" id="6t5IfhV7vrc" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="24kQdi" id="5e5Epz9BuN1">
-    <property role="3GE5qa" value="Statements.Yield" />
-    <ref role="1XX52x" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
-    <node concept="3EZMnI" id="5e5Epz9BuN3" role="2wV5jI">
-      <node concept="3F0ifn" id="5e5Epz9BuN7" role="3EZMnx">
-        <property role="3F0ifm" value="yield" />
-        <ref role="1ERwB7" node="5e5Epz9BuNi" resolve="RemoveYield" />
-        <node concept="2SqB2G" id="5e5Epz9BuNh" role="2SqHTX">
-          <property role="TrG5h" value="yield" />
-        </node>
-      </node>
-      <node concept="3F1sOY" id="5e5Epz9BuNc" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5e5Epz9BuN0" resolve="statement" />
-      </node>
-      <node concept="l2Vlx" id="5e5Epz9BuN6" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="1h_SRR" id="6v$Cp0meIXd">
-    <property role="3GE5qa" value="Statements.Using" />
-    <property role="TrG5h" value="RemoveUsing" />
-    <ref role="1h_SK9" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-    <node concept="1hA7zw" id="6v$Cp0meIYf" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="6v$Cp0meIYg" role="1hA7z_">
-        <node concept="3clFbS" id="6v$Cp0meIYh" role="2VODD2">
-          <node concept="3clFbJ" id="6v$Cp0meJ0l" role="3cqZAp">
-            <node concept="2OqwBi" id="6v$Cp0meJbF" role="3clFbw">
-              <node concept="0IXxy" id="6v$Cp0meJ0L" role="2Oq$k0" />
-              <node concept="2xy62i" id="6v$Cp0meJCJ" role="2OqNvi">
-                <node concept="1Q80Hx" id="6v$Cp0meJDz" role="2xHN3q" />
-                <node concept="2TlHUq" id="6v$Cp0meJED" role="3a7HXU">
-                  <ref role="2TlMyj" node="6v$Cp0meIYc" resolve="using" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="6v$Cp0meJ0n" role="3clFbx">
-              <node concept="3cpWs6" id="6v$Cp0meJHP" role="3cqZAp" />
-            </node>
-          </node>
-          <node concept="3clFbF" id="6v$Cp0meJMN" role="3cqZAp">
-            <node concept="2OqwBi" id="6v$Cp0meJPg" role="3clFbG">
-              <node concept="0IXxy" id="6v$Cp0meJMM" role="2Oq$k0" />
-              <node concept="1P9Npp" id="6v$Cp0meJSl" role="2OqNvi">
-                <node concept="2OqwBi" id="6v$Cp0meJUr" role="1P9ThW">
-                  <node concept="0IXxy" id="6v$Cp0meJSU" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6v$Cp0meK9V" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="5xnAHgZa2GI">
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclarationStatement" />
-    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
-      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="declaration" />
-      </node>
-      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="1h_SRR" id="6O4r_tdj4Zm">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <property role="TrG5h" value="VariableDeclaration_InitializerActions" />
-    <ref role="1h_SK9" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-    <node concept="1hA7zw" id="6O4r_tdj4ZV" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <property role="1hHO97" value="remove initializer" />
-      <node concept="1hAIg9" id="6O4r_tdj4ZW" role="1hA7z_">
-        <node concept="3clFbS" id="6O4r_tdj4ZX" role="2VODD2">
-          <node concept="3clFbJ" id="6O4r_tdsXfk" role="3cqZAp">
-            <node concept="3clFbS" id="6O4r_tdsXfm" role="3clFbx">
-              <node concept="3cpWs6" id="6O4r_tdvosy" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="6O4r_tdqypA" role="3clFbw">
-              <node concept="2OqwBi" id="6O4r_tdqxFH" role="2Oq$k0">
-                <node concept="0IXxy" id="6O4r_tdqxuW" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6O4r_tdqxX6" role="2OqNvi">
-                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                </node>
-              </node>
-              <node concept="2xy62i" id="6O4r_tdqyEY" role="2OqNvi">
-                <node concept="1Q80Hx" id="6O4r_tdqyIL" role="2xHN3q" />
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="6O4r_tdvozc" role="3cqZAp">
-            <node concept="2OqwBi" id="5QWEwg3xiAN" role="3clFbG">
-              <node concept="2OqwBi" id="6O4r_tdvoNo" role="2Oq$k0">
-                <node concept="0IXxy" id="6O4r_tdvozb" role="2Oq$k0" />
-                <node concept="3TrEf2" id="6O4r_tdvpn$" role="2OqNvi">
-                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                </node>
-              </node>
-              <node concept="3YRAZt" id="5QWEwg3xj1L" role="2OqNvi" />
-            </node>
-          </node>
-          <node concept="3clFbF" id="5QWEwg3xj5b" role="3cqZAp">
-            <node concept="2OqwBi" id="5QWEwg3xjiC" role="3clFbG">
-              <node concept="0IXxy" id="5QWEwg3xj5a" role="2Oq$k0" />
-              <node concept="1OKiuA" id="5QWEwg3xkga" role="2OqNvi">
-                <node concept="1Q80Hx" id="5QWEwg3xkhv" role="lBI5i" />
-                <node concept="2B6iha" id="5QWEwg3xkjU" role="lGT1i">
-                  <property role="1lyBwo" value="1S2pyLby17D/lastEditable" />
-                </node>
-                <node concept="3cmrfG" id="5QWEwg3xkmh" role="3dN3m$">
-                  <property role="3cmrfH" value="-1" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="jK8Ss" id="5QWEwg3Ag4i" role="jK8aL">
-        <node concept="3clFbS" id="5QWEwg3Ag4j" role="2VODD2">
-          <node concept="3clFbF" id="5QWEwg3AgpF" role="3cqZAp">
-            <node concept="2OqwBi" id="5QWEwg3AijH" role="3clFbG">
-              <node concept="2OqwBi" id="5QWEwg3AgQ0" role="2Oq$k0">
-                <node concept="0IXxy" id="5QWEwg3AgpE" role="2Oq$k0" />
-                <node concept="3TrEf2" id="5QWEwg3AhTF" role="2OqNvi">
-                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                </node>
-              </node>
-              <node concept="3x8VRR" id="5QWEwg3AiZA" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="iHtKXPjUmB">
-    <property role="3GE5qa" value="Statements.Using" />
-    <ref role="1XX52x" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
-    <node concept="3EZMnI" id="iHtKXPjUmD" role="2wV5jI">
-      <node concept="3EZMnI" id="6v$Cp0meIXq" role="3EZMnx">
-        <ref role="1ERwB7" node="6v$Cp0meIXd" resolve="RemoveUsing" />
-        <node concept="VPM3Z" id="6v$Cp0meIXs" role="3F10Kt" />
-        <node concept="l2Vlx" id="6v$Cp0meIXv" role="2iSdaV" />
-        <node concept="3F0ifn" id="iHtKXPjUmK" role="3EZMnx">
-          <property role="3F0ifm" value="using" />
-        </node>
-        <node concept="3F0ifn" id="iHtKXPjUmQ" role="3EZMnx">
-          <property role="3F0ifm" value="(" />
-          <node concept="11LMrY" id="iHtKXPmRNF" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-        </node>
-        <node concept="3F1sOY" id="iHtKXPjUn3" role="3EZMnx">
-          <ref role="1NtTu8" to="80bi:iHtKXPjUmm" resolve="resource" />
-        </node>
-        <node concept="3F0ifn" id="iHtKXPjUnd" role="3EZMnx">
-          <property role="3F0ifm" value=")" />
-          <node concept="11L4FC" id="iHtKXPmRNH" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="ljvvj" id="iHtKXPxrIg" role="3F10Kt">
-            <property role="VOm3f" value="true" />
-          </node>
-          <node concept="A1WHu" id="6v$Cp0m9g23" role="3vIgyS">
-            <ref role="A1WHt" node="6v$Cp0m2OEi" resolve="InsertUsing" />
-          </node>
-        </node>
-        <node concept="2SqB2G" id="6v$Cp0meIYc" role="2SqHTX">
-          <property role="TrG5h" value="using" />
-        </node>
-      </node>
-      <node concept="3F1sOY" id="iHtKXPjUnw" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:iHtKXPjUmo" resolve="statement" />
-      </node>
-      <node concept="l2Vlx" id="iHtKXPjUmG" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="24kQdi" id="2H$QQEVkW1m">
-    <property role="3GE5qa" value="Namespace" />
-    <ref role="1XX52x" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
-    <node concept="3EZMnI" id="4tlNOobs7hd" role="2wV5jI">
-      <node concept="l2Vlx" id="4tlNOobs7he" role="2iSdaV" />
-      <node concept="PMmxH" id="2H$QQEV9$DZ" role="3EZMnx">
-        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
-      </node>
-      <node concept="3F1sOY" id="2H$QQEVqVMB" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:2H$QQEVtErT" resolve="reference" />
-      </node>
-      <node concept="3F0ifn" id="4tlNOobs7it" role="3EZMnx">
-        <property role="3F0ifm" value=";" />
-        <node concept="11L4FC" id="4tlNOobAZFd" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-    </node>
+  <node concept="22mcaB" id="6u44Y77QZVp">
+    <property role="3GE5qa" value="Generics" />
+    <ref role="aqKnT" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
+    <node concept="22hDWj" id="6u44Y77QZVq" role="22hAXT" />
   </node>
   <node concept="1h_SRR" id="2H$QQET29s8">
     <property role="3GE5qa" value="Namespace" />
@@ -21358,265 +21102,12 @@
       </node>
     </node>
   </node>
-  <node concept="1h_SRR" id="5e5Epz9BuNi">
-    <property role="3GE5qa" value="Statements.Yield" />
-    <property role="TrG5h" value="RemoveYield" />
-    <ref role="1h_SK9" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
-    <node concept="1hA7zw" id="5e5Epz9BuNj" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <property role="1hHO97" value="remove yield" />
-      <node concept="1hAIg9" id="5e5Epz9BuNk" role="1hA7z_">
-        <node concept="3clFbS" id="5e5Epz9BuNl" role="2VODD2">
-          <node concept="3clFbJ" id="5e5Epz9BuPE" role="3cqZAp">
-            <node concept="2OqwBi" id="5e5Epz9Bv0X" role="3clFbw">
-              <node concept="0IXxy" id="5e5Epz9BuQ3" role="2Oq$k0" />
-              <node concept="2xy62i" id="5e5Epz9Bx67" role="2OqNvi">
-                <node concept="1Q80Hx" id="5e5Epz9Bx6T" role="2xHN3q" />
-                <node concept="2TlHUq" id="5e5Epz9Mzr3" role="3a7HXU">
-                  <ref role="2TlMyj" node="5e5Epz9BuNh" resolve="yield" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="5e5Epz9BuPG" role="3clFbx">
-              <node concept="3cpWs6" id="5e5Epz9Bxax" role="3cqZAp" />
-            </node>
-          </node>
-          <node concept="3clFbF" id="5e5Epz9BxdQ" role="3cqZAp">
-            <node concept="2OqwBi" id="5e5Epz9BxoZ" role="3clFbG">
-              <node concept="0IXxy" id="5e5Epz9BxdP" role="2Oq$k0" />
-              <node concept="1P9Npp" id="5e5Epz9BxOL" role="2OqNvi">
-                <node concept="2OqwBi" id="5e5Epz9By0k" role="1P9ThW">
-                  <node concept="0IXxy" id="5e5Epz9BxOP" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5e5Epz9Byr8" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:5e5Epz9BuN0" resolve="statement" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="3ICUPy" id="1XmGakPdCcn">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-    <node concept="1Qtc8_" id="1XmGakPdCTK" role="IW6Ez">
-      <node concept="aenpk" id="1XmGakPyjZS" role="1Qtc8A">
-        <node concept="mvV$s" id="1XmGakPsIwl" role="aenpr">
-          <node concept="A1WHu" id="1XmGakPsIyw" role="A14EM">
-            <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
-          </node>
-          <node concept="mvVNg" id="1XmGakPsIyy" role="mvV$0">
-            <node concept="3clFbS" id="1XmGakPsIyz" role="2VODD2">
-              <node concept="3clFbF" id="1XmGakPsIBg" role="3cqZAp">
-                <node concept="2OqwBi" id="1XmGakPsIQk" role="3clFbG">
-                  <node concept="7Obwk" id="1XmGakPsIBf" role="2Oq$k0" />
-                  <node concept="2Xjw5R" id="1XmGakPsJja" role="2OqNvi">
-                    <node concept="1xMEDy" id="1XmGakPsJjc" role="1xVPHs">
-                      <node concept="chp4Y" id="1XmGakPsJlI" role="ri$Ld">
-                        <ref role="cht4Q" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="27VH4U" id="1XmGakPyk0K" role="aenpu">
-          <node concept="3clFbS" id="1XmGakPyk0L" role="2VODD2">
-            <node concept="3clFbF" id="1XmGakPykgT" role="3cqZAp">
-              <node concept="2OqwBi" id="1XmGakPyrkp" role="3clFbG">
-                <node concept="2OqwBi" id="1XmGakPykFi" role="2Oq$k0">
-                  <node concept="7Obwk" id="1XmGakPykgS" role="2Oq$k0" />
-                  <node concept="2TvwIu" id="1XmGakPyl8H" role="2OqNvi" />
-                </node>
-                <node concept="1v1jN8" id="1XmGakPyu_9" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3c8P5G" id="iSyfcuX8bg" role="1Qtc8A">
-        <node concept="2kknPJ" id="iSyfcuX8fF" role="3c8P5H">
-          <ref role="2ZyFGn" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-        </node>
-        <node concept="3c8PGw" id="iSyfcuX8bj" role="3c8PHt">
-          <node concept="3clFbS" id="iSyfcuX8bl" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcuZZkQ" role="3cqZAp">
-              <node concept="37vLTI" id="iSyfcv02Kz" role="3clFbG">
-                <node concept="2OqwBi" id="iSyfcv02W$" role="37vLTx">
-                  <node concept="7Obwk" id="iSyfcv02Li" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="iSyfcv03bD" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="iSyfcuZZwd" role="37vLTJ">
-                  <node concept="3c8USq" id="iSyfcuZZkP" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="iSyfcuZZJ9" role="2OqNvi">
-                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="iSyfcv03n3" role="3cqZAp">
-              <node concept="2OqwBi" id="iSyfcv03ww" role="3clFbG">
-                <node concept="7Obwk" id="iSyfcw2bX7" role="2Oq$k0" />
-                <node concept="1P9Npp" id="iSyfcv03LP" role="2OqNvi">
-                  <node concept="3c8USq" id="iSyfcv03MP" role="1P9ThW" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cWJ9i" id="1XmGakPdCTO" role="1Qtc8$">
-        <node concept="CtIbL" id="1XmGakPdCTQ" role="CtIbM">
-          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
-        </node>
-      </node>
-    </node>
-    <node concept="22hDWj" id="1XmGakPmOWV" role="22hAXT" />
-  </node>
-  <node concept="PKFIW" id="2H$QQEV9$DW">
-    <property role="TrG5h" value="UsingKeyword" />
-    <property role="3GE5qa" value="Namespace" />
-    <ref role="1XX52x" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="3F0ifn" id="2H$QQEV9$DX" role="2wV5jI">
-      <property role="3F0ifm" value="using" />
-      <node concept="A1WHr" id="2H$QQEV9$DY" role="3vIgyS">
-        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
-      </node>
-    </node>
-  </node>
-  <node concept="1h_SRR" id="7HmXimQhemy">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <property role="TrG5h" value="RemoveAsync" />
-    <ref role="1h_SK9" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
-    <node concept="1hA7zw" id="7HmXimQhemz" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <property role="1hHO97" value="remove async modifier" />
-      <node concept="1hAIg9" id="7HmXimQhem$" role="1hA7z_">
-        <node concept="3clFbS" id="7HmXimQhem_" role="2VODD2">
-          <node concept="3clFbJ" id="7HmXimQhhSC" role="3cqZAp">
-            <node concept="3clFbS" id="7HmXimQhhT0" role="3clFbx">
-              <node concept="3cpWs6" id="7HmXimQhhWx" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="7HmXimQhfN5" role="3clFbw">
-              <node concept="0IXxy" id="7HmXimQhepk" role="2Oq$k0" />
-              <node concept="2xy62i" id="7HmXimQhgjP" role="2OqNvi">
-                <node concept="1Q80Hx" id="7HmXimQhgk$" role="2xHN3q" />
-                <node concept="2TlHUq" id="7HmXimQhhgS" role="3a7HXU">
-                  <ref role="2TlMyj" node="7HmXimQhgZA" resolve="async" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="7HmXimQhhZQ" role="3cqZAp">
-            <node concept="37vLTI" id="7HmXimQhlyi" role="3clFbG">
-              <node concept="3clFbT" id="7HmXimQhlyK" role="37vLTx" />
-              <node concept="2OqwBi" id="7HmXimQhibL" role="37vLTJ">
-                <node concept="0IXxy" id="7HmXimQhhZP" role="2Oq$k0" />
-                <node concept="3TrcHB" id="7HmXimQhiES" role="2OqNvi">
-                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="7HmXimQpfUQ" role="3cqZAp">
-            <node concept="2OqwBi" id="7HmXimQpg75" role="3clFbG">
-              <node concept="0IXxy" id="7HmXimQpfUP" role="2Oq$k0" />
-              <node concept="1OKiuA" id="7HmXimQpgC3" role="2OqNvi">
-                <node concept="1Q80Hx" id="7HmXimQpgCH" role="lBI5i" />
-                <node concept="2B6iha" id="7HmXimQpgLt" role="lGT1i">
-                  <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="24kQdi" id="7HmXimPhQcI">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
     <ref role="1XX52x" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
     <node concept="3F0A7n" id="7HmXimPhQcK" role="2wV5jI">
       <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
     </node>
-  </node>
-  <node concept="1h_SRR" id="5xnAHh0emj_">
-    <property role="3GE5qa" value="Expressions.Unary" />
-    <property role="TrG5h" value="RemoveAwait" />
-    <ref role="1h_SK9" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
-    <node concept="1hA7zw" id="5xnAHh0emjA" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="5xnAHh0emjB" role="1hA7z_">
-        <node concept="3clFbS" id="5xnAHh0emjC" role="2VODD2">
-          <node concept="3clFbJ" id="5xnAHh0hi42" role="3cqZAp">
-            <node concept="3clFbS" id="5xnAHh0hi44" role="3clFbx">
-              <node concept="3cpWs6" id="5xnAHh0hi_R" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="5xnAHh0hihq" role="3clFbw">
-              <node concept="0IXxy" id="5xnAHh0hi4W" role="2Oq$k0" />
-              <node concept="2xy62i" id="5xnAHh0hiy0" role="2OqNvi">
-                <node concept="1Q80Hx" id="5xnAHh0hiyA" role="2xHN3q" />
-                <node concept="2TlHUq" id="5xnAHh0k20P" role="3a7HXU">
-                  <ref role="2TlMyj" node="5xnAHh0uXTF" resolve="operator" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="5xnAHh0emme" role="3cqZAp">
-            <node concept="2OqwBi" id="5xnAHh0emyK" role="3clFbG">
-              <node concept="0IXxy" id="5xnAHh0emmd" role="2Oq$k0" />
-              <node concept="1P9Npp" id="5xnAHh0enmR" role="2OqNvi">
-                <node concept="2OqwBi" id="5xnAHh0en$J" role="1P9ThW">
-                  <node concept="0IXxy" id="5xnAHh0ennF" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="5xnAHh0enRd" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:5xnAHgZZgtR" resolve="task" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="22mcaB" id="iSyfcuX8Tw">
-    <property role="3GE5qa" value="Class / Struct.Parameters" />
-    <ref role="aqKnT" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-    <node concept="3N5dw7" id="iSyfcuX9_3" role="3ft7WO">
-      <node concept="3N5aqt" id="iSyfcuX9_4" role="3Na0zg">
-        <node concept="3clFbS" id="iSyfcuX9_5" role="2VODD2">
-          <node concept="3clFbF" id="iSyfcuXabA" role="3cqZAp">
-            <node concept="2pJPEk" id="iSyfcuX9Zk" role="3clFbG">
-              <node concept="2pJPED" id="iSyfcuX9Zm" role="2pJPEn">
-                <ref role="2pJxaS" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
-                <node concept="2pIpSj" id="iSyfcuXa4o" role="2pJxcM">
-                  <ref role="2pIpSl" to="80bi:7yZ_CF2xDX3" resolve="type" />
-                  <node concept="2pJPED" id="iSyfcuXa5G" role="28nt2d">
-                    <ref role="2pJxaS" to="80bi:5VT83U$LMPZ" resolve="Type" />
-                    <node concept="2pIpSj" id="iSyfcuXa6z" role="2pJxcM">
-                      <ref role="2pIpSl" to="80bi:5VT83U$LPp0" resolve="nonArrayType" />
-                      <node concept="36biLy" id="iSyfcuXa70" role="28nt2d">
-                        <node concept="3N4pyC" id="iSyfcuXa8q" role="36biLW" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="2kknPJ" id="iSyfcuX9_n" role="2klrvf">
-        <ref role="2ZyFGn" to="80bi:5_5a0KJX$kh" resolve="INonArrayType" />
-      </node>
-    </node>
-    <node concept="22hDWj" id="iSyfcuX8Ut" role="22hAXT" />
   </node>
   <node concept="3ICUPy" id="7HmXimR0WHi">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -21684,50 +21175,6 @@
     <node concept="22hDWg" id="7HmXimR11wF" role="22hAXT">
       <property role="TrG5h" value="AddAsync" />
     </node>
-  </node>
-  <node concept="1h_SRR" id="6t5IfhVaxwT">
-    <property role="3GE5qa" value="Statements" />
-    <property role="TrG5h" value="RemoveLock" />
-    <ref role="1h_SK9" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
-    <node concept="1hA7zw" id="6t5IfhVaxyM" role="1h_SK8">
-      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
-      <node concept="1hAIg9" id="6t5IfhVaxyN" role="1hA7z_">
-        <node concept="3clFbS" id="6t5IfhVaxyO" role="2VODD2">
-          <node concept="3clFbJ" id="6t5IfhVa$XF" role="3cqZAp">
-            <node concept="3clFbS" id="6t5IfhVa$Y3" role="3clFbx">
-              <node concept="3cpWs6" id="6t5IfhVa_2q" role="3cqZAp" />
-            </node>
-            <node concept="2OqwBi" id="6t5IfhVaxNo" role="3clFbw">
-              <node concept="0IXxy" id="6t5IfhVaxCp" role="2Oq$k0" />
-              <node concept="2xy62i" id="6t5IfhVazSW" role="2OqNvi">
-                <node concept="1Q80Hx" id="6t5IfhVazUu" role="2xHN3q" />
-                <node concept="2TlHUq" id="6t5IfhVa$jA" role="3a7HXU">
-                  <ref role="2TlMyj" node="6t5IfhVa$ha" resolve="lock" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3clFbF" id="6t5IfhVa_7w" role="3cqZAp">
-            <node concept="2OqwBi" id="6t5IfhVa_iD" role="3clFbG">
-              <node concept="0IXxy" id="6t5IfhVa_7v" role="2Oq$k0" />
-              <node concept="1P9Npp" id="6t5IfhVa_HJ" role="2OqNvi">
-                <node concept="2OqwBi" id="6t5IfhVa_Jk" role="1P9ThW">
-                  <node concept="0IXxy" id="6t5IfhVa_IK" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="6t5IfhVaAbH" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:6t5IfhV7vAf" resolve="statement" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="22mcaB" id="6u44Y77QZVp">
-    <property role="3GE5qa" value="Generics" />
-    <ref role="aqKnT" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
-    <node concept="22hDWj" id="6u44Y77QZVq" role="22hAXT" />
   </node>
   <node concept="24kQdi" id="7HmXimPhNct">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -21825,22 +21272,72 @@
       </node>
     </node>
   </node>
-  <node concept="22mcaB" id="iSyfcuUaO9">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-    <node concept="22hDWj" id="iSyfcuUaP6" role="22hAXT" />
-    <node concept="3eGOop" id="iSyfcvd_1$" role="3ft7WO">
-      <node concept="16NL3D" id="iSyfcvd_6u" role="upBLP">
-        <node concept="16Na2f" id="iSyfcvd_6v" role="16NL3A">
-          <node concept="3clFbS" id="iSyfcvd_6w" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcvdAR_" role="3cqZAp">
-              <node concept="2OqwBi" id="iSyfcvdDfT" role="3clFbG">
-                <node concept="ub8z3" id="iSyfcvdBzG" role="2Oq$k0" />
-                <node concept="liA8E" id="iSyfcvdEfR" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
-                  <node concept="10M0yZ" id="iSyfcvdBgr" role="37wK5m">
-                    <ref role="3cqZAo" node="5cm0BoTKIaF" resolve="identifier" />
-                    <ref role="1PxDUh" node="6H78krhSzlS" resolve="SubstitutionUtils" />
+  <node concept="PKFIW" id="p4z1jPbmlc">
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingDirectives" />
+    <ref role="1XX52x" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
+    <node concept="3F2HdR" id="p4z1jPms9B" role="2wV5jI">
+      <ref role="1NtTu8" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+      <ref role="APP_o" node="2H$QQET29s8" resolve="DeleteUsingDirective" />
+      <node concept="2iRkQZ" id="p4z1jPms9D" role="2czzBx" />
+      <node concept="pkWqt" id="p4z1jPmB6p" role="pqm2j">
+        <node concept="3clFbS" id="p4z1jPmB6q" role="2VODD2">
+          <node concept="3clFbF" id="p4z1jPmB8K" role="3cqZAp">
+            <node concept="2OqwBi" id="p4z1jPmFaC" role="3clFbG">
+              <node concept="2OqwBi" id="p4z1jPmBy7" role="2Oq$k0">
+                <node concept="pncrf" id="p4z1jPmB8J" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="p4z1jPmBVu" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
+                </node>
+              </node>
+              <node concept="3GX2aA" id="p4z1jPmLd9" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="p4z1jOxeUl">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="aqKnT" to="80bi:27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="22hDWj" id="p4z1jOxeUU" role="22hAXT" />
+    <node concept="1Qtc8_" id="p4z1jOxeVw" role="IW6Ez">
+      <node concept="3eGOoe" id="p4z1jOxeVQ" role="1Qtc8$" />
+      <node concept="3PzhKR" id="p4z1jOxeZ4" role="1Qtc8A">
+        <ref role="3PzhKQ" to="80bi:27q4jmdWXhm" resolve="referencedType" />
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="5xnAHh0emj_">
+    <property role="3GE5qa" value="Expressions.Unary" />
+    <property role="TrG5h" value="RemoveAwait" />
+    <ref role="1h_SK9" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
+    <node concept="1hA7zw" id="5xnAHh0emjA" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="5xnAHh0emjB" role="1hA7z_">
+        <node concept="3clFbS" id="5xnAHh0emjC" role="2VODD2">
+          <node concept="3clFbJ" id="5xnAHh0hi42" role="3cqZAp">
+            <node concept="3clFbS" id="5xnAHh0hi44" role="3clFbx">
+              <node concept="3cpWs6" id="5xnAHh0hi_R" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="5xnAHh0hihq" role="3clFbw">
+              <node concept="0IXxy" id="5xnAHh0hi4W" role="2Oq$k0" />
+              <node concept="2xy62i" id="5xnAHh0hiy0" role="2OqNvi">
+                <node concept="1Q80Hx" id="5xnAHh0hiyA" role="2xHN3q" />
+                <node concept="2TlHUq" id="5xnAHh0k20P" role="3a7HXU">
+                  <ref role="2TlMyj" node="5xnAHh0uXTF" resolve="operator" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5xnAHh0emme" role="3cqZAp">
+            <node concept="2OqwBi" id="5xnAHh0emyK" role="3clFbG">
+              <node concept="0IXxy" id="5xnAHh0emmd" role="2Oq$k0" />
+              <node concept="1P9Npp" id="5xnAHh0enmR" role="2OqNvi">
+                <node concept="2OqwBi" id="5xnAHh0en$J" role="1P9ThW">
+                  <node concept="0IXxy" id="5xnAHh0ennF" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5xnAHh0enRd" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:5xnAHgZZgtR" resolve="task" />
                   </node>
                 </node>
               </node>
@@ -21848,38 +21345,69 @@
           </node>
         </node>
       </node>
-      <node concept="16NfWO" id="iSyfcvdEGh" role="upBLP">
-        <node concept="uGdhv" id="iSyfcvd_WF" role="16NeZM">
-          <node concept="3clFbS" id="iSyfcvd_WH" role="2VODD2">
-            <node concept="3clFbF" id="iSyfcvdAdP" role="3cqZAp">
-              <node concept="3K4zz7" id="iSyfcvdAdQ" role="3clFbG">
-                <node concept="ub8z3" id="iSyfcvdAdR" role="3K4E3e" />
-                <node concept="Xl_RD" id="iSyfcvdAdS" role="3K4GZi">
-                  <property role="Xl_RC" value="&lt;name&gt;" />
-                </node>
-                <node concept="2OqwBi" id="iSyfcvdAdT" role="3K4Cdx">
-                  <node concept="ub8z3" id="iSyfcvdAdU" role="2Oq$k0" />
-                  <node concept="17RvpY" id="iSyfcvdAdV" role="2OqNvi" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7HmXimPhQt3">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="1XX52x" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
+    <node concept="3F2HdR" id="7HmXimPhQtc" role="2wV5jI">
+      <property role="2czwfO" value="," />
+      <ref role="1NtTu8" to="80bi:7HmXimPhQc_" resolve="parameters" />
+      <node concept="l2Vlx" id="7HmXimPhQte" role="2czzBx" />
+      <node concept="3F0ifn" id="7HmXimPwdwN" role="2czzBI">
+        <node concept="VPxyj" id="iSyfcvyupz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5xnAHgZa2GI">
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1XX52x" to="80bi:5xnAHgZa2vT" resolve="ImplicitLocalVariableDeclarationStatement" />
+    <node concept="3EZMnI" id="5xnAHgZa2IS" role="2wV5jI">
+      <node concept="3F1sOY" id="5xnAHgZdlrl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5xnAHgZdlnx" resolve="declaration" />
+      </node>
+      <node concept="3F0ifn" id="5xnAHgZdlsx" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="5xnAHgZdluI" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5xnAHgZa2IV" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="6t5IfhVaxwT">
+    <property role="3GE5qa" value="Statements" />
+    <property role="TrG5h" value="RemoveLock" />
+    <ref role="1h_SK9" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
+    <node concept="1hA7zw" id="6t5IfhVaxyM" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="6t5IfhVaxyN" role="1hA7z_">
+        <node concept="3clFbS" id="6t5IfhVaxyO" role="2VODD2">
+          <node concept="3clFbJ" id="6t5IfhVa$XF" role="3cqZAp">
+            <node concept="3clFbS" id="6t5IfhVa$Y3" role="3clFbx">
+              <node concept="3cpWs6" id="6t5IfhVa_2q" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="6t5IfhVaxNo" role="3clFbw">
+              <node concept="0IXxy" id="6t5IfhVaxCp" role="2Oq$k0" />
+              <node concept="2xy62i" id="6t5IfhVazSW" role="2OqNvi">
+                <node concept="1Q80Hx" id="6t5IfhVazUu" role="2xHN3q" />
+                <node concept="2TlHUq" id="6t5IfhVa$jA" role="3a7HXU">
+                  <ref role="2TlMyj" node="6t5IfhVa$ha" resolve="lock" />
                 </node>
               </node>
             </node>
           </node>
-        </node>
-      </node>
-      <node concept="16NL0t" id="iSyfcvd_VB" role="upBLP">
-        <node concept="2h3Zct" id="iSyfcvdERW" role="16NL0q">
-          <property role="2h4Kg1" value="add implicit parameter" />
-        </node>
-      </node>
-      <node concept="ucgPf" id="iSyfcvd_1_" role="3aKz83">
-        <node concept="3clFbS" id="iSyfcvd_1A" role="2VODD2">
-          <node concept="3clFbF" id="iSyfcvdAwU" role="3cqZAp">
-            <node concept="2pJPEk" id="iSyfcvdA$B" role="3clFbG">
-              <node concept="2pJPED" id="iSyfcvdA$D" role="2pJPEn">
-                <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-                <node concept="2pJxcG" id="iSyfcvdAJg" role="2pJxcM">
-                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
-                  <node concept="ub8z3" id="iSyfcvdAN7" role="28ntcv" />
+          <node concept="3clFbF" id="6t5IfhVa_7w" role="3cqZAp">
+            <node concept="2OqwBi" id="6t5IfhVa_iD" role="3clFbG">
+              <node concept="0IXxy" id="6t5IfhVa_7v" role="2Oq$k0" />
+              <node concept="1P9Npp" id="6t5IfhVa_HJ" role="2OqNvi">
+                <node concept="2OqwBi" id="6t5IfhVa_Jk" role="1P9ThW">
+                  <node concept="0IXxy" id="6t5IfhVa_IK" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6t5IfhVaAbH" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:6t5IfhV7vAf" resolve="statement" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -21887,6 +21415,139 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="3ICUPy" id="4qow2eZf3sX">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="aqKnT" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+    <node concept="1Qtc8_" id="4qow2eZf3w$" role="IW6Ez">
+      <node concept="3cWJ9i" id="4qow2eZf3xa" role="1Qtc8$">
+        <node concept="CtIbL" id="4qow2eZf3xc" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+      <node concept="IWgqT" id="4qow2eZf4SI" role="1Qtc8A">
+        <node concept="1hCUdq" id="4qow2eZf4SJ" role="1hCUd6">
+          <node concept="3clFbS" id="4qow2eZf4SK" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf5b3" role="3cqZAp">
+              <node concept="Xl_RD" id="4qow2eZf5b2" role="3clFbG">
+                <property role="Xl_RC" value="=" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="4qow2eZf4SL" role="IWgqQ">
+          <node concept="3clFbS" id="4qow2eZf4SM" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf8Vg" role="3cqZAp">
+              <node concept="2OqwBi" id="4qow2eZf9Z4" role="3clFbG">
+                <node concept="2OqwBi" id="4qow2eZf98M" role="2Oq$k0">
+                  <node concept="7Obwk" id="4qow2eZf8Vf" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4qow2eZf9Od" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                  </node>
+                </node>
+                <node concept="zfrQC" id="4qow2eZfatu" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="4qow2eZf5sj" role="2jiSrf">
+          <node concept="3clFbS" id="4qow2eZf5sk" role="2VODD2">
+            <node concept="3clFbF" id="4qow2eZf5IZ" role="3cqZAp">
+              <node concept="2OqwBi" id="4qow2eZf87R" role="3clFbG">
+                <node concept="2OqwBi" id="4qow2eZf6ce" role="2Oq$k0">
+                  <node concept="7Obwk" id="4qow2eZf5IY" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="4qow2eZf7$1" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                  </node>
+                </node>
+                <node concept="3w_OXm" id="4qow2eZf8$G" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqGtN" id="4qow2eZh_l_" role="2jZA2a">
+          <node concept="3cqJkl" id="4qow2eZh_lA" role="3cqGtW">
+            <node concept="3clFbS" id="4qow2eZh_lB" role="2VODD2">
+              <node concept="3clFbF" id="4qow2eZh_Z1" role="3cqZAp">
+                <node concept="Xl_RD" id="4qow2eZhBj3" role="3clFbG">
+                  <property role="Xl_RC" value="add initializer" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="22hDWj" id="4qow2eZf3ty" role="22hAXT" />
+  </node>
+  <node concept="24kQdi" id="6t5IfhV7vpH">
+    <property role="3GE5qa" value="Statements" />
+    <ref role="1XX52x" to="80bi:6t5IfhV7q21" resolve="LockStatement" />
+    <node concept="3EZMnI" id="6t5IfhV7vr9" role="2wV5jI">
+      <node concept="3EZMnI" id="6t5IfhVaxon" role="3EZMnx">
+        <ref role="1ERwB7" node="6t5IfhVaxwT" resolve="RemoveLock" />
+        <node concept="3F0ifn" id="6t5IfhV7vrH" role="3EZMnx">
+          <property role="3F0ifm" value="lock" />
+        </node>
+        <node concept="3F0ifn" id="6t5IfhV7vse" role="3EZMnx">
+          <property role="3F0ifm" value="(" />
+          <node concept="11LMrY" id="6t5IfhV7vw4" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="6t5IfhV7vD4" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:6t5IfhV7v$m" resolve="expression" />
+        </node>
+        <node concept="3F0ifn" id="6t5IfhV7vsJ" role="3EZMnx">
+          <property role="3F0ifm" value=")" />
+          <node concept="11L4FC" id="6t5IfhV7vxX" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="6t5IfhVaxt5" role="2iSdaV" />
+        <node concept="VPM3Z" id="6t5IfhVaxuZ" role="3F10Kt" />
+        <node concept="2SqB2G" id="6t5IfhVa$ha" role="2SqHTX">
+          <property role="TrG5h" value="lock" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="6t5IfhV7vEZ" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:6t5IfhV7vAf" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="6t5IfhV7vrc" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="iSyfcuX8Tw">
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <ref role="aqKnT" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+    <node concept="3N5dw7" id="iSyfcuX9_3" role="3ft7WO">
+      <node concept="3N5aqt" id="iSyfcuX9_4" role="3Na0zg">
+        <node concept="3clFbS" id="iSyfcuX9_5" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcuXabA" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcuX9Zk" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcuX9Zm" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+                <node concept="2pIpSj" id="iSyfcuXa4o" role="2pJxcM">
+                  <ref role="2pIpSl" to="80bi:7yZ_CF2xDX3" resolve="type" />
+                  <node concept="2pJPED" id="iSyfcuXa5G" role="28nt2d">
+                    <ref role="2pJxaS" to="80bi:5VT83U$LMPZ" resolve="Type" />
+                    <node concept="2pIpSj" id="iSyfcuXa6z" role="2pJxcM">
+                      <ref role="2pIpSl" to="80bi:5VT83U$LPp0" resolve="nonArrayType" />
+                      <node concept="36biLy" id="iSyfcuXa70" role="28nt2d">
+                        <node concept="3N4pyC" id="iSyfcuXa8q" role="36biLW" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2kknPJ" id="iSyfcuX9_n" role="2klrvf">
+        <ref role="2ZyFGn" to="80bi:5_5a0KJX$kh" resolve="INonArrayType" />
+      </node>
+    </node>
+    <node concept="22hDWj" id="iSyfcuX8Ut" role="22hAXT" />
   </node>
   <node concept="22mcaB" id="7HmXimPUxXM">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -22079,69 +21740,6 @@
       </node>
     </node>
   </node>
-  <node concept="24kQdi" id="iHtKXPmS6n">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:iHtKXPmS6d" resolve="LocalVariableDeclaration" />
-    <node concept="3EZMnI" id="iHtKXPmS6p" role="2wV5jI">
-      <node concept="PMmxH" id="iHtKXPmS6w" role="3EZMnx">
-        <ref role="PMmxG" node="5oHFRyIxpOR" resolve="HaveTypeComponent" />
-      </node>
-      <node concept="3F2HdR" id="iHtKXPmS6_" role="3EZMnx">
-        <property role="2czwfO" value="," />
-        <ref role="1NtTu8" to="80bi:iHtKXPmS6l" resolve="variables" />
-        <node concept="l2Vlx" id="iHtKXPmS6B" role="2czzBx" />
-      </node>
-      <node concept="l2Vlx" id="iHtKXPmS6s" role="2iSdaV" />
-    </node>
-  </node>
-  <node concept="PKFIW" id="p4z1jPbmlc">
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingDirectives" />
-    <ref role="1XX52x" to="80bi:p4z1jOVEuK" resolve="NamespaceContainer" />
-    <node concept="3F2HdR" id="p4z1jPms9B" role="2wV5jI">
-      <ref role="1NtTu8" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
-      <ref role="APP_o" node="2H$QQET29s8" resolve="DeleteUsingDirective" />
-      <node concept="2iRkQZ" id="p4z1jPms9D" role="2czzBx" />
-      <node concept="pkWqt" id="p4z1jPmB6p" role="pqm2j">
-        <node concept="3clFbS" id="p4z1jPmB6q" role="2VODD2">
-          <node concept="3clFbF" id="p4z1jPmB8K" role="3cqZAp">
-            <node concept="2OqwBi" id="p4z1jPmFaC" role="3clFbG">
-              <node concept="2OqwBi" id="p4z1jPmBy7" role="2Oq$k0">
-                <node concept="pncrf" id="p4z1jPmB8J" role="2Oq$k0" />
-                <node concept="3Tsc0h" id="p4z1jPmBVu" role="2OqNvi">
-                  <ref role="3TtcxE" to="80bi:2H$QQEUe7tD" resolve="usingDirectives" />
-                </node>
-              </node>
-              <node concept="3GX2aA" id="p4z1jPmLd9" role="2OqNvi" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="24kQdi" id="7HmXimPhQt3">
-    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
-    <ref role="1XX52x" to="80bi:7HmXimPhQc$" resolve="LambdaParameterList" />
-    <node concept="3F2HdR" id="7HmXimPhQtc" role="2wV5jI">
-      <property role="2czwfO" value="," />
-      <ref role="1NtTu8" to="80bi:7HmXimPhQc_" resolve="parameters" />
-      <node concept="l2Vlx" id="7HmXimPhQte" role="2czzBx" />
-      <node concept="3F0ifn" id="7HmXimPwdwN" role="2czzBI">
-        <node concept="VPxyj" id="iSyfcvyupz" role="3F10Kt">
-          <property role="VOm3f" value="true" />
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="PKFIW" id="5QWEwg3W_GX">
-    <property role="TrG5h" value="VariableNameComponent" />
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-    <node concept="3F0A7n" id="5QWEwg3W_GY" role="2wV5jI">
-      <property role="1cu_pB" value="gtguBGO/firstEditableCell" />
-      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
-    </node>
-  </node>
   <node concept="3ICUPy" id="5e5Epz9GuHl">
     <property role="3GE5qa" value="Statements.Yield" />
     <ref role="aqKnT" to="80bi:5e5Epz9BuMX" resolve="IYieldable" />
@@ -22217,6 +21815,473 @@
       </node>
     </node>
   </node>
+  <node concept="1h_SRR" id="6v$Cp0meIXd">
+    <property role="3GE5qa" value="Statements.Using" />
+    <property role="TrG5h" value="RemoveUsing" />
+    <ref role="1h_SK9" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+    <node concept="1hA7zw" id="6v$Cp0meIYf" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <node concept="1hAIg9" id="6v$Cp0meIYg" role="1hA7z_">
+        <node concept="3clFbS" id="6v$Cp0meIYh" role="2VODD2">
+          <node concept="3clFbJ" id="6v$Cp0meJ0l" role="3cqZAp">
+            <node concept="2OqwBi" id="6v$Cp0meJbF" role="3clFbw">
+              <node concept="0IXxy" id="6v$Cp0meJ0L" role="2Oq$k0" />
+              <node concept="2xy62i" id="6v$Cp0meJCJ" role="2OqNvi">
+                <node concept="1Q80Hx" id="6v$Cp0meJDz" role="2xHN3q" />
+                <node concept="2TlHUq" id="6v$Cp0meJED" role="3a7HXU">
+                  <ref role="2TlMyj" node="6v$Cp0meIYc" resolve="using" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="6v$Cp0meJ0n" role="3clFbx">
+              <node concept="3cpWs6" id="6v$Cp0meJHP" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="6v$Cp0meJMN" role="3cqZAp">
+            <node concept="2OqwBi" id="6v$Cp0meJPg" role="3clFbG">
+              <node concept="0IXxy" id="6v$Cp0meJMM" role="2Oq$k0" />
+              <node concept="1P9Npp" id="6v$Cp0meJSl" role="2OqNvi">
+                <node concept="2OqwBi" id="6v$Cp0meJUr" role="1P9ThW">
+                  <node concept="0IXxy" id="6v$Cp0meJSU" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6v$Cp0meK9V" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:iHtKXPjUmo" resolve="statement" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="2H$QQEVkW1m">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:2H$QQEVkVn6" resolve="UsingNamespaceDirective" />
+    <node concept="3EZMnI" id="4tlNOobs7hd" role="2wV5jI">
+      <node concept="l2Vlx" id="4tlNOobs7he" role="2iSdaV" />
+      <node concept="PMmxH" id="2H$QQEV9$DZ" role="3EZMnx">
+        <ref role="PMmxG" node="2H$QQEV9$DW" resolve="UsingKeyword" />
+      </node>
+      <node concept="3F1sOY" id="2H$QQEVqVMB" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:2H$QQEVtErT" resolve="reference" />
+      </node>
+      <node concept="3F0ifn" id="4tlNOobs7it" role="3EZMnx">
+        <property role="3F0ifm" value=";" />
+        <node concept="11L4FC" id="4tlNOobAZFd" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5e5Epz9BuN1">
+    <property role="3GE5qa" value="Statements.Yield" />
+    <ref role="1XX52x" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
+    <node concept="3EZMnI" id="5e5Epz9BuN3" role="2wV5jI">
+      <node concept="3F0ifn" id="5e5Epz9BuN7" role="3EZMnx">
+        <property role="3F0ifm" value="yield" />
+        <ref role="1ERwB7" node="5e5Epz9BuNi" resolve="RemoveYield" />
+        <node concept="2SqB2G" id="5e5Epz9BuNh" role="2SqHTX">
+          <property role="TrG5h" value="yield" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="5e5Epz9BuNc" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5e5Epz9BuN0" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="5e5Epz9BuN6" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="iHtKXPjUmB">
+    <property role="3GE5qa" value="Statements.Using" />
+    <ref role="1XX52x" to="80bi:iHtKXPjP1X" resolve="UsingStatement" />
+    <node concept="3EZMnI" id="iHtKXPjUmD" role="2wV5jI">
+      <node concept="3EZMnI" id="6v$Cp0meIXq" role="3EZMnx">
+        <ref role="1ERwB7" node="6v$Cp0meIXd" resolve="RemoveUsing" />
+        <node concept="VPM3Z" id="6v$Cp0meIXs" role="3F10Kt" />
+        <node concept="l2Vlx" id="6v$Cp0meIXv" role="2iSdaV" />
+        <node concept="3F0ifn" id="iHtKXPjUmK" role="3EZMnx">
+          <property role="3F0ifm" value="using" />
+        </node>
+        <node concept="3F0ifn" id="iHtKXPjUmQ" role="3EZMnx">
+          <property role="3F0ifm" value="(" />
+          <node concept="11LMrY" id="iHtKXPmRNF" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="iHtKXPjUn3" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:iHtKXPjUmm" resolve="resource" />
+        </node>
+        <node concept="3F0ifn" id="iHtKXPjUnd" role="3EZMnx">
+          <property role="3F0ifm" value=")" />
+          <node concept="11L4FC" id="iHtKXPmRNH" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="ljvvj" id="iHtKXPxrIg" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="A1WHu" id="6v$Cp0m9g23" role="3vIgyS">
+            <ref role="A1WHt" node="6v$Cp0m2OEi" resolve="InsertUsing" />
+          </node>
+        </node>
+        <node concept="2SqB2G" id="6v$Cp0meIYc" role="2SqHTX">
+          <property role="TrG5h" value="using" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="iHtKXPjUnw" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:iHtKXPjUmo" resolve="statement" />
+      </node>
+      <node concept="l2Vlx" id="iHtKXPjUmG" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="5e5Epz9BuNi">
+    <property role="3GE5qa" value="Statements.Yield" />
+    <property role="TrG5h" value="RemoveYield" />
+    <ref role="1h_SK9" to="80bi:5e5Epz9Bpur" resolve="YieldStatement" />
+    <node concept="1hA7zw" id="5e5Epz9BuNj" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove yield" />
+      <node concept="1hAIg9" id="5e5Epz9BuNk" role="1hA7z_">
+        <node concept="3clFbS" id="5e5Epz9BuNl" role="2VODD2">
+          <node concept="3clFbJ" id="5e5Epz9BuPE" role="3cqZAp">
+            <node concept="2OqwBi" id="5e5Epz9Bv0X" role="3clFbw">
+              <node concept="0IXxy" id="5e5Epz9BuQ3" role="2Oq$k0" />
+              <node concept="2xy62i" id="5e5Epz9Bx67" role="2OqNvi">
+                <node concept="1Q80Hx" id="5e5Epz9Bx6T" role="2xHN3q" />
+                <node concept="2TlHUq" id="5e5Epz9Mzr3" role="3a7HXU">
+                  <ref role="2TlMyj" node="5e5Epz9BuNh" resolve="yield" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="5e5Epz9BuPG" role="3clFbx">
+              <node concept="3cpWs6" id="5e5Epz9Bxax" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="5e5Epz9BxdQ" role="3cqZAp">
+            <node concept="2OqwBi" id="5e5Epz9BxoZ" role="3clFbG">
+              <node concept="0IXxy" id="5e5Epz9BxdP" role="2Oq$k0" />
+              <node concept="1P9Npp" id="5e5Epz9BxOL" role="2OqNvi">
+                <node concept="2OqwBi" id="5e5Epz9By0k" role="1P9ThW">
+                  <node concept="0IXxy" id="5e5Epz9BxOP" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5e5Epz9Byr8" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:5e5Epz9BuN0" resolve="statement" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="PKFIW" id="2H$QQEV9$DW">
+    <property role="TrG5h" value="UsingKeyword" />
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="1XX52x" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3F0ifn" id="2H$QQEV9$DX" role="2wV5jI">
+      <property role="3F0ifm" value="using" />
+      <node concept="A1WHr" id="2H$QQEV9$DY" role="3vIgyS">
+        <ref role="2ZyFGn" to="80bi:6hv6i2_Axqh" resolve="UsingDirective" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="iHtKXPmS6n">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="1XX52x" to="80bi:iHtKXPmS6d" resolve="LocalVariableDeclaration" />
+    <node concept="3EZMnI" id="iHtKXPmS6p" role="2wV5jI">
+      <node concept="PMmxH" id="iHtKXPmS6w" role="3EZMnx">
+        <ref role="PMmxG" node="5oHFRyIxpOR" resolve="HaveTypeComponent" />
+      </node>
+      <node concept="3F2HdR" id="iHtKXPmS6_" role="3EZMnx">
+        <property role="2czwfO" value="," />
+        <ref role="1NtTu8" to="80bi:iHtKXPmS6l" resolve="variables" />
+        <node concept="l2Vlx" id="iHtKXPmS6B" role="2czzBx" />
+      </node>
+      <node concept="l2Vlx" id="iHtKXPmS6s" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="5QWEwg3W_GX">
+    <property role="TrG5h" value="VariableNameComponent" />
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="1XX52x" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+    <node concept="3F0A7n" id="5QWEwg3W_GY" role="2wV5jI">
+      <property role="1cu_pB" value="gtguBGO/firstEditableCell" />
+      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="4jo$K3ejljC">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <ref role="1XX52x" to="80bi:4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
+    <node concept="3EZMnI" id="4jo$K3ejlkA" role="2wV5jI">
+      <node concept="3F0ifn" id="4jo$K3ejKSa" role="3EZMnx">
+        <property role="3F0ifm" value="var" />
+      </node>
+      <node concept="3F1sOY" id="4jo$K3ejlkI" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:4jo$K3ejllH" resolve="variable" />
+      </node>
+      <node concept="l2Vlx" id="4jo$K3ejlkD" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="7HmXimQhemy">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <property role="TrG5h" value="RemoveAsync" />
+    <ref role="1h_SK9" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+    <node concept="1hA7zw" id="7HmXimQhemz" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove async modifier" />
+      <node concept="1hAIg9" id="7HmXimQhem$" role="1hA7z_">
+        <node concept="3clFbS" id="7HmXimQhem_" role="2VODD2">
+          <node concept="3clFbJ" id="7HmXimQhhSC" role="3cqZAp">
+            <node concept="3clFbS" id="7HmXimQhhT0" role="3clFbx">
+              <node concept="3cpWs6" id="7HmXimQhhWx" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="7HmXimQhfN5" role="3clFbw">
+              <node concept="0IXxy" id="7HmXimQhepk" role="2Oq$k0" />
+              <node concept="2xy62i" id="7HmXimQhgjP" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQhgk$" role="2xHN3q" />
+                <node concept="2TlHUq" id="7HmXimQhhgS" role="3a7HXU">
+                  <ref role="2TlMyj" node="7HmXimQhgZA" resolve="async" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7HmXimQhhZQ" role="3cqZAp">
+            <node concept="37vLTI" id="7HmXimQhlyi" role="3clFbG">
+              <node concept="3clFbT" id="7HmXimQhlyK" role="37vLTx" />
+              <node concept="2OqwBi" id="7HmXimQhibL" role="37vLTJ">
+                <node concept="0IXxy" id="7HmXimQhhZP" role="2Oq$k0" />
+                <node concept="3TrcHB" id="7HmXimQhiES" role="2OqNvi">
+                  <ref role="3TsBF5" to="80bi:5xnAHh08MDV" resolve="isAsync" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="7HmXimQpfUQ" role="3cqZAp">
+            <node concept="2OqwBi" id="7HmXimQpg75" role="3clFbG">
+              <node concept="0IXxy" id="7HmXimQpfUP" role="2Oq$k0" />
+              <node concept="1OKiuA" id="7HmXimQpgC3" role="2OqNvi">
+                <node concept="1Q80Hx" id="7HmXimQpgCH" role="lBI5i" />
+                <node concept="2B6iha" id="7HmXimQpgLt" role="lGT1i">
+                  <property role="1lyBwo" value="1S2pyLby17G/firstEditable" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="iSyfcuUaO9">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="22hDWj" id="iSyfcuUaP6" role="22hAXT" />
+    <node concept="3eGOop" id="iSyfcvd_1$" role="3ft7WO">
+      <node concept="16NL3D" id="iSyfcvd_6u" role="upBLP">
+        <node concept="16Na2f" id="iSyfcvd_6v" role="16NL3A">
+          <node concept="3clFbS" id="iSyfcvd_6w" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAR_" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcvdDfT" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdBzG" role="2Oq$k0" />
+                <node concept="liA8E" id="iSyfcvdEfR" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.matches(java.lang.String)" resolve="matches" />
+                  <node concept="10M0yZ" id="iSyfcvdBgr" role="37wK5m">
+                    <ref role="3cqZAo" node="5cm0BoTKIaF" resolve="identifier" />
+                    <ref role="1PxDUh" node="6H78krhSzlS" resolve="SubstitutionUtils" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NfWO" id="iSyfcvdEGh" role="upBLP">
+        <node concept="uGdhv" id="iSyfcvd_WF" role="16NeZM">
+          <node concept="3clFbS" id="iSyfcvd_WH" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcvdAdP" role="3cqZAp">
+              <node concept="3K4zz7" id="iSyfcvdAdQ" role="3clFbG">
+                <node concept="ub8z3" id="iSyfcvdAdR" role="3K4E3e" />
+                <node concept="Xl_RD" id="iSyfcvdAdS" role="3K4GZi">
+                  <property role="Xl_RC" value="&lt;name&gt;" />
+                </node>
+                <node concept="2OqwBi" id="iSyfcvdAdT" role="3K4Cdx">
+                  <node concept="ub8z3" id="iSyfcvdAdU" role="2Oq$k0" />
+                  <node concept="17RvpY" id="iSyfcvdAdV" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="16NL0t" id="iSyfcvd_VB" role="upBLP">
+        <node concept="2h3Zct" id="iSyfcvdERW" role="16NL0q">
+          <property role="2h4Kg1" value="add implicit parameter" />
+        </node>
+      </node>
+      <node concept="ucgPf" id="iSyfcvd_1_" role="3aKz83">
+        <node concept="3clFbS" id="iSyfcvd_1A" role="2VODD2">
+          <node concept="3clFbF" id="iSyfcvdAwU" role="3cqZAp">
+            <node concept="2pJPEk" id="iSyfcvdA$B" role="3clFbG">
+              <node concept="2pJPED" id="iSyfcvdA$D" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+                <node concept="2pJxcG" id="iSyfcvdAJg" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="ub8z3" id="iSyfcvdAN7" role="28ntcv" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="6O4r_tdj4Zm">
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <property role="TrG5h" value="VariableDeclaration_InitializerActions" />
+    <ref role="1h_SK9" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
+    <node concept="1hA7zw" id="6O4r_tdj4ZV" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove initializer" />
+      <node concept="1hAIg9" id="6O4r_tdj4ZW" role="1hA7z_">
+        <node concept="3clFbS" id="6O4r_tdj4ZX" role="2VODD2">
+          <node concept="3clFbJ" id="6O4r_tdsXfk" role="3cqZAp">
+            <node concept="3clFbS" id="6O4r_tdsXfm" role="3clFbx">
+              <node concept="3cpWs6" id="6O4r_tdvosy" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="6O4r_tdqypA" role="3clFbw">
+              <node concept="2OqwBi" id="6O4r_tdqxFH" role="2Oq$k0">
+                <node concept="0IXxy" id="6O4r_tdqxuW" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6O4r_tdqxX6" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                </node>
+              </node>
+              <node concept="2xy62i" id="6O4r_tdqyEY" role="2OqNvi">
+                <node concept="1Q80Hx" id="6O4r_tdqyIL" role="2xHN3q" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6O4r_tdvozc" role="3cqZAp">
+            <node concept="2OqwBi" id="5QWEwg3xiAN" role="3clFbG">
+              <node concept="2OqwBi" id="6O4r_tdvoNo" role="2Oq$k0">
+                <node concept="0IXxy" id="6O4r_tdvozb" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6O4r_tdvpn$" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                </node>
+              </node>
+              <node concept="3YRAZt" id="5QWEwg3xj1L" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbF" id="5QWEwg3xj5b" role="3cqZAp">
+            <node concept="2OqwBi" id="5QWEwg3xjiC" role="3clFbG">
+              <node concept="0IXxy" id="5QWEwg3xj5a" role="2Oq$k0" />
+              <node concept="1OKiuA" id="5QWEwg3xkga" role="2OqNvi">
+                <node concept="1Q80Hx" id="5QWEwg3xkhv" role="lBI5i" />
+                <node concept="2B6iha" id="5QWEwg3xkjU" role="lGT1i">
+                  <property role="1lyBwo" value="1S2pyLby17D/lastEditable" />
+                </node>
+                <node concept="3cmrfG" id="5QWEwg3xkmh" role="3dN3m$">
+                  <property role="3cmrfH" value="-1" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="5QWEwg3Ag4i" role="jK8aL">
+        <node concept="3clFbS" id="5QWEwg3Ag4j" role="2VODD2">
+          <node concept="3clFbF" id="5QWEwg3AgpF" role="3cqZAp">
+            <node concept="2OqwBi" id="5QWEwg3AijH" role="3clFbG">
+              <node concept="2OqwBi" id="5QWEwg3AgQ0" role="2Oq$k0">
+                <node concept="0IXxy" id="5QWEwg3AgpE" role="2Oq$k0" />
+                <node concept="3TrEf2" id="5QWEwg3AhTF" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
+                </node>
+              </node>
+              <node concept="3x8VRR" id="5QWEwg3AiZA" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="1XmGakPdCcn">
+    <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
+    <ref role="aqKnT" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
+    <node concept="1Qtc8_" id="1XmGakPdCTK" role="IW6Ez">
+      <node concept="aenpk" id="1XmGakPyjZS" role="1Qtc8A">
+        <node concept="mvV$s" id="1XmGakPsIwl" role="aenpr">
+          <node concept="A1WHu" id="1XmGakPsIyw" role="A14EM">
+            <ref role="A1WHt" node="7HmXimR0WHi" resolve="AddAsync" />
+          </node>
+          <node concept="mvVNg" id="1XmGakPsIyy" role="mvV$0">
+            <node concept="3clFbS" id="1XmGakPsIyz" role="2VODD2">
+              <node concept="3clFbF" id="1XmGakPsIBg" role="3cqZAp">
+                <node concept="2OqwBi" id="1XmGakPsIQk" role="3clFbG">
+                  <node concept="7Obwk" id="1XmGakPsIBf" role="2Oq$k0" />
+                  <node concept="2Xjw5R" id="1XmGakPsJja" role="2OqNvi">
+                    <node concept="1xMEDy" id="1XmGakPsJjc" role="1xVPHs">
+                      <node concept="chp4Y" id="1XmGakPsJlI" role="ri$Ld">
+                        <ref role="cht4Q" to="80bi:7HmXimPhNc2" resolve="LambdaExpression" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="1XmGakPyk0K" role="aenpu">
+          <node concept="3clFbS" id="1XmGakPyk0L" role="2VODD2">
+            <node concept="3clFbF" id="1XmGakPykgT" role="3cqZAp">
+              <node concept="2OqwBi" id="1XmGakPyrkp" role="3clFbG">
+                <node concept="2OqwBi" id="1XmGakPykFi" role="2Oq$k0">
+                  <node concept="7Obwk" id="1XmGakPykgS" role="2Oq$k0" />
+                  <node concept="2TvwIu" id="1XmGakPyl8H" role="2OqNvi" />
+                </node>
+                <node concept="1v1jN8" id="1XmGakPyu_9" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3c8P5G" id="iSyfcuX8bg" role="1Qtc8A">
+        <node concept="2kknPJ" id="iSyfcuX8fF" role="3c8P5H">
+          <ref role="2ZyFGn" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+        </node>
+        <node concept="3c8PGw" id="iSyfcuX8bj" role="3c8PHt">
+          <node concept="3clFbS" id="iSyfcuX8bl" role="2VODD2">
+            <node concept="3clFbF" id="iSyfcuZZkQ" role="3cqZAp">
+              <node concept="37vLTI" id="iSyfcv02Kz" role="3clFbG">
+                <node concept="2OqwBi" id="iSyfcv02W$" role="37vLTx">
+                  <node concept="7Obwk" id="iSyfcv02Li" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcv03bD" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="iSyfcuZZwd" role="37vLTJ">
+                  <node concept="3c8USq" id="iSyfcuZZkP" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="iSyfcuZZJ9" role="2OqNvi">
+                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="iSyfcv03n3" role="3cqZAp">
+              <node concept="2OqwBi" id="iSyfcv03ww" role="3clFbG">
+                <node concept="7Obwk" id="iSyfcw2bX7" role="2Oq$k0" />
+                <node concept="1P9Npp" id="iSyfcv03LP" role="2OqNvi">
+                  <node concept="3c8USq" id="iSyfcv03MP" role="1P9ThW" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="1XmGakPdCTO" role="1Qtc8$">
+        <node concept="CtIbL" id="1XmGakPdCTQ" role="CtIbM">
+          <property role="CtIbK" value="1A4kJjlVmVt/LEFT" />
+        </node>
+      </node>
+    </node>
+    <node concept="22hDWj" id="1XmGakPmOWV" role="22hAXT" />
+  </node>
   <node concept="24kQdi" id="5xnAHgZZgy7">
     <property role="3GE5qa" value="Expressions.Unary" />
     <ref role="1XX52x" to="80bi:5xnAHgZZgnF" resolve="AwaitExpression" />
@@ -22232,83 +22297,6 @@
       <node concept="3F1sOY" id="5xnAHgZZgCI" role="3EZMnx">
         <ref role="1NtTu8" to="80bi:5xnAHgZZgtR" resolve="task" />
       </node>
-    </node>
-  </node>
-  <node concept="3ICUPy" id="4qow2eZf3sX">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="aqKnT" to="80bi:6JhOkL8vqJY" resolve="VariableDeclaration" />
-    <node concept="1Qtc8_" id="4qow2eZf3w$" role="IW6Ez">
-      <node concept="3cWJ9i" id="4qow2eZf3xa" role="1Qtc8$">
-        <node concept="CtIbL" id="4qow2eZf3xc" role="CtIbM">
-          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
-        </node>
-      </node>
-      <node concept="IWgqT" id="4qow2eZf4SI" role="1Qtc8A">
-        <node concept="1hCUdq" id="4qow2eZf4SJ" role="1hCUd6">
-          <node concept="3clFbS" id="4qow2eZf4SK" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf5b3" role="3cqZAp">
-              <node concept="Xl_RD" id="4qow2eZf5b2" role="3clFbG">
-                <property role="Xl_RC" value="=" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="IWg2L" id="4qow2eZf4SL" role="IWgqQ">
-          <node concept="3clFbS" id="4qow2eZf4SM" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf8Vg" role="3cqZAp">
-              <node concept="2OqwBi" id="4qow2eZf9Z4" role="3clFbG">
-                <node concept="2OqwBi" id="4qow2eZf98M" role="2Oq$k0">
-                  <node concept="7Obwk" id="4qow2eZf8Vf" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4qow2eZf9Od" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                  </node>
-                </node>
-                <node concept="zfrQC" id="4qow2eZfatu" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="27VH4U" id="4qow2eZf5sj" role="2jiSrf">
-          <node concept="3clFbS" id="4qow2eZf5sk" role="2VODD2">
-            <node concept="3clFbF" id="4qow2eZf5IZ" role="3cqZAp">
-              <node concept="2OqwBi" id="4qow2eZf87R" role="3clFbG">
-                <node concept="2OqwBi" id="4qow2eZf6ce" role="2Oq$k0">
-                  <node concept="7Obwk" id="4qow2eZf5IY" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4qow2eZf7$1" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:2HvFt1LDv0x" resolve="initializer" />
-                  </node>
-                </node>
-                <node concept="3w_OXm" id="4qow2eZf8$G" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cqGtN" id="4qow2eZh_l_" role="2jZA2a">
-          <node concept="3cqJkl" id="4qow2eZh_lA" role="3cqGtW">
-            <node concept="3clFbS" id="4qow2eZh_lB" role="2VODD2">
-              <node concept="3clFbF" id="4qow2eZh_Z1" role="3cqZAp">
-                <node concept="Xl_RD" id="4qow2eZhBj3" role="3clFbG">
-                  <property role="Xl_RC" value="add initializer" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="22hDWj" id="4qow2eZf3ty" role="22hAXT" />
-  </node>
-  <node concept="24kQdi" id="4jo$K3ejljC">
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <ref role="1XX52x" to="80bi:4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
-    <node concept="3EZMnI" id="4jo$K3ejlkA" role="2wV5jI">
-      <node concept="3F0ifn" id="4jo$K3ejKSa" role="3EZMnx">
-        <property role="3F0ifm" value="var" />
-      </node>
-      <node concept="3F1sOY" id="4jo$K3ejlkI" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:4jo$K3ejllH" resolve="variable" />
-      </node>
-      <node concept="l2Vlx" id="4jo$K3ejlkD" role="2iSdaV" />
     </node>
   </node>
   <node concept="24kQdi" id="2H$QQEUtQI6">

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -25,7 +25,9 @@
         <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
         <child id="3348158742936976577" name="members" index="25R1y" />
       </concept>
-      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9" />
+      <concept id="1224240836180" name="jetbrains.mps.lang.structure.structure.DeprecatedNodeAnnotation" flags="ig" index="asaX9">
+        <property id="1225118933224" name="comment" index="YLQ7P" />
+      </concept>
       <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
         <property id="7862711839422615217" name="text" index="t5JxN" />
       </concept>
@@ -3271,7 +3273,25 @@
         </node>
         <node concept="1PaTwC" id="7TfmMh1pDSg" role="1PaQFQ">
           <node concept="3oM_SD" id="7TfmMh1pDSf" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: type-parameter" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0MC" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0MD" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0ME" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0MF" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0MG" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77R0MH" role="1PaTwD">
+            <property role="3oM_SC" value="type-parameter" />
           </node>
         </node>
       </node>
@@ -14635,7 +14655,22 @@
         </node>
         <node concept="1PaTwC" id="2vo5eZuHBSn" role="1PaQFQ">
           <node concept="3oM_SD" id="2vo5eZuHBSm" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar:" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77chOO" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77chOP" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77chOQ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77chOR" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77chOS" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
           </node>
           <node concept="3oM_SD" id="2vo5eZuHBUb" role="1PaTwD">
             <property role="3oM_SC" value="no" />
@@ -14664,6 +14699,9 @@
       <property role="20kJfa" value="typeParameterConstraintsClause" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="6hv6i2_AXOQ" resolve="TypeParameterConstraintsClause" />
+    </node>
+    <node concept="PrWs8" id="6u44Y77chP5" role="PrDN$">
+      <ref role="PrY4T" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
     </node>
   </node>
   <node concept="1TIwiD" id="3zXINoFWW$0">
@@ -15179,7 +15217,7 @@
     <property role="TrG5h" value="GenericTypeParameterReference" />
     <property role="3GE5qa" value="References.TypeRelatedReferences" />
     <property role="R4oN_" value="Reference to a generic type parameter" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="27q4jmdWYxN" resolve="TypeReference" />
     <node concept="1TJgyj" id="2wJFJXA1jf" role="1TKVEi">
       <property role="IQ2ns" value="45245710896469199" />
       <property role="20kJfa" value="typeParameter" />
@@ -15216,79 +15254,59 @@
             <property role="3oM_SC" value="" />
           </node>
         </node>
-        <node concept="1PaTwC" id="27q4jmdX6G0" role="1PaQFQ">
-          <node concept="3oM_SD" id="27q4jmdX6FZ" role="1PaTwD">
-            <property role="3oM_SC" value="Note" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6Gj" role="1PaTwD">
-            <property role="3oM_SC" value="that" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6Gm" role="1PaTwD">
-            <property role="3oM_SC" value="implementation" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6Gq" role="1PaTwD">
-            <property role="3oM_SC" value="of" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6Gv" role="1PaTwD">
-            <property role="3oM_SC" value="generic" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6G_" role="1PaTwD">
-            <property role="3oM_SC" value="type" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6GG" role="1PaTwD">
-            <property role="3oM_SC" value="parameters" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6GO" role="1PaTwD">
-            <property role="3oM_SC" value="is" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6GX" role="1PaTwD">
-            <property role="3oM_SC" value="not" />
-          </node>
-          <node concept="3oM_SD" id="27q4jmdX6H7" role="1PaTwD">
-            <property role="3oM_SC" value="ideal:" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="27q4jmdX6Hj" role="1PaQFQ">
-          <node concept="3oM_SD" id="27q4jmdX6Hi" role="1PaTwD">
+        <node concept="1PaTwC" id="6u44Y776UeS" role="1PaQFQ">
+          <node concept="3oM_SD" id="6u44Y776UeR" role="1PaTwD">
             <property role="3oM_SC" value="The" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6Ir" role="1PaTwD">
-            <property role="3oM_SC" value="concept" />
+          <node concept="3oM_SD" id="6u44Y776Ufl" role="1PaTwD">
+            <property role="3oM_SC" value="scope" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6HL" role="1PaTwD">
-            <property role="3oM_SC" value="GenericTypeParameterReference" />
+          <node concept="3oM_SD" id="6u44Y776Ufo" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6HO" role="1PaTwD">
-            <property role="3oM_SC" value="should" />
+          <node concept="3oM_SD" id="6u44Y776Ufs" role="1PaTwD">
+            <property role="3oM_SC" value="type" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6HS" role="1PaTwD">
-            <property role="3oM_SC" value="inherit" />
+          <node concept="3oM_SD" id="6u44Y776Ufx" role="1PaTwD">
+            <property role="3oM_SC" value="parameters" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6I_" role="1PaTwD">
-            <property role="3oM_SC" value="TypeReference" />
+          <node concept="3oM_SD" id="6u44Y776UfB" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
           </node>
-        </node>
-        <node concept="1PaTwC" id="27q4jmdX6IJ" role="1PaQFQ">
-          <node concept="3oM_SD" id="27q4jmdX6II" role="1PaTwD">
-            <property role="3oM_SC" value="and" />
+          <node concept="3oM_SD" id="6u44Y776UfI" role="1PaTwD">
+            <property role="3oM_SC" value="composed" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6Ia" role="1PaTwD">
+          <node concept="3oM_SD" id="6u44Y776UfQ" role="1PaTwD">
+            <property role="3oM_SC" value="recursively" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y776UfZ" role="1PaTwD">
+            <property role="3oM_SC" value="by" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y776UiJ" role="1PaTwD">
             <property role="3oM_SC" value="the" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6Ii" role="1PaTwD">
-            <property role="3oM_SC" value="concept" />
+        </node>
+        <node concept="1PaTwC" id="6u44Y776UiV" role="1PaQFQ">
+          <node concept="3oM_SD" id="6u44Y776UiU" role="1PaTwD">
+            <property role="3oM_SC" value="parent" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6Js" role="1PaTwD">
-            <property role="3oM_SC" value="GenericTypeParameterReferenceString" />
+          <node concept="3oM_SD" id="6u44Y776UjP" role="1PaTwD">
+            <property role="3oM_SC" value="methods" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6Jx" role="1PaTwD">
-            <property role="3oM_SC" value="should" />
+          <node concept="3oM_SD" id="6u44Y776UjS" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6JB" role="1PaTwD">
-            <property role="3oM_SC" value="be" />
+          <node concept="3oM_SD" id="6u44Y776UjW" role="1PaTwD">
+            <property role="3oM_SC" value="classes" />
           </node>
-          <node concept="3oM_SD" id="27q4jmdX6JI" role="1PaTwD">
-            <property role="3oM_SC" value="removed." />
+          <node concept="3oM_SD" id="6u44Y77bTXu" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77bTX$" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6u44Y77bTXF" role="1PaTwD">
+            <property role="3oM_SC" value="reference." />
           </node>
         </node>
         <node concept="1PaTwC" id="1HkqSaCLqMb" role="1PaQFQ">
@@ -16111,6 +16129,9 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="asaX9" id="6u44Y770kpo" role="lGtFl">
+      <property role="YLQ7P" value="Replaced by GenericTypeParameterReference" />
     </node>
   </node>
   <node concept="PlHQZ" id="1HkqSaCLgAV">
@@ -16993,245 +17014,6 @@
     <property role="34LRSv" value="set" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
   </node>
-  <node concept="1TIwiD" id="2H$QQEVkVn6">
-    <property role="EcuMT" value="3126865292757808582" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingNamespaceDirective" />
-    <property role="34LRSv" value="using" />
-    <property role="R4oN_" value="Using directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
-            <property role="3oM_SC" value="using-namespace-directive" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098553" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="p4z1jOVEuK">
-    <property role="EcuMT" value="451639884280407984" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="NamespaceContainer" />
-    <property role="R5$K7" value="true" />
-    <property role="R4oN_" value="Represents files and namespaces" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588292748" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="usingDirectives" />
-      <property role="20lbJX" value="fLJekj5/_0__n" />
-      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    </node>
-    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="2H$QQEUtQI0">
-    <property role="EcuMT" value="3126865292743371648" />
-    <property role="3GE5qa" value="Namespace" />
-    <property role="TrG5h" value="UsingAliasDirective" />
-    <property role="34LRSv" value="using alias" />
-    <property role="R4oN_" value="Using alias directive" />
-    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
-    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
-      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
-    </node>
-    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
-      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
-        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
-          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
-            <property role="3oM_SC" value="C#" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
-            <property role="3oM_SC" value="5.0" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
-            <property role="3oM_SC" value="grammar" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
-            <property role="3oM_SC" value="entry:" />
-          </node>
-          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
-            <property role="3oM_SC" value="using-alias-directive" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
-      <property role="IQ2ns" value="3126865292760098556" />
-      <property role="20kJfa" value="reference" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="p4z1jNJogm">
-    <property role="EcuMT" value="451639884260410390" />
-    <property role="TrG5h" value="NamespaceReference" />
-    <property role="R4oN_" value="Reference to a namespace" />
-    <property role="3GE5qa" value="References.TypeRelatedReferences" />
-    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
-    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
-      <property role="IQ2ns" value="451639884260410769" />
-      <property role="20kJfa" value="referencedType" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
-      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="5xnAHgZa2vT">
-    <property role="EcuMT" value="6365726834694825977" />
-    <property role="TrG5h" value="ImplicitLocalVariableDeclarationStatement" />
-    <property role="34LRSv" value="var" />
-    <property role="R4oN_" value="implicitly-typed local variable" />
-    <property role="3GE5qa" value="Statements.Declaration" />
-    <ref role="1TJDcQ" node="1FYNzU$mBmN" resolve="DeclarationStatement" />
-    <node concept="1TJgyj" id="5xnAHgZdlnx" role="1TKVEi">
-      <property role="IQ2ns" value="6365726834695689697" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="declaration" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
-    </node>
-    <node concept="PrWs8" id="5xnAHgZghJ3" role="PzmwI">
-      <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
-    </node>
-  </node>
-  <node concept="1TIwiD" id="iHtKXPjP1X">
-    <property role="EcuMT" value="337056455399002237" />
-    <property role="3GE5qa" value="Statements.Using" />
-    <property role="TrG5h" value="UsingStatement" />
-    <property role="34LRSv" value="using" />
-    <property role="R4oN_" value="using statement" />
-    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
-    <node concept="1TJgyj" id="iHtKXPjUmm" role="1TKVEi">
-      <property role="IQ2ns" value="337056455399024022" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="resource" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="iHtKXPjUmu" resolve="IResourceAcquisition" />
-    </node>
-    <node concept="1TJgyj" id="iHtKXPjUmo" role="1TKVEi">
-      <property role="IQ2ns" value="337056455399024024" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="statement" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
-    </node>
-  </node>
-  <node concept="PlHQZ" id="iHtKXPjUmu">
-    <property role="TrG5h" value="IResourceAcquisition" />
-    <property role="3GE5qa" value="Statements.Using" />
-    <property role="EcuMT" value="337056455399024029" />
-    <node concept="3H0Qfr" id="iHtKXPOlvX" role="lGtFl">
-      <node concept="1Pa9Pv" id="iHtKXPOlvY" role="3H0Qfi">
-        <node concept="1PaTwC" id="iHtKXPOlvZ" role="1PaQFQ">
-          <node concept="3oM_SD" id="iHtKXPOlwe" role="1PaTwD">
-            <property role="3oM_SC" value="Corresponds" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwO2" role="1PaTwD">
-            <property role="3oM_SC" value="to" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwNT" role="1PaTwD">
-            <property role="3oM_SC" value="resource-acquisition" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwOc" role="1PaTwD">
-            <property role="3oM_SC" value="in" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwOn" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwOY" role="1PaTwD">
-            <property role="3oM_SC" value="specification" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwPb" role="1PaTwD">
-            <property role="3oM_SC" value="and" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwPp" role="1PaTwD">
-            <property role="3oM_SC" value="marks" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwPC" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwS0" role="1PaTwD">
-            <property role="3oM_SC" value="concepts" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwPS" role="1PaTwD">
-            <property role="3oM_SC" value="that" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwQ9" role="1PaTwD">
-            <property role="3oM_SC" value="can" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwQr" role="1PaTwD">
-            <property role="3oM_SC" value="fulfil" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwQI" role="1PaTwD">
-            <property role="3oM_SC" value="this" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwR2" role="1PaTwD">
-            <property role="3oM_SC" value="role" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOwRn" role="1PaTwD">
-            <property role="3oM_SC" value="in" />
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOl$B" role="1PaTwD">
-            <property role="3oM_SC" value="a" />
-          </node>
-          <node concept="tu5oc" id="iHtKXPOlwG" role="1PaTwD">
-            <node concept="2tMXA0" id="iHtKXPOlwU" role="tu5of">
-              <ref role="2tMXA_" node="iHtKXPjP1X" resolve="UsingStatement" />
-            </node>
-          </node>
-          <node concept="3oM_SD" id="iHtKXPOlyn" role="1PaTwD">
-            <property role="3oM_SC" value="." />
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
-  <node concept="1TIwiD" id="iHtKXPmS6d">
-    <property role="EcuMT" value="337056455399801229" />
-    <property role="3GE5qa" value="Identifiers.Concepts" />
-    <property role="TrG5h" value="LocalVariableDeclaration" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="iHtKXPmS6i" role="PzmwI">
-      <ref role="PrY4T" node="5oHFRyIxp1s" resolve="IHaveType" />
-    </node>
-    <node concept="PrWs8" id="iHtKXPO9tS" role="PzmwI">
-      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
-    </node>
-    <node concept="PrWs8" id="iHtKXPmS6e" role="PzmwI">
-      <ref role="PrY4T" node="iHtKXPjUmu" resolve="IResourceAcquisition" />
-    </node>
-    <node concept="1TJgyj" id="iHtKXPmS6l" role="1TKVEi">
-      <property role="IQ2ns" value="337056455399801237" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="variables" />
-      <property role="20lbJX" value="fLJekj6/_1__n" />
-      <ref role="20lvS9" node="6JhOkL8vqJY" resolve="VariableDeclaration" />
-    </node>
-  </node>
   <node concept="1TIwiD" id="7HmXimPhQc$">
     <property role="EcuMT" value="8887560456966202148" />
     <property role="TrG5h" value="LambdaParameterList" />
@@ -17401,6 +17183,54 @@
       </node>
     </node>
   </node>
+  <node concept="1TIwiD" id="5e5Epz9Bpur">
+    <property role="EcuMT" value="6018402950733207451" />
+    <property role="3GE5qa" value="Statements.Yield" />
+    <property role="TrG5h" value="YieldStatement" />
+    <property role="34LRSv" value="yield" />
+    <property role="R4oN_" value="yield statement" />
+    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
+    <node concept="1TJgyj" id="5e5Epz9BuN0" role="1TKVEi">
+      <property role="IQ2ns" value="6018402950733229248" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="statement" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5e5Epz9BuMX" resolve="IYieldable" />
+    </node>
+    <node concept="3H0Qfr" id="5e5Epza10IQ" role="lGtFl">
+      <node concept="1Pa9Pv" id="5e5Epza10IR" role="3H0Qfi">
+        <node concept="1PaTwC" id="5e5Epza10IS" role="1PaQFQ">
+          <node concept="3oM_SD" id="5e5Epza10IT" role="1PaTwD">
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwi" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwl" role="1PaTwD">
+            <property role="3oM_SC" value="yield-statement," />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwm" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwn" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwo" role="1PaTwD">
+            <property role="3oM_SC" value="§8.14" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwp" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwq" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6CB8zQnAWwr" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
   <node concept="1TIwiD" id="7HmXimPhQcC">
     <property role="EcuMT" value="8887560456966202152" />
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -17493,6 +17323,64 @@
       </node>
     </node>
   </node>
+  <node concept="1TIwiD" id="6t5IfhV7q21">
+    <property role="EcuMT" value="7441557319476682881" />
+    <property role="3GE5qa" value="Statements" />
+    <property role="TrG5h" value="LockStatement" />
+    <property role="34LRSv" value="lock" />
+    <property role="R4oN_" value="lock statement" />
+    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
+    <node concept="1TJgyj" id="6t5IfhV7v$m" role="1TKVEi">
+      <property role="IQ2ns" value="7441557319476705558" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5VT83U$LgKs" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="6t5IfhV7vAf" role="1TKVEi">
+      <property role="IQ2ns" value="7441557319476705679" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="statement" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
+    </node>
+    <node concept="3H0Qfr" id="7BRYAO5ggs3" role="lGtFl">
+      <node concept="1Pa9Pv" id="7BRYAO5ggs4" role="3H0Qfi">
+        <node concept="1PaTwC" id="7BRYAO5ggs5" role="1PaQFQ">
+          <node concept="3oM_SD" id="7BRYAO5ggs6" role="1PaTwD">
+            <property role="3oM_SC" value="Corresponds" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggut" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5gguu" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5gguX" role="1PaTwD">
+            <property role="3oM_SC" value="lock-statement" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggvU" role="1PaTwD">
+            <property role="3oM_SC" value="defined" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggwp" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggwq" role="1PaTwD">
+            <property role="3oM_SC" value="§8.12" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggxn" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggxo" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7BRYAO5ggxR" role="1PaTwD">
+            <property role="3oM_SC" value="specification." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
   <node concept="1TIwiD" id="7HmXimPhNc2">
     <property role="EcuMT" value="8887560456966189826" />
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
@@ -17551,6 +17439,46 @@
       <ref role="PrY4T" node="7HmXimRLOdX" resolve="ICanBeAsync" />
     </node>
   </node>
+  <node concept="1TIwiD" id="5xnAHgZa2vT">
+    <property role="EcuMT" value="6365726834694825977" />
+    <property role="TrG5h" value="ImplicitLocalVariableDeclarationStatement" />
+    <property role="34LRSv" value="var" />
+    <property role="R4oN_" value="implicitly-typed local variable" />
+    <property role="3GE5qa" value="Statements.Declaration" />
+    <ref role="1TJDcQ" node="1FYNzU$mBmN" resolve="DeclarationStatement" />
+    <node concept="1TJgyj" id="5xnAHgZdlnx" role="1TKVEi">
+      <property role="IQ2ns" value="6365726834695689697" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="declaration" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="4jo$K3ejl4y" resolve="ImplicitLocalVariableDeclaration" />
+    </node>
+    <node concept="PrWs8" id="5xnAHgZghJ3" role="PzmwI">
+      <ref role="PrY4T" node="1FYNzU$v7xY" resolve="IForInitializer" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="iHtKXPjP1X">
+    <property role="EcuMT" value="337056455399002237" />
+    <property role="3GE5qa" value="Statements.Using" />
+    <property role="TrG5h" value="UsingStatement" />
+    <property role="34LRSv" value="using" />
+    <property role="R4oN_" value="using statement" />
+    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
+    <node concept="1TJgyj" id="iHtKXPjUmm" role="1TKVEi">
+      <property role="IQ2ns" value="337056455399024022" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="resource" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="iHtKXPjUmu" resolve="IResourceAcquisition" />
+    </node>
+    <node concept="1TJgyj" id="iHtKXPjUmo" role="1TKVEi">
+      <property role="IQ2ns" value="337056455399024024" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="statement" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
+    </node>
+  </node>
   <node concept="1TIwiD" id="5xnAHgZZgnF">
     <property role="EcuMT" value="6365726834708776427" />
     <property role="3GE5qa" value="Expressions.Unary" />
@@ -17605,26 +17533,40 @@
       </node>
     </node>
   </node>
-  <node concept="PlHQZ" id="7HmXimRLOdX">
-    <property role="TrG5h" value="ICanBeAsync" />
-    <property role="EcuMT" value="8887560457008137085" />
-    <property role="3GE5qa" value="Modifiers" />
-    <node concept="1TJgyi" id="5xnAHh08MDV" role="1TKVEl">
-      <property role="IQ2nx" value="6365726834711276155" />
-      <property role="TrG5h" value="isAsync" />
-      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+  <node concept="1TIwiD" id="2H$QQEVkVn6">
+    <property role="EcuMT" value="3126865292757808582" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingNamespaceDirective" />
+    <property role="34LRSv" value="using" />
+    <property role="R4oN_" value="Using directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="3H0Qfr" id="2H$QQEVoyMr" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyMs" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyMt" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyMu" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMD" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMG" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMK" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMP" role="1PaTwD">
+            <property role="3oM_SC" value="using-namespace-directive" />
+          </node>
+        </node>
+      </node>
     </node>
-  </node>
-  <node concept="1TIwiD" id="iSyfcvrmN2">
-    <property role="TrG5h" value="Parameter" />
-    <property role="EcuMT" value="340172349652162055" />
-    <property role="R5$K7" value="true" />
-    <property role="3GE5qa" value="Class / Struct.Parameters" />
-    <node concept="PrWs8" id="iSyfcvrmTa" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-    <node concept="PrWs8" id="iSyfcvrmTc" role="PzmwI">
-      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
+    <node concept="1TJgyj" id="2H$QQEVtErT" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098553" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="p4z1jNJogm" resolve="NamespaceReference" />
     </node>
   </node>
   <node concept="1TIwiD" id="4jo$K3ejl4y">
@@ -17870,116 +17812,195 @@
       </node>
     </node>
   </node>
-  <node concept="1TIwiD" id="6t5IfhV7q21">
-    <property role="EcuMT" value="7441557319476682881" />
-    <property role="3GE5qa" value="Statements" />
-    <property role="TrG5h" value="LockStatement" />
-    <property role="34LRSv" value="lock" />
-    <property role="R4oN_" value="lock statement" />
-    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
-    <node concept="1TJgyj" id="6t5IfhV7v$m" role="1TKVEi">
-      <property role="IQ2ns" value="7441557319476705558" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="expression" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="5VT83U$LgKs" resolve="Expression" />
-    </node>
-    <node concept="1TJgyj" id="6t5IfhV7vAf" role="1TKVEi">
-      <property role="IQ2ns" value="7441557319476705679" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="statement" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
-    </node>
-    <node concept="3H0Qfr" id="7BRYAO5ggs3" role="lGtFl">
-      <node concept="1Pa9Pv" id="7BRYAO5ggs4" role="3H0Qfi">
-        <node concept="1PaTwC" id="7BRYAO5ggs5" role="1PaQFQ">
-          <node concept="3oM_SD" id="7BRYAO5ggs6" role="1PaTwD">
-            <property role="3oM_SC" value="Corresponds" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggut" role="1PaTwD">
-            <property role="3oM_SC" value="to" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5gguu" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5gguX" role="1PaTwD">
-            <property role="3oM_SC" value="lock-statement" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggvU" role="1PaTwD">
-            <property role="3oM_SC" value="defined" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggwp" role="1PaTwD">
-            <property role="3oM_SC" value="in" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggwq" role="1PaTwD">
-            <property role="3oM_SC" value="§8.12" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggxn" role="1PaTwD">
-            <property role="3oM_SC" value="of" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggxo" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="7BRYAO5ggxR" role="1PaTwD">
-            <property role="3oM_SC" value="specification." />
-          </node>
-        </node>
-      </node>
+  <node concept="PlHQZ" id="7HmXimRLOdX">
+    <property role="TrG5h" value="ICanBeAsync" />
+    <property role="EcuMT" value="8887560457008137085" />
+    <property role="3GE5qa" value="Modifiers" />
+    <node concept="1TJgyi" id="5xnAHh08MDV" role="1TKVEl">
+      <property role="IQ2nx" value="6365726834711276155" />
+      <property role="TrG5h" value="isAsync" />
+      <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
   </node>
-  <node concept="1TIwiD" id="5e5Epz9Bpur">
-    <property role="EcuMT" value="6018402950733207451" />
-    <property role="3GE5qa" value="Statements.Yield" />
-    <property role="TrG5h" value="YieldStatement" />
-    <property role="34LRSv" value="yield" />
-    <property role="R4oN_" value="yield statement" />
-    <ref role="1TJDcQ" node="1FYNzU$qtce" resolve="EmbeddedStatement" />
-    <node concept="1TJgyj" id="5e5Epz9BuN0" role="1TKVEi">
-      <property role="IQ2ns" value="6018402950733229248" />
+  <node concept="1TIwiD" id="p4z1jOVEuK">
+    <property role="EcuMT" value="451639884280407984" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="NamespaceContainer" />
+    <property role="R5$K7" value="true" />
+    <property role="R4oN_" value="Represents files and namespaces" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="2H$QQEUe7tD" role="1TKVEi">
+      <property role="IQ2ns" value="7232527154588292748" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="statement" />
-      <property role="20lbJX" value="fLJekj4/_1" />
-      <ref role="20lvS9" node="5e5Epz9BuMX" resolve="IYieldable" />
+      <property role="20kJfa" value="usingDirectives" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6hv6i2_Axqh" resolve="UsingDirective" />
     </node>
-    <node concept="3H0Qfr" id="5e5Epza10IQ" role="lGtFl">
-      <node concept="1Pa9Pv" id="5e5Epza10IR" role="3H0Qfi">
-        <node concept="1PaTwC" id="5e5Epza10IS" role="1PaQFQ">
-          <node concept="3oM_SD" id="5e5Epza10IT" role="1PaTwD">
-            <property role="3oM_SC" value="Represents" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwi" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwl" role="1PaTwD">
-            <property role="3oM_SC" value="yield-statement," />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwm" role="1PaTwD">
-            <property role="3oM_SC" value="defined" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwn" role="1PaTwD">
-            <property role="3oM_SC" value="in" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwo" role="1PaTwD">
-            <property role="3oM_SC" value="§8.14" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwp" role="1PaTwD">
-            <property role="3oM_SC" value="of" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwq" role="1PaTwD">
-            <property role="3oM_SC" value="the" />
-          </node>
-          <node concept="3oM_SD" id="6CB8zQnAWwr" role="1PaTwD">
-            <property role="3oM_SC" value="specification." />
-          </node>
-        </node>
-      </node>
+    <node concept="PrWs8" id="p4z1jP72r8" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
   </node>
   <node concept="PlHQZ" id="5e5Epz9BuMX">
     <property role="EcuMT" value="6018402950733229245" />
     <property role="3GE5qa" value="Statements.Yield" />
     <property role="TrG5h" value="IYieldable" />
+  </node>
+  <node concept="PlHQZ" id="iHtKXPjUmu">
+    <property role="TrG5h" value="IResourceAcquisition" />
+    <property role="3GE5qa" value="Statements.Using" />
+    <property role="EcuMT" value="337056455399024029" />
+    <node concept="3H0Qfr" id="iHtKXPOlvX" role="lGtFl">
+      <node concept="1Pa9Pv" id="iHtKXPOlvY" role="3H0Qfi">
+        <node concept="1PaTwC" id="iHtKXPOlvZ" role="1PaQFQ">
+          <node concept="3oM_SD" id="iHtKXPOlwe" role="1PaTwD">
+            <property role="3oM_SC" value="Corresponds" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwO2" role="1PaTwD">
+            <property role="3oM_SC" value="to" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwNT" role="1PaTwD">
+            <property role="3oM_SC" value="resource-acquisition" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwOc" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwOn" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwOY" role="1PaTwD">
+            <property role="3oM_SC" value="specification" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwPb" role="1PaTwD">
+            <property role="3oM_SC" value="and" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwPp" role="1PaTwD">
+            <property role="3oM_SC" value="marks" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwPC" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwS0" role="1PaTwD">
+            <property role="3oM_SC" value="concepts" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwPS" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwQ9" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwQr" role="1PaTwD">
+            <property role="3oM_SC" value="fulfil" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwQI" role="1PaTwD">
+            <property role="3oM_SC" value="this" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwR2" role="1PaTwD">
+            <property role="3oM_SC" value="role" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOwRn" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOl$B" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="tu5oc" id="iHtKXPOlwG" role="1PaTwD">
+            <node concept="2tMXA0" id="iHtKXPOlwU" role="tu5of">
+              <ref role="2tMXA_" node="iHtKXPjP1X" resolve="UsingStatement" />
+            </node>
+          </node>
+          <node concept="3oM_SD" id="iHtKXPOlyn" role="1PaTwD">
+            <property role="3oM_SC" value="." />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1TIwiD" id="iHtKXPmS6d">
+    <property role="EcuMT" value="337056455399801229" />
+    <property role="3GE5qa" value="Identifiers.Concepts" />
+    <property role="TrG5h" value="LocalVariableDeclaration" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="iHtKXPmS6i" role="PzmwI">
+      <ref role="PrY4T" node="5oHFRyIxp1s" resolve="IHaveType" />
+    </node>
+    <node concept="PrWs8" id="iHtKXPO9tS" role="PzmwI">
+      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
+    </node>
+    <node concept="PrWs8" id="iHtKXPmS6e" role="PzmwI">
+      <ref role="PrY4T" node="iHtKXPjUmu" resolve="IResourceAcquisition" />
+    </node>
+    <node concept="1TJgyj" id="iHtKXPmS6l" role="1TKVEi">
+      <property role="IQ2ns" value="337056455399801237" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="variables" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <ref role="20lvS9" node="6JhOkL8vqJY" resolve="VariableDeclaration" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="iSyfcvrmN2">
+    <property role="TrG5h" value="Parameter" />
+    <property role="EcuMT" value="340172349652162055" />
+    <property role="R5$K7" value="true" />
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <node concept="PrWs8" id="iSyfcvrmTa" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="PrWs8" id="iSyfcvrmTc" role="PzmwI">
+      <ref role="PrY4T" node="6JhOkL8vqKa" resolve="IReferencableVariableDeclaration" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2H$QQEUtQI0">
+    <property role="EcuMT" value="3126865292743371648" />
+    <property role="3GE5qa" value="Namespace" />
+    <property role="TrG5h" value="UsingAliasDirective" />
+    <property role="34LRSv" value="using alias" />
+    <property role="R4oN_" value="Using alias directive" />
+    <ref role="1TJDcQ" node="6hv6i2_Axqh" resolve="UsingDirective" />
+    <node concept="PrWs8" id="2H$QQEUtQI4" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLg9k" resolve="IReferencableTypeDeclaration" />
+    </node>
+    <node concept="3H0Qfr" id="2H$QQEVoyLV" role="lGtFl">
+      <node concept="1Pa9Pv" id="2H$QQEVoyLW" role="3H0Qfi">
+        <node concept="1PaTwC" id="2H$QQEVoyLX" role="1PaQFQ">
+          <node concept="3oM_SD" id="2H$QQEVoyLY" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyM9" role="1PaTwD">
+            <property role="3oM_SC" value="5.0" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMc" role="1PaTwD">
+            <property role="3oM_SC" value="grammar" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMg" role="1PaTwD">
+            <property role="3oM_SC" value="entry:" />
+          </node>
+          <node concept="3oM_SD" id="2H$QQEVoyMl" role="1PaTwD">
+            <property role="3oM_SC" value="using-alias-directive" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1TJgyj" id="2H$QQEVtErW" role="1TKVEi">
+      <property role="IQ2ns" value="3126865292760098556" />
+      <property role="20kJfa" value="reference" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <ref role="20lvS9" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="p4z1jNJogm">
+    <property role="EcuMT" value="451639884260410390" />
+    <property role="TrG5h" value="NamespaceReference" />
+    <property role="R4oN_" value="Reference to a namespace" />
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="1TJgyj" id="p4z1jNJomh" role="1TKVEi">
+      <property role="IQ2ns" value="451639884260410769" />
+      <property role="20kJfa" value="referencedType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6hv6i2_AzRh" resolve="NamespaceDeclaration" />
+      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
+    </node>
   </node>
 </model>
 

--- a/CsBaseLanguage/solutions/CsBaseLanguage.build/models/CsBaseLanguage.build.mps
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.build/models/CsBaseLanguage.build.mps
@@ -286,15 +286,20 @@
             </node>
           </node>
         </node>
-        <node concept="3rtmxn" id="5QWEwg3MQiP" role="3bR31x">
-          <node concept="3LXTmp" id="5QWEwg3MQiQ" role="3rtmxm">
-            <node concept="3qWCbU" id="5QWEwg3MQiR" role="3LXTna">
+        <node concept="1SiIV0" id="6u44Y77UIlc" role="3bR37C">
+          <node concept="3bR9La" id="6u44Y77UIld" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
+          </node>
+        </node>
+        <node concept="3rtmxn" id="3rWl$6CN6Y" role="3bR31x">
+          <node concept="3LXTmp" id="3rWl$6CN6Z" role="3rtmxm">
+            <node concept="3qWCbU" id="3rWl$6CN70" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
-            <node concept="55IIr" id="5QWEwg3MQiS" role="3LXTmr">
-              <node concept="2Ry0Ak" id="5QWEwg3MQiT" role="iGT6I">
+            <node concept="55IIr" id="3rWl$6CN71" role="3LXTmr">
+              <node concept="2Ry0Ak" id="3rWl$6CN72" role="iGT6I">
                 <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="5QWEwg3MQiU" role="2Ry0An">
+                <node concept="2Ry0Ak" id="3rWl$6CN73" role="2Ry0An">
                   <property role="2Ry0Am" value="CsBaseLanguage" />
                 </node>
               </node>
@@ -338,15 +343,15 @@
             </node>
           </node>
         </node>
-        <node concept="3rtmxn" id="5QWEwg3MQiB" role="3bR31x">
-          <node concept="3LXTmp" id="5QWEwg3MQiC" role="3rtmxm">
-            <node concept="3qWCbU" id="5QWEwg3MQiD" role="3LXTna">
+        <node concept="3rtmxn" id="3rWl$6CN6K" role="3bR31x">
+          <node concept="3LXTmp" id="3rWl$6CN6L" role="3rtmxm">
+            <node concept="3qWCbU" id="3rWl$6CN6M" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
-            <node concept="55IIr" id="5QWEwg3MQiE" role="3LXTmr">
-              <node concept="2Ry0Ak" id="5QWEwg3MQiF" role="iGT6I">
+            <node concept="55IIr" id="3rWl$6CN6N" role="3LXTmr">
+              <node concept="2Ry0Ak" id="3rWl$6CN6O" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5QWEwg3MQiG" role="2Ry0An">
+                <node concept="2Ry0Ak" id="3rWl$6CN6P" role="2Ry0An">
                   <property role="2Ry0Am" value="CsBaseLanguage.plugin" />
                 </node>
               </node>
@@ -400,15 +405,15 @@
             </node>
           </node>
         </node>
-        <node concept="3rtmxn" id="5QWEwg3MQiI" role="3bR31x">
-          <node concept="3LXTmp" id="5QWEwg3MQiJ" role="3rtmxm">
-            <node concept="3qWCbU" id="5QWEwg3MQiK" role="3LXTna">
+        <node concept="3rtmxn" id="3rWl$6CN6R" role="3bR31x">
+          <node concept="3LXTmp" id="3rWl$6CN6S" role="3rtmxm">
+            <node concept="3qWCbU" id="3rWl$6CN6T" role="3LXTna">
               <property role="3qWCbO" value="icons/**, resources/**" />
             </node>
-            <node concept="55IIr" id="5QWEwg3MQiL" role="3LXTmr">
-              <node concept="2Ry0Ak" id="5QWEwg3MQiM" role="iGT6I">
+            <node concept="55IIr" id="3rWl$6CN6U" role="3LXTmr">
+              <node concept="2Ry0Ak" id="3rWl$6CN6V" role="iGT6I">
                 <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="5QWEwg3MQiN" role="2Ry0An">
+                <node concept="2Ry0Ak" id="3rWl$6CN6W" role="2Ry0An">
                   <property role="2Ry0Am" value="CsBaseLanguage.build" />
                 </node>
               </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.sandbox/models/CsBaseLanguage.Preview/GenericClass.cs.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.sandbox/models/CsBaseLanguage.Preview/GenericClass.cs.mpsr
@@ -25,9 +25,6 @@
       <concept id="2439281069887055987" name="CsBaseLanguage.structure.TypeReference" flags="ng" index="2Gav_6">
         <child id="2439281069887057717" name="genericTypeParameters" index="2GavS0" />
       </concept>
-      <concept id="1969317145989153978" name="CsBaseLanguage.structure.GenericTypeParameterReferenceString" flags="ng" index="2N$mWS">
-        <property id="1969317145989153982" name="referencedGenericTypeParameter" index="2N$mWW" />
-      </concept>
       <concept id="5349962588329702914" name="CsBaseLanguage.structure.GenericMemberReference" flags="ng" index="2XeTiy">
         <child id="5349962588334854210" name="innerTypes" index="2XqJby" />
       </concept>
@@ -77,6 +74,9 @@
         <reference id="7783118190387115239" name="memberDeclaration" index="2aT8gA" />
         <child id="7783118190387115237" name="anotherMemberReference" index="2aT8g$" />
       </concept>
+      <concept id="45245710896469196" name="CsBaseLanguage.structure.GenericTypeParameterReference" flags="ng" index="3XeaDR">
+        <reference id="45245710896469199" name="typeParameter" index="3XeaDO" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -120,8 +120,8 @@
                 <node concept="2Gatwc" id="4px1bdhjvPl" role="3UfBpY">
                   <ref role="2Gaslz" node="4px1bdhjvOz" resolve="Maybe" />
                   <node concept="3UfwP1" id="4px1bdhjvPp" role="2GavS0">
-                    <node concept="2N$mWS" id="4px1bdhjvPr" role="3UfBpY">
-                      <property role="2N$mWW" value="T" />
+                    <node concept="3XeaDR" id="3SS9x79$4W6" role="3UfBpY">
+                      <ref role="3XeaDO" node="4px1bdhjvOB" resolve="T" />
                     </node>
                   </node>
                 </node>
@@ -134,8 +134,8 @@
           <node concept="2Gatwc" id="4px1bdhjvON" role="3UfBpY">
             <ref role="2Gaslz" node="4px1bdhjvOz" resolve="Maybe" />
             <node concept="3UfwP1" id="4px1bdhjvOR" role="2GavS0">
-              <node concept="2N$mWS" id="4px1bdhjvOV" role="3UfBpY">
-                <property role="2N$mWW" value="T" />
+              <node concept="3XeaDR" id="6u44Y774x_e" role="3UfBpY">
+                <ref role="3XeaDO" node="4px1bdhjvOB" resolve="T" />
               </node>
             </node>
           </node>
@@ -153,8 +153,8 @@
             <node concept="2XeTiy" id="5138HL8mKzk" role="2YuCjP">
               <ref role="2aT8gA" node="4px1bdhjvOz" resolve="Maybe" />
               <node concept="3UfwP1" id="5138HL8mKzl" role="2XqJby">
-                <node concept="2N$mWS" id="5138HL8mKzq" role="3UfBpY">
-                  <property role="2N$mWW" value="T" />
+                <node concept="3XeaDR" id="6u44Y77bEN9" role="3UfBpY">
+                  <ref role="3XeaDO" node="20pfvX3JbBa" resolve="T" />
                 </node>
               </node>
               <node concept="1VUwCF" id="5138HL8mKzw" role="2aT8g$">
@@ -168,8 +168,8 @@
           <node concept="2Gatwc" id="4px1bdhs3ln" role="3UfBpY">
             <ref role="2Gaslz" node="4px1bdhjvOz" resolve="Maybe" />
             <node concept="3UfwP1" id="4px1bdhs3lr" role="2GavS0">
-              <node concept="2N$mWS" id="4px1bdhs3lt" role="3UfBpY">
-                <property role="2N$mWW" value="T" />
+              <node concept="3XeaDR" id="6u44Y77bENa" role="3UfBpY">
+                <ref role="3XeaDO" node="20pfvX3JbBa" resolve="T" />
               </node>
             </node>
           </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.sandbox/models/CsBaseLanguage.Preview/InterfaceSample.cs.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.sandbox/models/CsBaseLanguage.Preview/InterfaceSample.cs.mpsr
@@ -11,9 +11,6 @@
       <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
         <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
       </concept>
-      <concept id="1969317145989153978" name="CsBaseLanguage.structure.GenericTypeParameterReferenceString" flags="ng" index="2N$mWS">
-        <property id="1969317145989153982" name="referencedGenericTypeParameter" index="2N$mWW" />
-      </concept>
       <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
         <child id="8700838527816343363" name="type" index="2UegB9" />
       </concept>
@@ -72,15 +69,15 @@
           <node concept="31KZC3" id="5nwwXS9O$2K" role="1ux1J">
             <property role="TrG5h" value="value" />
             <node concept="3UfwP1" id="5nwwXS9O$2L" role="2UegB9">
-              <node concept="2N$mWS" id="5nwwXS9O$2Q" role="3UfBpY">
-                <property role="2N$mWW" value="T" />
+              <node concept="3XeaDR" id="6u44Y77bJSB" role="3UfBpY">
+                <ref role="3XeaDO" node="5nwwXS9O$2s" resolve="T" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3UfwP1" id="5nwwXS9O$2C" role="3Sw9wT">
-          <node concept="2N$mWS" id="5nwwXS9O$32" role="3UfBpY">
-            <property role="2N$mWW" value="T" />
+          <node concept="3XeaDR" id="6u44Y77bJSC" role="3UfBpY">
+            <ref role="3XeaDO" node="5nwwXS9O$2s" resolve="T" />
           </node>
         </node>
       </node>
@@ -97,8 +94,8 @@
           <node concept="3X5iw3" id="5nwwXS9O$40" role="3X4xEB" />
         </node>
         <node concept="3UfwP1" id="5nwwXS9O$46" role="3Sw9wT">
-          <node concept="2N$mWS" id="5nwwXS9O$4b" role="3UfBpY">
-            <property role="2N$mWW" value="T1" />
+          <node concept="3XeaDR" id="6u44Y77bJSD" role="3UfBpY">
+            <ref role="3XeaDO" node="5nwwXS9O$3r" resolve="T1" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
@@ -18,7 +18,7 @@
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:d74e25c9-4d91-43b6-bad7-d18af7bf6674:CsBaseLanguage" version="3" />
+    <language slang="l:d74e25c9-4d91-43b6-bad7-d18af7bf6674:CsBaseLanguage" version="4" />
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_VarianceModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_VarianceModifier.mpsr
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588409138" name="CsBaseLanguage.structure.TypeParameter" flags="ng" index="31Lcgi">
+        <property id="1969317145989153390" name="varianceAnnotation" index="2N$mBG" />
+      </concept>
+      <concept id="7232527154588300036" name="CsBaseLanguage.structure.DelegateDeclaration" flags="ng" index="31LiC$" />
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6167894786982645659" name="CsBaseLanguage.structure.IGenericTypeList" flags="ngI" index="1FzkKU">
+        <child id="6167894786982659430" name="typeParameter" index="1Fzgr7" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="4tlNOo95ndP">
+    <property role="3GE5qa" value="editor.BasicEditing.DelegateDeclaration" />
+    <property role="TrG5h" value="DelegateDeclaration_VarianceModifier" />
+    <node concept="1qefOq" id="4tlNOo95nfa" role="25YQCW">
+      <node concept="31LiC$" id="4tlNOo95nfM" role="1qenE9">
+        <property role="TrG5h" value="Delegate" />
+        <node concept="1ux1I" id="4tlNOo95nfN" role="1fIg$P" />
+        <node concept="1pH0Yj" id="4tlNOo95ngJ" role="3Sw9wT" />
+        <node concept="31Lcgi" id="4tlNOo95nhn" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+          <node concept="LIFWc" id="4tlNOo95nhX" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="property_name" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4tlNOo95nib" role="25YQFr">
+      <node concept="31LiC$" id="4tlNOo95niN" role="1qenE9">
+        <property role="TrG5h" value="Delegate" />
+        <node concept="1ux1I" id="4tlNOo95niO" role="1fIg$P" />
+        <node concept="1pH0Yj" id="4tlNOo95nj5" role="3Sw9wT" />
+        <node concept="31Lcgi" id="4tlNOo95nk5" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+          <property role="2N$mBG" value="6$wrg4AAh$2/in" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="4tlNOo95nl5" role="LjaKd">
+      <node concept="2TK7Tu" id="4tlNOo95CIK" role="3cqZAp">
+        <property role="2TTd_B" value=" in" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_VarianceModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_VarianceModifier.mpsr
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports />
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588409138" name="CsBaseLanguage.structure.TypeParameter" flags="ng" index="31Lcgi">
+        <property id="1969317145989153390" name="varianceAnnotation" index="2N$mBG" />
+      </concept>
+      <concept id="7232527154588300038" name="CsBaseLanguage.structure.InterfaceDeclaration" flags="ng" index="31LiCA" />
+      <concept id="6167894786982645659" name="CsBaseLanguage.structure.IGenericTypeList" flags="ngI" index="1FzkKU">
+        <child id="6167894786982659430" name="typeParameter" index="1Fzgr7" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="4tlNOo96c6x">
+    <property role="3GE5qa" value="editor.BasicEditing.InterfaceDeclaration" />
+    <property role="TrG5h" value="InterfaceDeclaration_VarianceModifier" />
+    <node concept="1qefOq" id="4tlNOo96c6z" role="25YQCW">
+      <node concept="31LiCA" id="4tlNOo96c6y" role="1qenE9">
+        <property role="TrG5h" value="Interface" />
+        <node concept="31Lcgi" id="4tlNOo96c6B" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+          <node concept="LIFWc" id="4tlNOo96c6D" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="property_name" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4tlNOo96c6F" role="25YQFr">
+      <node concept="31LiCA" id="4tlNOo96c6J" role="1qenE9">
+        <property role="TrG5h" value="Interface" />
+        <node concept="31Lcgi" id="4tlNOo96c6K" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+          <property role="2N$mBG" value="6$wrg4AAh$3/out" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="4tlNOo96c6R" role="LjaKd">
+      <node concept="2TK7Tu" id="4tlNOo96cb_" role="3cqZAp">
+        <property role="2TTd_B" value=" out" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.Migrations@tests.mps
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.Migrations@tests.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:cdffce59-3f9f-414f-8f9c-8adb72229a47(CsBaseLanguage.tests.Migrations@tests)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
@@ -35,11 +36,23 @@
       <concept id="7486903154347131554" name="CsBaseLanguage.structure.VariableDeclaratorList" flags="ng" index="1ux1y">
         <child id="7486903154347131555" name="VariableDeclarator" index="1ux1z" />
       </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I">
+        <child id="7486903154347131567" name="formalParameter" index="1ux1J" />
+      </concept>
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
       <concept id="4960876621219057954" name="CsBaseLanguage.structure.ImplicitLocalVariableDeclaration" flags="ng" index="2a_s8y">
         <child id="4960876621219059053" name="variable" index="2a_spH" />
       </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
       <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM">
         <child id="3125407777189916705" name="initializer" index="1qY_RL" />
+      </concept>
+      <concept id="1969317145989153978" name="CsBaseLanguage.structure.GenericTypeParameterReferenceString" flags="ng" index="2N$mWS">
+        <property id="1969317145989153982" name="referencedGenericTypeParameter" index="2N$mWW" />
       </concept>
       <concept id="1945218857512035115" name="CsBaseLanguage.structure.LocalConstantDeclaration" flags="ng" index="2YAUOl">
         <child id="1945218857512106857" name="constantDeclarator" index="2YAbln" />
@@ -58,11 +71,25 @@
         <child id="1945218857512106801" name="expression" index="2YAbkf" />
         <child id="1945218857512106799" name="constant" index="2YAbkh" />
       </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
       <concept id="7232527154588443306" name="CsBaseLanguage.structure.FieldDeclaration" flags="ng" index="31KRIa">
         <child id="7232527154588443341" name="variableDeclaratorList" index="31KRJH" />
       </concept>
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="7232527154588409138" name="CsBaseLanguage.structure.TypeParameter" flags="ng" index="31Lcgi" />
       <concept id="6365726834694825977" name="CsBaseLanguage.structure.ImplicitLocalVariableDeclarationStatement" flags="ng" index="1BvVOH">
         <child id="6365726834695689697" name="declaration" index="1BoGWP" />
+      </concept>
+      <concept id="6167894786982645659" name="CsBaseLanguage.structure.IGenericTypeList" flags="ngI" index="1FzkKU">
+        <child id="6167894786982659430" name="typeParameter" index="1Fzgr7" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
       </concept>
       <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
         <child id="6209812394072710474" name="type" index="3SE38M" />
@@ -74,6 +101,9 @@
         <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
       </concept>
       <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+      <concept id="45245710896469196" name="CsBaseLanguage.structure.GenericTypeParameterReference" flags="ng" index="3XeaDR">
+        <reference id="45245710896469199" name="typeParameter" index="3XeaDO" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -162,9 +192,6 @@
       </node>
     </node>
     <node concept="3toFNv" id="2ETkgtk0SkN" role="2fuLKQ" />
-  </node>
-  <node concept="2XOHcx" id="2ETkgtk0CyR">
-    <property role="2XOHcw" value="${project_home}" />
   </node>
   <node concept="2lJO3n" id="2ETkgtk0Sui">
     <property role="TrG5h" value="UpdateConstantDeclarations_Test" />
@@ -273,6 +300,119 @@
               <property role="1pzoAX" value="3" />
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="54DISwcHuhS">
+    <property role="2XOHcw" value="${project_home}" />
+  </node>
+  <node concept="2lJO3n" id="6u44Y785on2">
+    <property role="TrG5h" value="Migrate_GenericTypeParameterReferenceString_Test" />
+    <node concept="1qefOq" id="6u44Y785oq8" role="2lJO3o">
+      <node concept="31KRCM" id="6u44Y785owG" role="1qenE9">
+        <property role="TrG5h" value="GenericMethod" />
+        <node concept="1ux1M" id="6u44Y785owH" role="31KRCR">
+          <node concept="31KRCQ" id="6u44Y785owI" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="6u44Y785owJ" role="1fIg$P">
+          <node concept="31KZC3" id="6u44Y785pc8" role="1ux1J">
+            <property role="TrG5h" value="t" />
+            <node concept="3UfwP1" id="6u44Y785pc9" role="2UegB9">
+              <node concept="2N$mWS" id="6u44Y785pd1" role="3UfBpY">
+                <property role="2N$mWW" value="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6u44Y785ozx" role="3Sw9wT">
+          <node concept="2N$mWS" id="6u44Y785o_6" role="3UfBpY">
+            <property role="2N$mWW" value="T" />
+          </node>
+        </node>
+        <node concept="31Lcgi" id="6u44Y785oyJ" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6u44Y785oBp" role="2lJO3o">
+      <node concept="31KRCM" id="6u44Y785oBq" role="1qenE9">
+        <property role="TrG5h" value="GenericMethod" />
+        <node concept="1ux1M" id="6u44Y785oBr" role="31KRCR">
+          <node concept="31KRCQ" id="6u44Y785oBs" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="6u44Y785oBt" role="1fIg$P">
+          <node concept="31KZC3" id="6u44Y785pfM" role="1ux1J">
+            <property role="TrG5h" value="u" />
+            <node concept="3UfwP1" id="6u44Y785pfN" role="2UegB9">
+              <node concept="2N$mWS" id="6u44Y785pgs" role="3UfBpY">
+                <property role="2N$mWW" value="U" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6u44Y785oBu" role="3Sw9wT">
+          <node concept="2N$mWS" id="6u44Y785oBv" role="3UfBpY">
+            <property role="2N$mWW" value="U" />
+          </node>
+        </node>
+        <node concept="31Lcgi" id="6u44Y785oBw" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="3ea_Bc" id="6u44Y785on3" role="3ea0P7">
+      <ref role="3ea_Bf" to="wqvk:6u44Y77b001" resolve="Migrate_GenericTypeParameterReferenceString" />
+    </node>
+    <node concept="1qefOq" id="6u44Y785oHi" role="2lJPY$">
+      <node concept="31KRCM" id="3SS9x79_Lm5" role="1qenE9">
+        <property role="TrG5h" value="GenericMethod" />
+        <node concept="1ux1M" id="3SS9x79_Lm6" role="31KRCR">
+          <node concept="31KRCQ" id="3SS9x79_Lm7" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="3SS9x79_Lm8" role="1fIg$P">
+          <node concept="31KZC3" id="3SS9x79_Lm9" role="1ux1J">
+            <property role="TrG5h" value="t" />
+            <node concept="3UfwP1" id="3SS9x79_Lma" role="2UegB9">
+              <node concept="3XeaDR" id="3SS9x79_Lmb" role="3UfBpY">
+                <ref role="3XeaDO" node="3SS9x79_Lme" resolve="T" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="3SS9x79_Lmc" role="3Sw9wT">
+          <node concept="3XeaDR" id="3SS9x79_Lmd" role="3UfBpY">
+            <ref role="3XeaDO" node="3SS9x79_Lme" resolve="T" />
+          </node>
+        </node>
+        <node concept="31Lcgi" id="3SS9x79_Lme" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6u44Y785oHj" role="2lJPY$">
+      <node concept="31KRCM" id="3SS9x79_Lmf" role="1qenE9">
+        <property role="TrG5h" value="GenericMethod" />
+        <node concept="1ux1M" id="3SS9x79_Lmg" role="31KRCR">
+          <node concept="31KRCQ" id="3SS9x79_Lmh" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="3SS9x79_Lmi" role="1fIg$P">
+          <node concept="31KZC3" id="3SS9x79_Lmj" role="1ux1J">
+            <property role="TrG5h" value="u" />
+            <node concept="3UfwP1" id="3SS9x79_Lmk" role="2UegB9">
+              <node concept="2N$mWS" id="3SS9x79_Lml" role="3UfBpY">
+                <property role="2N$mWW" value="U" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="3SS9x79_Lmm" role="3Sw9wT">
+          <node concept="2N$mWS" id="3SS9x79_Lmn" role="3UfBpY">
+            <property role="2N$mWW" value="U" />
+          </node>
+        </node>
+        <node concept="31Lcgi" id="3SS9x79_Lmo" role="1Fzgr7">
+          <property role="TrG5h" value="T" />
         </node>
       </node>
     </node>


### PR DESCRIPTION
Some improvements to working with generic types:

- Deprecate GenericTypeParameterReferenceString
  
  This commit follows the recommendation in the DocBit of the concept to
  make the GenericTypeParameterReference a TypeReference. The scope for
  the reference is determined using the ScopeProvider mechanism, added
  to IGenericTypeList. The substitute menu for TypeParameter was removed
  as it does not need to be substituted manually.

  A migration (with test) is also included to replace string references,
  if a type parameter with that name can be resolved.

- Fix and simplify type parameter variance
  
  Fixes the issue that CsBaseLanguage only supported variance keywords in
  (generic) delegates, while the 5.0 language specification also allows
  them in interfaces. The "isVarianceAnnotatable" property of a
  TypeParameter now queries the enclosing IGenericTypeList for this
  information, so it no longer needs to be managed from code. Two editor
  tests have been added to check this feature.

- Improve handling of generic parameters
  
  The AddGenericParameterListSection transformation menu is now only
  included if the referenced type is generic, which is inferred using a
  new method. A descriptive text has been added to the transformation
  menus for generic type lists and some changes were made to their editors
  to remove extra spaces from the textgen output.