### PR TITLE
Implement attributes

### DIFF
--- a/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/CsBaseLanguage.intentions.mps
@@ -6,15 +6,27 @@
     <use id="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67" name="jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions" version="4" />
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="14" />
+    <use id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts" version="0" />
+    <use id="d4615e3b-d671-4ba9-af01-2b78369b0ba7" name="jetbrains.mps.lang.pattern" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>
   <imports>
     <import index="6bz1" ref="r:d3905048-7598-4a84-931a-cbbcbcda146d(jetbrains.mps.lang.intentions.methods)" />
     <import index="80bi" ref="r:95fc96a8-27f5-4ee9-87a9-d1035329badc(CsBaseLanguage.structure)" />
+    <import index="dorh" ref="r:c3a662b8-7aa3-4b01-af89-32513e44ae75(CsBaseLanguage.editor)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="kvwr" ref="r:87569a15-2e04-4705-b4d1-423b59bfb8a0(CsBaseLanguage.behavior)" implicit="true" />
   </imports>
   <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
+    </language>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="3647146066980922272" name="jetbrains.mps.lang.editor.structure.SelectInEditorOperation" flags="nn" index="1OKiuA">
+        <child id="1948540814633499358" name="editorContext" index="lBI5i" />
+      </concept>
+    </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
@@ -95,6 +107,7 @@
       </concept>
     </language>
     <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="3618415754251190715" name="jetbrains.mps.lang.intentions.structure.ChildFilterFunction" flags="in" index="zTJ1e" />
       <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
       <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
       <concept id="1192795771125" name="jetbrains.mps.lang.intentions.structure.IsApplicableBlock" flags="in" index="2SaL7w" />
@@ -105,6 +118,7 @@
         <property id="2522969319638091385" name="isErrorIntention" index="2ZfUl3" />
         <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
         <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093994" name="childFilterFunction" index="2ZfVeg" />
         <child id="2522969319638093995" name="isApplicableFunction" index="2ZfVeh" />
         <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
         <child id="1205851242421" name="methodDeclaration" index="32lrUH" />
@@ -149,6 +163,7 @@
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
       <concept id="767145758118872833" name="jetbrains.mps.lang.actions.structure.NF_LinkList_AddNewChildOperation" flags="nn" index="2DeJg1" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
@@ -184,15 +199,28 @@
       <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
         <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
       </concept>
+      <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
+        <reference id="1154546997487" name="concept" index="3gnhBz" />
+      </concept>
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="5944356402132808749" name="jetbrains.mps.lang.smodel.structure.ConceptSwitchStatement" flags="nn" index="1_3QMa">
+        <child id="6039268229365417680" name="defaultBlock" index="1prKM_" />
+        <child id="5944356402132808753" name="case" index="1_3QMm" />
+        <child id="5944356402132808752" name="expression" index="1_3QMn" />
+      </concept>
+      <concept id="5944356402132808754" name="jetbrains.mps.lang.smodel.structure.SubconceptCase" flags="ng" index="1_3QMl">
+        <child id="1163670677455" name="concept" index="3Kbmr1" />
+        <child id="1163670683720" name="body" index="3Kbo56" />
       </concept>
       <concept id="1144195091934" name="jetbrains.mps.lang.smodel.structure.Node_IsRoleOperation" flags="nn" index="1BlSNk">
         <reference id="1144195362400" name="conceptOfParent" index="1BmUXE" />
@@ -238,6 +266,7 @@
       <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
       <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
@@ -1044,6 +1073,191 @@
                 <ref role="37wK5l" to="kvwr:iSyfcwmhgE" resolve="isImplicit" />
               </node>
             </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="7Jk5HDX73PP">
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AddAttributes" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+    <node concept="2S6ZIM" id="7Jk5HDX73PQ" role="2ZfVej">
+      <node concept="3clFbS" id="7Jk5HDX73PR" role="2VODD2">
+        <node concept="3clFbF" id="7Jk5HDX749u" role="3cqZAp">
+          <node concept="Xl_RD" id="7Jk5HDX749t" role="3clFbG">
+            <property role="Xl_RC" value="Add attributes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="7Jk5HDX73PS" role="2ZfgGD">
+      <node concept="3clFbS" id="7Jk5HDX73PT" role="2VODD2">
+        <node concept="3clFbF" id="7Jk5HDX76rz" role="3cqZAp">
+          <node concept="2OqwBi" id="7Jk5HDX79fV" role="3clFbG">
+            <node concept="2OqwBi" id="7Jk5HDX76$S" role="2Oq$k0">
+              <node concept="2Sf5sV" id="7Jk5HDX76ry" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="7Jk5HDX76I_" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:7Jk5HDWZnIO" resolve="attributeSections" />
+              </node>
+            </node>
+            <node concept="2DeJg1" id="7Jk5HDX7dDR" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="7Jk5HDX7e4e" role="2ZfVeh">
+      <node concept="3clFbS" id="7Jk5HDX7e4f" role="2VODD2">
+        <node concept="3clFbF" id="5n2LpYj7fet" role="3cqZAp">
+          <node concept="1Wc70l" id="5n2LpYj7oY_" role="3clFbG">
+            <node concept="2OqwBi" id="5n2LpYj7iqS" role="3uHU7B">
+              <node concept="2OqwBi" id="5n2LpYj7fp$" role="2Oq$k0">
+                <node concept="3Tsc0h" id="5n2LpYj7fwX" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:7Jk5HDWZnIO" resolve="attributeSections" />
+                </node>
+                <node concept="2Sf5sV" id="5n2LpYjlGuG" role="2Oq$k0" />
+              </node>
+              <node concept="1v1jN8" id="5n2LpYj7m49" role="2OqNvi" />
+            </node>
+            <node concept="2OqwBi" id="5n2LpYjp9YG" role="3uHU7w">
+              <node concept="2Sf5sV" id="5n2LpYjp9qN" role="2Oq$k0" />
+              <node concept="2qgKlT" id="5n2LpYjpaj4" role="2OqNvi">
+                <ref role="37wK5l" to="kvwr:60ZH30$MfIa" resolve="supportsAttributes" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="zTJ1e" id="60ZH30$FnND" role="2ZfVeg">
+      <node concept="3clFbS" id="60ZH30$FnNE" role="2VODD2">
+        <node concept="1_3QMa" id="5n2LpYjlsXv" role="3cqZAp">
+          <node concept="2OqwBi" id="5n2LpYjlt7N" role="1_3QMn">
+            <node concept="2Sf5sV" id="5n2LpYjlsZP" role="2Oq$k0" />
+            <node concept="2yIwOk" id="5n2LpYjltKv" role="2OqNvi" />
+          </node>
+          <node concept="1_3QMl" id="5n2LpYjltMz" role="1_3QMm">
+            <node concept="3gn64h" id="5n2LpYjltM$" role="3Kbmr1">
+              <ref role="3gnhBz" to="80bi:60ZH30zYZTk" resolve="Field" />
+            </node>
+            <node concept="3clFbS" id="5n2LpYjltM_" role="3Kbo56">
+              <node concept="3cpWs6" id="5n2LpYjluF5" role="3cqZAp">
+                <node concept="3clFbT" id="5n2LpYjluI2" role="3cqZAk">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1_3QMl" id="5n2LpYjluZ7" role="1_3QMm">
+            <node concept="3gn64h" id="5n2LpYjluZ9" role="3Kbmr1">
+              <ref role="3gnhBz" to="80bi:iSyfcvrmN2" resolve="Parameter" />
+            </node>
+            <node concept="3clFbS" id="5n2LpYjluZb" role="3Kbo56">
+              <node concept="3cpWs6" id="5n2LpYjlB_w" role="3cqZAp">
+                <node concept="3clFbT" id="5n2LpYjlBB8" role="3cqZAk">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5n2LpYjluP8" role="1prKM_">
+            <node concept="3cpWs6" id="5n2LpYjluP7" role="3cqZAp">
+              <node concept="3clFbT" id="5n2LpYjluSr" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="6aIFk8bISX5">
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AddAttributeTarget" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="80bi:6vAOG1ABcaf" resolve="AttributeSection" />
+    <node concept="2S6ZIM" id="6aIFk8bISX6" role="2ZfVej">
+      <node concept="3clFbS" id="6aIFk8bISX7" role="2VODD2">
+        <node concept="3clFbF" id="6aIFk8bITgp" role="3cqZAp">
+          <node concept="Xl_RD" id="6aIFk8bITgo" role="3clFbG">
+            <property role="Xl_RC" value="Specify attribute target" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="6aIFk8bISX8" role="2ZfgGD">
+      <node concept="3clFbS" id="6aIFk8bISX9" role="2VODD2">
+        <node concept="3clFbF" id="6aIFk8cpirP" role="3cqZAp">
+          <node concept="2OqwBi" id="6y6b8L7DY_4" role="3clFbG">
+            <node concept="2OqwBi" id="6aIFk8cpiUS" role="2Oq$k0">
+              <node concept="2OqwBi" id="6aIFk8cpi_b" role="2Oq$k0">
+                <node concept="2Sf5sV" id="6aIFk8cpirO" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6y6b8L7vIZd" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:6aIFk8bTdHj" resolve="target" />
+                </node>
+              </node>
+              <node concept="2DeJnY" id="6y6b8L7vLCd" role="2OqNvi" />
+            </node>
+            <node concept="1OKiuA" id="6y6b8L7DYX3" role="2OqNvi">
+              <node concept="1XNTG" id="6y6b8L7DYZh" role="lBI5i" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="6aIFk8bITRr" role="2ZfVeh">
+      <node concept="3clFbS" id="6aIFk8bITRs" role="2VODD2">
+        <node concept="3clFbF" id="6aIFk8bIU6P" role="3cqZAp">
+          <node concept="2OqwBi" id="6aIFk8bIURp" role="3clFbG">
+            <node concept="2OqwBi" id="6aIFk8bIUvi" role="2Oq$k0">
+              <node concept="2Sf5sV" id="6aIFk8bIU6O" role="2Oq$k0" />
+              <node concept="3TrEf2" id="6y6b8L7vI$U" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:6aIFk8bTdHj" resolve="target" />
+              </node>
+            </node>
+            <node concept="3w_OXm" id="6aIFk8bTiwI" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2S6QgY" id="5n2LpYi75Gz">
+    <property role="TrG5h" value="AddGlobalAttributes" />
+    <ref role="2ZfgGC" to="80bi:6hv6i2_AqOA" resolve="File" />
+    <node concept="2S6ZIM" id="5n2LpYi75G$" role="2ZfVej">
+      <node concept="3clFbS" id="5n2LpYi75G_" role="2VODD2">
+        <node concept="3clFbF" id="5n2LpYi762B" role="3cqZAp">
+          <node concept="Xl_RD" id="5n2LpYi762A" role="3clFbG">
+            <property role="Xl_RC" value="Add global attributes" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="5n2LpYi75GA" role="2ZfgGD">
+      <node concept="3clFbS" id="5n2LpYi75GB" role="2VODD2">
+        <node concept="3clFbF" id="5n2LpYi7fvX" role="3cqZAp">
+          <node concept="2OqwBi" id="5n2LpYi7iFz" role="3clFbG">
+            <node concept="2OqwBi" id="5n2LpYi7fEX" role="2Oq$k0">
+              <node concept="2Sf5sV" id="5n2LpYi7fvW" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="5n2LpYi7fUj" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:6hv6i2_AyhC" resolve="globalAttributeList" />
+              </node>
+            </node>
+            <node concept="2DeJg1" id="5n2LpYi7sMK" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2SaL7w" id="5n2LpYi765T" role="2ZfVeh">
+      <node concept="3clFbS" id="5n2LpYi765U" role="2VODD2">
+        <node concept="3clFbF" id="5n2LpYi76nv" role="3cqZAp">
+          <node concept="2OqwBi" id="5n2LpYi7atm" role="3clFbG">
+            <node concept="2OqwBi" id="5n2LpYi76LK" role="2Oq$k0">
+              <node concept="2Sf5sV" id="5n2LpYi76nu" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="5n2LpYi77e5" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:6hv6i2_AyhC" resolve="globalAttributeList" />
+              </node>
+            </node>
+            <node concept="1v1jN8" id="5n2LpYi7fq7" role="2OqNvi" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/behavior.mps
@@ -75,6 +75,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -122,10 +125,11 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
       </concept>
@@ -134,7 +138,7 @@
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
@@ -143,6 +147,11 @@
       <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
+      </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
         <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
       </concept>
@@ -150,6 +159,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
@@ -190,6 +200,9 @@
       <concept id="1138661924179" name="jetbrains.mps.lang.smodel.structure.Property_SetOperation" flags="nn" index="tyxLq">
         <child id="1138662048170" name="value" index="tz02z" />
       </concept>
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
         <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
@@ -203,9 +216,19 @@
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1966870290088668512" name="jetbrains.mps.lang.smodel.structure.Enum_MemberLiteral" flags="ng" index="2ViDtV">
+        <reference id="1966870290088668516" name="memberDeclaration" index="2ViDtZ" />
+      </concept>
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
+      <concept id="1180031783296" name="jetbrains.mps.lang.smodel.structure.Concept_IsSubConceptOfOperation" flags="nn" index="2Zo12i">
+        <child id="1180031783297" name="conceptArgument" index="2Zo12j" />
+      </concept>
+      <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
+        <reference id="1240170836027" name="enum" index="2ZWj4r" />
+      </concept>
+      <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="6677504323281689838" name="jetbrains.mps.lang.smodel.structure.SConceptType" flags="in" index="3bZ5Sz" />
       <concept id="1154546950173" name="jetbrains.mps.lang.smodel.structure.ConceptReference" flags="ng" index="3gn64h">
         <reference id="1154546997487" name="concept" index="3gnhBz" />
@@ -214,6 +237,8 @@
       <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
         <child id="1177027386292" name="conceptArgument" index="cj9EA" />
       </concept>
+      <concept id="1171999116870" name="jetbrains.mps.lang.smodel.structure.Node_IsNullOperation" flags="nn" index="3w_OXm" />
+      <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
       </concept>
@@ -225,6 +250,10 @@
       <concept id="5944356402132808754" name="jetbrains.mps.lang.smodel.structure.SubconceptCase" flags="ng" index="1_3QMl">
         <child id="1163670677455" name="concept" index="3Kbmr1" />
         <child id="1163670683720" name="body" index="3Kbo56" />
+      </concept>
+      <concept id="1144195091934" name="jetbrains.mps.lang.smodel.structure.Node_IsRoleOperation" flags="nn" index="1BlSNk">
+        <reference id="1144195362400" name="conceptOfParent" index="1BmUXE" />
+        <reference id="1144195396777" name="linkInParent" index="1Bn3mz" />
       </concept>
       <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI">
         <property id="1238684351431" name="asCast" index="1BlNFB" />
@@ -241,13 +270,28 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
+      <concept id="2453008993612717253" name="jetbrains.mps.lang.smodel.structure.EnumSwitchCaseBody_Expression" flags="ng" index="3X5gDF">
+        <child id="2453008993612717254" name="expression" index="3X5gDC" />
+      </concept>
+      <concept id="2453008993612559843" name="jetbrains.mps.lang.smodel.structure.EnumSwitchCase" flags="ng" index="3X5Udd">
+        <child id="2453008993612717146" name="body" index="3X5gFO" />
+        <child id="2453008993612559844" name="members" index="3X5Uda" />
+      </concept>
+      <concept id="2453008993612559839" name="jetbrains.mps.lang.smodel.structure.EnumSwitchExpression" flags="ng" index="3X5UdL">
+        <child id="2453008993612714935" name="cases" index="3X5gkp" />
+        <child id="2453008993612559840" name="enumExpression" index="3X5Ude" />
+        <child id="2453008993619909454" name="otherwiseBody" index="3XxORw" />
+      </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
+      </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -273,10 +317,15 @@
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1235566554328" name="jetbrains.mps.baseLanguage.collections.structure.AnyOperation" flags="nn" index="2HwmR7" />
       <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
@@ -527,6 +576,55 @@
         </node>
       </node>
     </node>
+    <node concept="13i0hz" id="6oIHlJheHPB" role="13h7CS">
+      <property role="TrG5h" value="isReadWrite" />
+      <ref role="13i0hy" node="6oIHlJhcLM0" resolve="isReadWrite" />
+      <node concept="3Tm1VV" id="6oIHlJheHPC" role="1B3o_S" />
+      <node concept="3clFbS" id="6oIHlJheHPV" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhiZ27" role="3cqZAp">
+          <node concept="1Wc70l" id="6oIHlJhj0Mq" role="3clFbG">
+            <node concept="2OqwBi" id="6oIHlJhj4oG" role="3uHU7w">
+              <node concept="2OqwBi" id="6oIHlJhj13U" role="2Oq$k0">
+                <node concept="13iPFW" id="6oIHlJhj0Ns" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="6oIHlJhj1Lo" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:6vAOG1ABcc1" resolve="accessorDeclaration" />
+                </node>
+              </node>
+              <node concept="2HxqBE" id="6oIHlJhj73G" role="2OqNvi">
+                <node concept="1bVj0M" id="6oIHlJhj73I" role="23t8la">
+                  <node concept="3clFbS" id="6oIHlJhj73J" role="1bW5cS">
+                    <node concept="3clFbF" id="6oIHlJhj77Y" role="3cqZAp">
+                      <node concept="2OqwBi" id="6oIHlJhj8By" role="3clFbG">
+                        <node concept="2OqwBi" id="6oIHlJhj7lR" role="2Oq$k0">
+                          <node concept="37vLTw" id="6oIHlJhj77X" role="2Oq$k0">
+                            <ref role="3cqZAo" node="6oIHlJhj73K" resolve="it" />
+                          </node>
+                          <node concept="2qgKlT" id="6oIHlJhj89v" role="2OqNvi">
+                            <ref role="37wK5l" node="6oIHlJhfnjp" resolve="visibility" />
+                          </node>
+                        </node>
+                        <node concept="3w_OXm" id="6oIHlJhja23" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="6oIHlJhj73K" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6oIHlJhj73L" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6oIHlJhqg_X" role="3uHU7B">
+              <node concept="13iAh5" id="6oIHlJhqgne" role="2Oq$k0" />
+              <node concept="2qgKlT" id="6oIHlJhqgOV" role="2OqNvi">
+                <ref role="37wK5l" node="6oIHlJhcLM0" resolve="isReadWrite" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="6oIHlJheHPW" role="3clF45" />
+    </node>
   </node>
   <node concept="13h7C7" id="3zXINoFYeNZ">
     <property role="3GE5qa" value="Class / Struct.Properties" />
@@ -551,6 +649,40 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="6oIHlJhf4tN" role="13h7CS">
+      <property role="TrG5h" value="isPublic" />
+      <ref role="13i0hy" node="6oIHlJhcELf" resolve="isPublic" />
+      <node concept="3Tm1VV" id="6oIHlJhf4tO" role="1B3o_S" />
+      <node concept="3clFbS" id="6oIHlJhf4u6" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhjsFs" role="3cqZAp">
+          <node concept="3K4zz7" id="6oIHlJhhGiW" role="3clFbG">
+            <node concept="3clFbT" id="6oIHlJhhGkJ" role="3K4E3e" />
+            <node concept="2OqwBi" id="6oIHlJhhMor" role="3K4GZi">
+              <node concept="1PxgMI" id="6oIHlJhqYu0" role="2Oq$k0">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="6oIHlJhqYww" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
+                </node>
+                <node concept="2OqwBi" id="6oIHlJhhJ6E" role="1m5AlR">
+                  <node concept="13iPFW" id="6oIHlJhhHFS" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="6oIHlJhqXXY" role="2OqNvi" />
+                </node>
+              </node>
+              <node concept="2qgKlT" id="6oIHlJhhN6x" role="2OqNvi">
+                <ref role="37wK5l" node="6oIHlJhcELf" resolve="isPublic" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6oIHlJhhEi6" role="3K4Cdx">
+              <node concept="BsUDl" id="6oIHlJhhDXJ" role="2Oq$k0">
+                <ref role="37wK5l" node="6oIHlJhfnjp" resolve="visibility" />
+              </node>
+              <node concept="3x8VRR" id="6oIHlJhhHCh" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="6oIHlJhf4u7" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="2a8$IxLXdsU">
@@ -650,6 +782,32 @@
         <node concept="3bZ5Sz" id="2mA2D1nEgma" role="1tU5fm" />
       </node>
     </node>
+    <node concept="13i0hz" id="6oIHlJhs0pC" role="13h7CS">
+      <property role="TrG5h" value="properties" />
+      <node concept="3Tm1VV" id="6oIHlJhs0pD" role="1B3o_S" />
+      <node concept="3clFbS" id="6oIHlJhs0pF" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhs0xY" role="3cqZAp">
+          <node concept="2OqwBi" id="6oIHlJhs5IO" role="3clFbG">
+            <node concept="2OqwBi" id="6oIHlJhs0TH" role="2Oq$k0">
+              <node concept="13iPFW" id="6oIHlJhs0xX" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="6oIHlJhs1Rq" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:6hv6i2_AZEU" resolve="classMemberDeclaration" />
+              </node>
+            </node>
+            <node concept="v3k3i" id="6oIHlJhsbnm" role="2OqNvi">
+              <node concept="chp4Y" id="6oIHlJhsbq6" role="v3oSu">
+                <ref role="cht4Q" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="6oIHlJhsby1" role="3clF45">
+        <node concept="3Tqbb2" id="6oIHlJhsby4" role="A3Ik2">
+          <ref role="ehGHo" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
+        </node>
+      </node>
+    </node>
     <node concept="13hLZK" id="2mA2D1nDMaS" role="13h7CW">
       <node concept="3clFbS" id="2mA2D1nDMaT" role="2VODD2" />
     </node>
@@ -675,6 +833,35 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="13i0hz" id="60ZH30$V3wC" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30$V3wD" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$V3wI" role="3clF47">
+        <node concept="3clFbF" id="60ZH30$V3JW" role="3cqZAp">
+          <node concept="3clFbC" id="60ZH30$V3UH" role="3clFbG">
+            <node concept="2OqwBi" id="60ZH30$V6gC" role="3uHU7w">
+              <node concept="1XH99k" id="60ZH30$V4yx" role="2Oq$k0">
+                <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+              </node>
+              <node concept="2ViDtV" id="60ZH30$V72J" role="2OqNvi">
+                <ref role="2ViDtZ" to="80bi:60ZH30$V4dF" resolve="typevar" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="60ZH30$V3JT" role="3uHU7B">
+              <ref role="3cqZAo" node="60ZH30$V3wJ" resolve="target" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30$V3wJ" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30$V3wK" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30$V3wL" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="c1dsm9xs_V">
@@ -838,6 +1025,43 @@
         </node>
       </node>
       <node concept="10P_77" id="6FfQk_SPz5j" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="6y6b8L7z3ip" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="6y6b8L7z3iz" role="1B3o_S" />
+      <node concept="3clFbS" id="6y6b8L7z3i_" role="3clF47">
+        <node concept="3cpWs6" id="6y6b8L7z3DZ" role="3cqZAp">
+          <node concept="3X5UdL" id="6y6b8L7z3FB" role="3cqZAk">
+            <node concept="37vLTw" id="6y6b8L7z3GA" role="3X5Ude">
+              <ref role="3cqZAo" node="6y6b8L7z3iA" resolve="target" />
+            </node>
+            <node concept="3X5Udd" id="6y6b8L7z3Qw" role="3X5gkp">
+              <node concept="21nZrQ" id="6y6b8L7z3Qv" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalgJ" resolve="return" />
+              </node>
+              <node concept="21nZrQ" id="6y6b8L7z3SF" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalgK" resolve="type" />
+              </node>
+              <node concept="3X5gDF" id="6y6b8L7z3Rv" role="3X5gFO">
+                <node concept="3clFbT" id="6y6b8L7z3Ru" role="3X5gDC">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3X5gDF" id="6y6b8L7z3WW" role="3XxORw">
+              <node concept="3clFbT" id="6y6b8L7z3WV" role="3X5gDC" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6y6b8L7z3iA" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="6y6b8L7z3iB" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="6y6b8L7z3iC" role="3clF45" />
     </node>
   </node>
   <node concept="13h7C7" id="2XZTPU1n$J3">
@@ -1867,6 +2091,627 @@
     </node>
     <node concept="13hLZK" id="7HmXimPF_y8" role="13h7CW">
       <node concept="3clFbS" id="7HmXimPF_y9" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6aIFk8cib1C">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="13h7C2" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+    <node concept="13i0hz" id="60ZH30$MfIa" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="supportsAttributes" />
+      <node concept="3Tm1VV" id="60ZH30$MfIb" role="1B3o_S" />
+      <node concept="10P_77" id="60ZH30$MfIc" role="3clF45" />
+      <node concept="3clFbS" id="60ZH30$MfId" role="3clF47">
+        <node concept="3clFbF" id="60ZH30$MfPr" role="3cqZAp">
+          <node concept="3clFbT" id="60ZH30$MfPq" role="3clFbG">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6aIFk8cib2p" role="13h7CS">
+      <property role="13i0it" value="true" />
+      <property role="TrG5h" value="supportsTarget" />
+      <node concept="3Tm1VV" id="6aIFk8cib2q" role="1B3o_S" />
+      <node concept="10P_77" id="6aIFk8cioFj" role="3clF45" />
+      <node concept="3clFbS" id="6aIFk8cib2s" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhsrKV" role="3cqZAp">
+          <node concept="3clFbT" id="6oIHlJhsrKU" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="6aIFk8cioBy" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="6aIFk8cioBx" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="6aIFk8cib1D" role="13h7CW">
+      <node concept="3clFbS" id="6aIFk8cib1E" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6y6b8L7z3aj">
+    <property role="3GE5qa" value="Namespace" />
+    <ref role="13h7C2" to="80bi:6hv6i2_Azc2" resolve="TypeDeclaration" />
+    <node concept="13i0hz" id="6aIFk8cibqc" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3clFbS" id="6aIFk8cibqh" role="3clF47">
+        <node concept="3clFbF" id="6aIFk8cioYY" role="3cqZAp">
+          <node concept="3clFbC" id="6aIFk8cip9Z" role="3clFbG">
+            <node concept="2OqwBi" id="6aIFk8cirf6" role="3uHU7w">
+              <node concept="1XH99k" id="6aIFk8cipsv" role="2Oq$k0">
+                <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+              </node>
+              <node concept="2ViDtV" id="6aIFk8cirEv" role="2OqNvi">
+                <ref role="2ViDtZ" to="80bi:7Jk5HDXalgK" resolve="type" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="6aIFk8cioYX" role="3uHU7B">
+              <ref role="3cqZAo" node="6aIFk8cirMt" resolve="target" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="6aIFk8cirMt" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="6aIFk8clPYf" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="6aIFk8cirMw" role="1B3o_S" />
+      <node concept="10P_77" id="6aIFk8clPYe" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="6y6b8L7z3ak" role="13h7CW">
+      <node concept="3clFbS" id="6y6b8L7z3al" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30zYXJ9">
+    <ref role="13h7C2" to="80bi:60ZH30zYXEq" resolve="Property" />
+    <node concept="13i0hz" id="6oIHlJhcLM0" role="13h7CS">
+      <property role="TrG5h" value="isReadWrite" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="6oIHlJhcLM1" role="1B3o_S" />
+      <node concept="10P_77" id="6oIHlJhcLMM" role="3clF45" />
+      <node concept="3clFbS" id="6oIHlJhcLM3" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhim3k" role="3cqZAp">
+          <node concept="2OqwBi" id="6oIHlJhiF5d" role="3clFbG">
+            <node concept="2OqwBi" id="6oIHlJhiF5e" role="2Oq$k0">
+              <node concept="2OqwBi" id="6oIHlJhiF5f" role="2Oq$k0">
+                <node concept="13iPFW" id="6oIHlJhiF5g" role="2Oq$k0" />
+                <node concept="32TBzR" id="6oIHlJhiF5h" role="2OqNvi" />
+              </node>
+              <node concept="v3k3i" id="6oIHlJhiF5i" role="2OqNvi">
+                <node concept="chp4Y" id="6oIHlJhiF5j" role="v3oSu">
+                  <ref role="cht4Q" to="80bi:60ZH30$IGz$" resolve="ISetAccessor" />
+                </node>
+              </node>
+            </node>
+            <node concept="3GX2aA" id="6oIHlJhqdrm" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="60ZH30zYXJa" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30zYXJb" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30zYXKo" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30zYXKp" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30zYXKu" role="3clF47">
+        <node concept="3cpWs6" id="60ZH30zYXkW" role="3cqZAp">
+          <node concept="3X5UdL" id="60ZH30zYXmo" role="3cqZAk">
+            <node concept="37vLTw" id="60ZH30zYXnn" role="3X5Ude">
+              <ref role="3cqZAo" node="60ZH30zYXKv" resolve="target" />
+            </node>
+            <node concept="3X5Udd" id="60ZH30zYXom" role="3X5gkp">
+              <node concept="21nZrQ" id="60ZH30zYXol" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXal2Z" resolve="field" />
+              </node>
+              <node concept="21nZrQ" id="60ZH30zYXqz" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalfL" resolve="property" />
+              </node>
+              <node concept="3X5gDF" id="60ZH30zYXpP" role="3X5gFO">
+                <node concept="3clFbT" id="60ZH30zYXpO" role="3X5gDC">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3X5gDF" id="60ZH30zYXun" role="3XxORw">
+              <node concept="3clFbT" id="60ZH30zYXum" role="3X5gDC" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30zYXKv" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30zYXKw" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30zYXKx" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30zYYUz">
+    <ref role="13h7C2" to="80bi:60ZH30zYY06" resolve="Method" />
+    <node concept="13hLZK" id="60ZH30zYYU$" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30zYYU_" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30zYYVM" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30zYYVN" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30zYYVS" role="3clF47">
+        <node concept="3cpWs6" id="6y6b8L7yYol" role="3cqZAp">
+          <node concept="3X5UdL" id="6y6b8L7yYpX" role="3cqZAk">
+            <node concept="37vLTw" id="6y6b8L7yYqW" role="3X5Ude">
+              <ref role="3cqZAo" node="60ZH30zYYVT" resolve="target" />
+            </node>
+            <node concept="3X5Udd" id="6y6b8L7yYsp" role="3X5gkp">
+              <node concept="21nZrQ" id="6y6b8L7yYso" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalfh" resolve="method" />
+              </node>
+              <node concept="21nZrQ" id="6y6b8L7yYuj" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalgJ" resolve="return" />
+              </node>
+              <node concept="3X5gDF" id="6y6b8L7yYx9" role="3X5gFO">
+                <node concept="3clFbT" id="6y6b8L7yYx8" role="3X5gDC">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3X5gDF" id="6y6b8L7yY$j" role="3XxORw">
+              <node concept="3clFbT" id="6y6b8L7yY$i" role="3X5gDC" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30zYYVT" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30zYYVU" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30zYYVV" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30zYZVe">
+    <ref role="13h7C2" to="80bi:60ZH30zYZTk" resolve="Field" />
+    <node concept="13hLZK" id="60ZH30zYZVf" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30zYZVg" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30zYZVZ" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30zYZW0" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30zYZW5" role="3clF47">
+        <node concept="3clFbF" id="60ZH30zZ0Aw" role="3cqZAp">
+          <node concept="3clFbC" id="60ZH30zZ0Lh" role="3clFbG">
+            <node concept="2OqwBi" id="60ZH30zZ2Mm" role="3uHU7w">
+              <node concept="1XH99k" id="60ZH30zZ14f" role="2Oq$k0">
+                <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+              </node>
+              <node concept="2ViDtV" id="60ZH30zZ3dw" role="2OqNvi">
+                <ref role="2ViDtZ" to="80bi:7Jk5HDXal2Z" resolve="field" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="60ZH30zZ0Av" role="3uHU7B">
+              <ref role="3cqZAo" node="60ZH30zYZW6" resolve="target" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30zYZW6" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30zYZW7" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30zYZW8" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30$IG5p">
+    <ref role="13h7C2" to="80bi:60ZH30$IG25" resolve="IGetAccessor" />
+    <node concept="13hLZK" id="60ZH30$IG5q" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30$IG5r" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30$IG76" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30$IG77" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$IG7c" role="3clF47">
+        <node concept="3cpWs6" id="60ZH30$IGmu" role="3cqZAp">
+          <node concept="3X5UdL" id="60ZH30$IGnC" role="3cqZAk">
+            <node concept="37vLTw" id="60ZH30$IGoB" role="3X5Ude">
+              <ref role="3cqZAo" node="60ZH30$IG7d" resolve="target" />
+            </node>
+            <node concept="3X5Udd" id="60ZH30$IGpA" role="3X5gkp">
+              <node concept="21nZrQ" id="60ZH30$IGp_" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalfh" resolve="method" />
+              </node>
+              <node concept="21nZrQ" id="60ZH30$IGsf" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalgJ" resolve="return" />
+              </node>
+              <node concept="3X5gDF" id="60ZH30$IGq_" role="3X5gFO">
+                <node concept="3clFbT" id="60ZH30$IGq$" role="3X5gDC">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3X5gDF" id="60ZH30$IGw$" role="3XxORw">
+              <node concept="3clFbT" id="60ZH30$IGyf" role="3X5gDC" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30$IG7d" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30$IG7e" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30$IG7f" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30$IG_W">
+    <ref role="13h7C2" to="80bi:60ZH30$IGz$" resolve="ISetAccessor" />
+    <node concept="13hLZK" id="60ZH30$IG_X" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30$IG_Y" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30$IGBX" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30$IGBY" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$IGC3" role="3clF47">
+        <node concept="3cpWs6" id="60ZH30$IGRl" role="3cqZAp">
+          <node concept="3X5UdL" id="60ZH30$IGSX" role="3cqZAk">
+            <node concept="37vLTw" id="60ZH30$IGTW" role="3X5Ude">
+              <ref role="3cqZAo" node="60ZH30$IGC4" resolve="target" />
+            </node>
+            <node concept="3X5Udd" id="60ZH30$IGUV" role="3X5gkp">
+              <node concept="21nZrQ" id="60ZH30$IGUU" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalfh" resolve="method" />
+              </node>
+              <node concept="21nZrQ" id="60ZH30$IGWn" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalfK" resolve="param" />
+              </node>
+              <node concept="21nZrQ" id="60ZH30$IGXk" role="3X5Uda">
+                <ref role="21nZrZ" to="80bi:7Jk5HDXalgJ" resolve="return" />
+              </node>
+              <node concept="3X5gDF" id="60ZH30$IGZG" role="3X5gFO">
+                <node concept="3clFbT" id="60ZH30$IGZF" role="3X5gDC">
+                  <property role="3clFbU" value="true" />
+                </node>
+              </node>
+            </node>
+            <node concept="3X5gDF" id="60ZH30$IH3K" role="3XxORw">
+              <node concept="3clFbT" id="60ZH30$IH3J" role="3X5gDC" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30$IGC4" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30$IGC5" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30$IGC6" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30$M41b">
+    <property role="3GE5qa" value="Class / Struct.Parameters" />
+    <ref role="13h7C2" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
+    <node concept="13i0hz" id="60ZH30$Mgbo" role="13h7CS">
+      <property role="TrG5h" value="supportsAttributes" />
+      <ref role="13i0hy" node="60ZH30$MfIa" resolve="attributesEnabled" />
+      <node concept="3Tm1VV" id="60ZH30$Mgbp" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$Mgbu" role="3clF47">
+        <node concept="3clFbF" id="60ZH30$MgyO" role="3cqZAp">
+          <node concept="2OqwBi" id="60ZH30$Mhea" role="3clFbG">
+            <node concept="13iPFW" id="60ZH30$MgyN" role="2Oq$k0" />
+            <node concept="1BlSNk" id="60ZH30$Mhso" role="2OqNvi">
+              <ref role="1BmUXE" to="80bi:6vAOG1ABcaI" resolve="FormalParameterList" />
+              <ref role="1Bn3mz" to="80bi:6vAOG1ABcaJ" resolve="formalParameter" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30$Mgbv" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="60ZH30zZ47F" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="60ZH30zZ47G" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30zZ47L" role="3clF47">
+        <node concept="3clFbF" id="60ZH30zZ4mD" role="3cqZAp">
+          <node concept="3clFbC" id="60ZH30zZ4xq" role="3clFbG">
+            <node concept="2OqwBi" id="60ZH30zZ6y1" role="3uHU7w">
+              <node concept="1XH99k" id="60ZH30zZ4NU" role="2Oq$k0">
+                <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+              </node>
+              <node concept="2ViDtV" id="60ZH30zZ7k8" role="2OqNvi">
+                <ref role="2ViDtZ" to="80bi:7Jk5HDXalfK" resolve="param" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="60ZH30zZ4mA" role="3uHU7B">
+              <ref role="3cqZAo" node="60ZH30zZ47M" resolve="target" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30zZ47M" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="60ZH30zZ47N" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30zZ47O" role="3clF45" />
+    </node>
+    <node concept="13hLZK" id="60ZH30$M41c" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30$M41d" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30$MG_L">
+    <property role="3GE5qa" value="Comments" />
+    <ref role="13h7C2" to="80bi:1gNlOGhuBgE" resolve="Comment" />
+    <node concept="13hLZK" id="60ZH30$MG_M" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30$MG_N" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30$MGB0" role="13h7CS">
+      <property role="TrG5h" value="supportsAttributes" />
+      <ref role="13i0hy" node="60ZH30$MfIa" resolve="attributesEnabled" />
+      <node concept="3Tm1VV" id="60ZH30$MGB1" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$MGB6" role="3clF47">
+        <node concept="3clFbF" id="60ZH30$MGTG" role="3cqZAp">
+          <node concept="3clFbT" id="60ZH30$MGTF" role="3clFbG" />
+        </node>
+      </node>
+      <node concept="10P_77" id="60ZH30$MGB7" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="60ZH30$MSiq">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="13h7C2" to="80bi:6hv6i2_ABc4" resolve="Attribute" />
+    <node concept="13hLZK" id="60ZH30$MSir" role="13h7CW">
+      <node concept="3clFbS" id="60ZH30$MSis" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="60ZH30$MSjb" role="13h7CS">
+      <property role="TrG5h" value="getScope" />
+      <ref role="13i0hy" to="tpcu:52_Geb4QDV$" resolve="getScope" />
+      <node concept="3Tm1VV" id="60ZH30$MSjc" role="1B3o_S" />
+      <node concept="3clFbS" id="60ZH30$MSjl" role="3clF47">
+        <node concept="3clFbJ" id="60ZH30_8ubt" role="3cqZAp">
+          <node concept="3clFbS" id="60ZH30_8ubv" role="3clFbx">
+            <node concept="3cpWs6" id="6oIHlJhpDp7" role="3cqZAp">
+              <node concept="2YIFZM" id="6oIHlJhspze" role="3cqZAk">
+                <ref role="37wK5l" to="o8zo:4IP40Bi3eAf" resolve="forNamedElements" />
+                <ref role="1Pybhc" to="o8zo:4IP40Bi3e_R" resolve="ListScope" />
+                <node concept="2OqwBi" id="6oIHlJhsdC9" role="37wK5m">
+                  <node concept="2OqwBi" id="6oIHlJhpGoP" role="2Oq$k0">
+                    <node concept="2OqwBi" id="6oIHlJhpEIG" role="2Oq$k0">
+                      <node concept="2OqwBi" id="6oIHlJhpDPc" role="2Oq$k0">
+                        <node concept="13iPFW" id="6oIHlJhpD$5" role="2Oq$k0" />
+                        <node concept="3TrEf2" id="6oIHlJhpEfo" role="2OqNvi">
+                          <ref role="3Tt5mk" to="80bi:6aIFk8bB0bX" resolve="attributeClass" />
+                        </node>
+                      </node>
+                      <node concept="3TrEf2" id="6oIHlJhpF_Y" role="2OqNvi">
+                        <ref role="3Tt5mk" to="80bi:5n2LpYj7C8E" resolve="referencedType" />
+                      </node>
+                    </node>
+                    <node concept="2qgKlT" id="6oIHlJhscWT" role="2OqNvi">
+                      <ref role="37wK5l" node="6oIHlJhs0pC" resolve="properties" />
+                    </node>
+                  </node>
+                  <node concept="3zZkjj" id="6oIHlJhsfjK" role="2OqNvi">
+                    <node concept="1bVj0M" id="6oIHlJhsfjM" role="23t8la">
+                      <node concept="3clFbS" id="6oIHlJhsfjN" role="1bW5cS">
+                        <node concept="3clFbF" id="6oIHlJhsfod" role="3cqZAp">
+                          <node concept="1Wc70l" id="6oIHlJhsnxo" role="3clFbG">
+                            <node concept="2OqwBi" id="6oIHlJhsnPT" role="3uHU7w">
+                              <node concept="37vLTw" id="6oIHlJhsn_q" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6oIHlJhsfjO" resolve="it" />
+                              </node>
+                              <node concept="2qgKlT" id="6oIHlJhspna" role="2OqNvi">
+                                <ref role="37wK5l" node="6oIHlJhcLM0" resolve="isReadWrite" />
+                              </node>
+                            </node>
+                            <node concept="1Wc70l" id="6oIHlJhsl75" role="3uHU7B">
+                              <node concept="2OqwBi" id="6oIHlJhsfJp" role="3uHU7B">
+                                <node concept="37vLTw" id="6oIHlJhsfoc" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="6oIHlJhsfjO" resolve="it" />
+                                </node>
+                                <node concept="2qgKlT" id="6oIHlJhsjH7" role="2OqNvi">
+                                  <ref role="37wK5l" node="6oIHlJhcELf" resolve="isPublic" />
+                                </node>
+                              </node>
+                              <node concept="3fqX7Q" id="6oIHlJhslaC" role="3uHU7w">
+                                <node concept="2OqwBi" id="6oIHlJhslBT" role="3fr31v">
+                                  <node concept="37vLTw" id="6oIHlJhsleg" role="2Oq$k0">
+                                    <ref role="3cqZAo" node="6oIHlJhsfjO" resolve="it" />
+                                  </node>
+                                  <node concept="2qgKlT" id="6oIHlJhsmfd" role="2OqNvi">
+                                    <ref role="37wK5l" node="6oIHlJhqPUU" resolve="isStatic" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="gl6BB" id="6oIHlJhsfjO" role="1bW2Oz">
+                        <property role="TrG5h" value="it" />
+                        <node concept="2jxLKc" id="6oIHlJhsfjP" role="1tU5fm" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="60ZH30_8vaf" role="3clFbw">
+            <node concept="37vLTw" id="60ZH30_8uxx" role="2Oq$k0">
+              <ref role="3cqZAo" node="60ZH30$MSjm" resolve="kind" />
+            </node>
+            <node concept="2Zo12i" id="60ZH30_8w1T" role="2OqNvi">
+              <node concept="chp4Y" id="60ZH30_8wgu" role="2Zo12j">
+                <ref role="cht4Q" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="6oIHlJhsqCy" role="3cqZAp" />
+        <node concept="3cpWs6" id="60ZH30$ZQy9" role="3cqZAp">
+          <node concept="2ShNRf" id="60ZH30$ZQUq" role="3cqZAk">
+            <node concept="1pGfFk" id="60ZH30$ZRh2" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="o8zo:7ipADkTfAzT" resolve="EmptyScope" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="60ZH30$MSjm" role="3clF46">
+        <property role="TrG5h" value="kind" />
+        <node concept="3bZ5Sz" id="60ZH30$MSjn" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="60ZH30$MSjo" role="3clF46">
+        <property role="TrG5h" value="child" />
+        <node concept="3Tqbb2" id="60ZH30$MSjp" role="1tU5fm" />
+      </node>
+      <node concept="3uibUv" id="60ZH30$MSjq" role="3clF45">
+        <ref role="3uigEE" to="o8zo:3fifI_xCtN$" resolve="Scope" />
+      </node>
+    </node>
+  </node>
+  <node concept="13h7C7" id="2KItQQV8wB5">
+    <ref role="13h7C2" to="80bi:2KItQQV8wB2" resolve="Constructor" />
+    <node concept="13hLZK" id="2KItQQV8wB6" role="13h7CW">
+      <node concept="3clFbS" id="2KItQQV8wB7" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="2KItQQV8wBo" role="13h7CS">
+      <property role="TrG5h" value="supportsTarget" />
+      <ref role="13i0hy" node="6aIFk8cib2p" resolve="supportsTarget" />
+      <node concept="3Tm1VV" id="2KItQQV8wBp" role="1B3o_S" />
+      <node concept="3clFbS" id="2KItQQV8wBC" role="3clF47">
+        <node concept="3clFbF" id="2KItQQV8wVC" role="3cqZAp">
+          <node concept="3clFbC" id="2KItQQV8x6v" role="3clFbG">
+            <node concept="2OqwBi" id="2KItQQV8z6g" role="3uHU7w">
+              <node concept="1XH99k" id="2KItQQV8xox" role="2Oq$k0">
+                <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+              </node>
+              <node concept="2ViDtV" id="2KItQQV8zyl" role="2OqNvi">
+                <ref role="2ViDtZ" to="80bi:7Jk5HDXalfh" resolve="method" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="2KItQQV8wVB" role="3uHU7B">
+              <ref role="3cqZAo" node="2KItQQV8wBD" resolve="target" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2KItQQV8wBD" role="3clF46">
+        <property role="TrG5h" value="target" />
+        <node concept="2ZThk1" id="2KItQQV8wBE" role="1tU5fm">
+          <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+        </node>
+      </node>
+      <node concept="10P_77" id="2KItQQV8wBF" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="6oIHlJhcEK0">
+    <property role="3GE5qa" value="Modifiers" />
+    <ref role="13h7C2" to="80bi:5oHFRyIxp1o" resolve="IHaveModifiers" />
+    <node concept="13i0hz" id="6oIHlJhcELf" role="13h7CS">
+      <property role="TrG5h" value="isPublic" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="6oIHlJhcELg" role="1B3o_S" />
+      <node concept="10P_77" id="6oIHlJhcEM1" role="3clF45" />
+      <node concept="3clFbS" id="6oIHlJhcELi" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhcEPs" role="3cqZAp">
+          <node concept="2OqwBi" id="6oIHlJhfQz$" role="3clFbG">
+            <node concept="BsUDl" id="6oIHlJhfQcU" role="2Oq$k0">
+              <ref role="37wK5l" node="6oIHlJhfnjp" resolve="visibility" />
+            </node>
+            <node concept="1mIQ4w" id="6oIHlJhfRtg" role="2OqNvi">
+              <node concept="chp4Y" id="6oIHlJhfRxr" role="cj9EA">
+                <ref role="cht4Q" to="80bi:3h4LMeIRHqY" resolve="Public" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6oIHlJhqPUU" role="13h7CS">
+      <property role="TrG5h" value="isStatic" />
+      <property role="13i0it" value="true" />
+      <node concept="3Tm1VV" id="6oIHlJhqPUV" role="1B3o_S" />
+      <node concept="10P_77" id="6oIHlJhqPUW" role="3clF45" />
+      <node concept="3clFbS" id="6oIHlJhqPUX" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhqPUY" role="3cqZAp">
+          <node concept="2OqwBi" id="6oIHlJhqSL6" role="3clFbG">
+            <node concept="2OqwBi" id="6oIHlJhqQa1" role="2Oq$k0">
+              <node concept="13iPFW" id="6oIHlJhqQ29" role="2Oq$k0" />
+              <node concept="3Tsc0h" id="6oIHlJhqQp8" role="2OqNvi">
+                <ref role="3TtcxE" to="80bi:5oHFRyIxp1p" resolve="iModifier" />
+              </node>
+            </node>
+            <node concept="2HwmR7" id="6oIHlJhqURc" role="2OqNvi">
+              <node concept="1bVj0M" id="6oIHlJhqURe" role="23t8la">
+                <node concept="3clFbS" id="6oIHlJhqURf" role="1bW5cS">
+                  <node concept="3clFbF" id="6oIHlJhqW1u" role="3cqZAp">
+                    <node concept="2OqwBi" id="6oIHlJhqWiH" role="3clFbG">
+                      <node concept="37vLTw" id="6oIHlJhqW4z" role="2Oq$k0">
+                        <ref role="3cqZAo" node="6oIHlJhqURg" resolve="it" />
+                      </node>
+                      <node concept="1mIQ4w" id="6oIHlJhqPV1" role="2OqNvi">
+                        <node concept="chp4Y" id="6oIHlJhqPV2" role="cj9EA">
+                          <ref role="cht4Q" to="80bi:3h4LMeIRWvZ" resolve="Static" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="6oIHlJhqURg" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="6oIHlJhqURh" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="6oIHlJhfnjp" role="13h7CS">
+      <property role="TrG5h" value="visibility" />
+      <node concept="3Tm1VV" id="6oIHlJhfnjq" role="1B3o_S" />
+      <node concept="3Tqbb2" id="6oIHlJhfnmn" role="3clF45">
+        <ref role="ehGHo" to="80bi:3h4LMeIRHrP" resolve="IVisibility" />
+      </node>
+      <node concept="3clFbS" id="6oIHlJhfnjs" role="3clF47">
+        <node concept="3clFbF" id="6oIHlJhfnwt" role="3cqZAp">
+          <node concept="2OqwBi" id="6oIHlJhfxVG" role="3clFbG">
+            <node concept="2OqwBi" id="6oIHlJhfv1I" role="2Oq$k0">
+              <node concept="2OqwBi" id="6oIHlJhfnFE" role="2Oq$k0">
+                <node concept="13iPFW" id="6oIHlJhfnws" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="6oIHlJhfnUu" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:5oHFRyIxp1p" resolve="iModifier" />
+                </node>
+              </node>
+              <node concept="v3k3i" id="6oIHlJhfxc$" role="2OqNvi">
+                <node concept="chp4Y" id="6oIHlJhfxdN" role="v3oSu">
+                  <ref role="cht4Q" to="80bi:3h4LMeIRHrP" resolve="IVisibility" />
+                </node>
+              </node>
+            </node>
+            <node concept="1uHKPH" id="6oIHlJhfyIs" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="6oIHlJhcEK1" role="13h7CW">
+      <node concept="3clFbS" id="6oIHlJhcEK2" role="2VODD2" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/constraints.mps
@@ -96,7 +96,7 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
@@ -107,7 +107,7 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
@@ -242,7 +242,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
       <concept id="709746936026466394" name="jetbrains.mps.lang.core.structure.ChildAttribute" flags="ng" index="3VBwX9">
@@ -2833,6 +2833,16 @@
             </node>
           </node>
         </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1M2fIO" id="60ZH30$MS7W">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1M2myG" to="80bi:7Jk5HDXCy9o" resolve="NamedArgument" />
+    <node concept="1N5Pfh" id="60ZH30$MS8T" role="1Mr941">
+      <ref role="1N5Vy1" to="80bi:7Jk5HDXCyC8" resolve="property" />
+      <node concept="1dDu$B" id="60ZH30$V78w" role="1N6uqs">
+        <ref role="1dDu$A" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/editor.mps
@@ -80,6 +80,7 @@
         <child id="8329266386016685951" name="editorContext" index="2xHN3q" />
         <child id="8979250711607012232" name="cellSelector" index="3a7HXU" />
       </concept>
+      <concept id="8371900013785948369" name="jetbrains.mps.lang.editor.structure.QueryFunction_SubstituteMenu_Parameter" flags="ig" index="2$S_p_" />
       <concept id="6718020819487620876" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Default" flags="ng" index="A1WHr" />
       <concept id="6718020819487620873" name="jetbrains.mps.lang.editor.structure.TransformationMenuReference_Named" flags="ng" index="A1WHu">
         <reference id="6718020819487620874" name="menu" index="A1WHt" />
@@ -89,6 +90,10 @@
       </concept>
       <concept id="3473224453637651916" name="jetbrains.mps.lang.editor.structure.TransformationLocation_SideTransform_PlaceInCellHolder" flags="ng" index="CtIbL">
         <property id="3473224453637651917" name="placeInCell" index="CtIbK" />
+      </concept>
+      <concept id="308059530142752797" name="jetbrains.mps.lang.editor.structure.SubstituteMenuPart_Parameterized" flags="ng" index="2F$Pav">
+        <child id="8371900013785948359" name="part" index="2$S_pN" />
+        <child id="8371900013785948365" name="parameterQuery" index="2$S_pT" />
       </concept>
       <concept id="1638911550608610798" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_Execute" flags="ig" index="IWg2L" />
       <concept id="1638911550608610278" name="jetbrains.mps.lang.editor.structure.TransformationMenuPart_Action" flags="ng" index="IWgqT">
@@ -134,6 +139,10 @@
       <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ngI" index="2ZABuq">
         <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
         <child id="5991739802479788259" name="type" index="22hAXT" />
+      </concept>
+      <concept id="1630016958697286851" name="jetbrains.mps.lang.editor.structure.QueryFunctionParameter_parameterObject" flags="ng" index="2ZBlsa" />
+      <concept id="1630016958697057551" name="jetbrains.mps.lang.editor.structure.IMenuPartParameterized" flags="ngI" index="2ZBHr6">
+        <child id="1630016958697057552" name="parameterType" index="2ZBHrp" />
       </concept>
       <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
       <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
@@ -470,6 +479,7 @@
     </language>
     <language id="aee9cad2-acd4-4608-aef2-0004f6a1cdbd" name="jetbrains.mps.lang.actions">
       <concept id="5979988948250981289" name="jetbrains.mps.lang.actions.structure.SNodeCreatorAndInitializer" flags="nn" index="2fJWfE" />
+      <concept id="767145758118872830" name="jetbrains.mps.lang.actions.structure.NF_Link_SetNewChildOperation" flags="nn" index="2DeJnY" />
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
@@ -502,11 +512,15 @@
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
       <concept id="1145573345940" name="jetbrains.mps.lang.smodel.structure.Node_GetAllSiblingsOperation" flags="nn" index="2TvwIu" />
+      <concept id="1966870290088668520" name="jetbrains.mps.lang.smodel.structure.Enum_MembersOperation" flags="ng" index="2ViDtN" />
       <concept id="1139184414036" name="jetbrains.mps.lang.smodel.structure.LinkList_AddNewChildOperation" flags="nn" index="WFELt">
         <reference id="1139877738879" name="concept" index="1A0vxQ" />
       </concept>
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1143512015885" name="jetbrains.mps.lang.smodel.structure.Node_GetNextSiblingOperation" flags="nn" index="YCak7" />
+      <concept id="1240170042401" name="jetbrains.mps.lang.smodel.structure.SEnumerationMemberType" flags="in" index="2ZThk1">
+        <reference id="1240170836027" name="enum" index="2ZWj4r" />
+      </concept>
       <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
         <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
       </concept>
@@ -549,6 +563,9 @@
       <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
+      <concept id="5779574625830813396" name="jetbrains.mps.lang.smodel.structure.EnumerationIdRefExpression" flags="ng" index="1XH99k">
+        <reference id="5779574625830813397" name="enumDeclaration" index="1XH99l" />
+      </concept>
       <concept id="1228341669568" name="jetbrains.mps.lang.smodel.structure.Node_DetachOperation" flags="nn" index="3YRAZt" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -586,6 +603,7 @@
       <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
       <concept id="1165595910856" name="jetbrains.mps.baseLanguage.collections.structure.GetLastOperation" flags="nn" index="1yVyf7" />
       <concept id="1225730411176" name="jetbrains.mps.baseLanguage.collections.structure.FindLastOperation" flags="nn" index="1zesIP" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
       <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
@@ -1376,6 +1394,36 @@
           <property role="VOm3f" value="true" />
         </node>
       </node>
+      <node concept="3EZMnI" id="5n2LpYi6U3e" role="3EZMnx">
+        <node concept="3F2HdR" id="5n2LpYi6TTb" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:6hv6i2_AyhC" resolve="globalAttributeList" />
+          <node concept="2iRkQZ" id="5n2LpYi6U64" role="2czzBx" />
+          <node concept="ljvvj" id="5n2LpYi6TUa" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="5n2LpYi6U0O" role="3EZMnx">
+          <node concept="ljvvj" id="5n2LpYi6U1N" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="5n2LpYi6U8V" role="2iSdaV" />
+        <node concept="pkWqt" id="5n2LpYi6Uan" role="pqm2j">
+          <node concept="3clFbS" id="5n2LpYi6Uao" role="2VODD2">
+            <node concept="3clFbF" id="5n2LpYi6UcI" role="3cqZAp">
+              <node concept="2OqwBi" id="5n2LpYi6YRk" role="3clFbG">
+                <node concept="2OqwBi" id="5n2LpYi6UAZ" role="2Oq$k0">
+                  <node concept="pncrf" id="5n2LpYi6UcH" role="2Oq$k0" />
+                  <node concept="3Tsc0h" id="5n2LpYi6Vhb" role="2OqNvi">
+                    <ref role="3TtcxE" to="80bi:6hv6i2_AyhC" resolve="globalAttributeList" />
+                  </node>
+                </node>
+                <node concept="3GX2aA" id="5n2LpYi75EM" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
       <node concept="3F2HdR" id="6vAOG1ACMk$" role="3EZMnx">
         <ref role="1NtTu8" to="80bi:6hv6i2_A$dV" resolve="namespaceMemberDeclaration" />
         <node concept="pj6Ft" id="6vAOG1ACOqV" role="3F10Kt">
@@ -1400,6 +1448,12 @@
     <property role="3GE5qa" value="Class / Struct" />
     <ref role="1XX52x" to="80bi:6hv6i2_Azc3" resolve="ClassDeclaration" />
     <node concept="3EZMnI" id="6vAOG1ACmDo" role="2wV5jI">
+      <node concept="PMmxH" id="7Jk5HDWZooB" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="7Jk5HDWZoIb" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyIK5Da" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -1506,6 +1560,12 @@
     <property role="3GE5qa" value="Enum" />
     <ref role="1XX52x" to="80bi:6hv6i2_Azc7" resolve="EnumDeclaration" />
     <node concept="3EZMnI" id="6$wrg4A_Pfn" role="2wV5jI">
+      <node concept="PMmxH" id="6y6b8L7zcIc" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="6y6b8L7zcId" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyIJku2" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -1550,6 +1610,12 @@
     <property role="3GE5qa" value="Interface" />
     <ref role="1XX52x" to="80bi:6hv6i2_Azc6" resolve="InterfaceDeclaration" />
     <node concept="3EZMnI" id="6$wrg4AA2Bx" role="2wV5jI">
+      <node concept="PMmxH" id="6y6b8L7zcoz" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="6y6b8L7zco$" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="6tzy5CC2Ye7" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -1746,6 +1812,12 @@
     <ref role="1XX52x" to="80bi:6hv6i2_Azc4" resolve="DelegateDeclaration" />
     <node concept="3EZMnI" id="6$wrg4AAmi6" role="2wV5jI">
       <node concept="l2Vlx" id="6$wrg4AAxKQ" role="2iSdaV" />
+      <node concept="PMmxH" id="6y6b8L7zbIQ" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="6y6b8L7zbIR" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="6tzy5CC1zIX" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -1867,6 +1939,12 @@
     <property role="3GE5qa" value="Class / Struct" />
     <ref role="1XX52x" to="80bi:6hv6i2_Azc5" resolve="StructDeclaration" />
     <node concept="3EZMnI" id="6$wrg4A_JoF" role="2wV5jI">
+      <node concept="PMmxH" id="6y6b8L7zbvi" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="6y6b8L7zbFz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="6tzy5CC4eHY" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -1974,6 +2052,12 @@
     <ref role="1XX52x" to="80bi:6hv6i2_B6ci" resolve="MethodDeclaration" />
     <node concept="3EZMnI" id="3x25Ph9Gc_m" role="2wV5jI">
       <node concept="l2Vlx" id="3x25Ph9Gc_p" role="2iSdaV" />
+      <node concept="PMmxH" id="60ZH30$6zZp" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6$2U" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyIGjKl" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -2957,6 +3041,12 @@
     <property role="3GE5qa" value="Class / Struct.Constructors" />
     <ref role="1XX52x" to="80bi:6vAOG1ABnF5" resolve="StaticConstructorDeclaration" />
     <node concept="3EZMnI" id="3h4LMeIWDSw" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$6yTS" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6yVA" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="3F1sOY" id="1gNlOGhoOGZ" role="3EZMnx">
         <property role="2ru_X1" value="true" />
         <ref role="1NtTu8" to="80bi:6vAOG1ABnF6" resolve="extern" />
@@ -3046,6 +3136,9 @@
     <ref role="1XX52x" to="80bi:6hv6i2_Becz" resolve="FormalParameter" />
     <node concept="3EZMnI" id="7yZ_CF2xDXj" role="2wV5jI">
       <node concept="l2Vlx" id="7yZ_CF2xDXk" role="2iSdaV" />
+      <node concept="PMmxH" id="60ZH30$3ok7" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="3F1sOY" id="5nBCUOUb2uc" role="3EZMnx">
         <ref role="1NtTu8" to="80bi:5nBCUOUb2s7" resolve="parameterModifier" />
         <node concept="pkWqt" id="5nBCUOUb2vE" role="pqm2j">
@@ -3089,23 +3182,8 @@
     <property role="3GE5qa" value="Generics" />
     <ref role="1XX52x" to="80bi:6hv6i2_AXOM" resolve="TypeParameter" />
     <node concept="3EZMnI" id="4oSbvdvV$BM" role="2wV5jI">
-      <node concept="3F1sOY" id="4oSbvdvV_5k" role="3EZMnx">
-        <ref role="1NtTu8" to="80bi:6hv6i2_AXON" resolve="attributeList" />
-        <node concept="pkWqt" id="4oSbvdvW1eS" role="pqm2j">
-          <node concept="3clFbS" id="4oSbvdvW1eT" role="2VODD2">
-            <node concept="3clFbF" id="4oSbvdvW1me" role="3cqZAp">
-              <node concept="2OqwBi" id="4oSbvdvW2GM" role="3clFbG">
-                <node concept="2OqwBi" id="4oSbvdvW1Bc" role="2Oq$k0">
-                  <node concept="pncrf" id="4oSbvdvW1md" role="2Oq$k0" />
-                  <node concept="3TrEf2" id="4oSbvdvW1WP" role="2OqNvi">
-                    <ref role="3Tt5mk" to="80bi:6hv6i2_AXON" resolve="attributeList" />
-                  </node>
-                </node>
-                <node concept="3x8VRR" id="4oSbvdvW3a5" role="2OqNvi" />
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="PMmxH" id="60ZH30$V3rd" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
       </node>
       <node concept="3F0A7n" id="1HkqSaCMxa8" role="3EZMnx">
         <ref role="1NtTu8" to="80bi:1HkqSaCLg9I" resolve="varianceAnnotation" />
@@ -3271,6 +3349,12 @@
     <property role="3GE5qa" value="Class / Struct.Constants" />
     <ref role="1XX52x" to="80bi:6hv6i2_B47j" resolve="ConstantDeclaration" />
     <node concept="3EZMnI" id="3zXINoFT1Xg" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$6zky" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6zkz" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyILRjm" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -3297,6 +3381,9 @@
     <property role="3GE5qa" value="Class / Struct.Properties" />
     <ref role="1XX52x" to="80bi:6vAOG1ABcbt" resolve="GetAccessorDeclaration" />
     <node concept="3EZMnI" id="3zXINoFYMYD" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$IHQ5" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="PMmxH" id="4TAPLm0h1Mo" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -3351,6 +3438,12 @@
     <property role="3GE5qa" value="Class / Struct.Properties" />
     <ref role="1XX52x" to="80bi:6vAOG1ABcaT" resolve="PropertyDeclaration" />
     <node concept="3EZMnI" id="3zXINoFUcVK" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$6$5j" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6$5M" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyILRmt" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -3390,6 +3483,9 @@
     <property role="3GE5qa" value="Class / Struct.Properties" />
     <ref role="1XX52x" to="80bi:6vAOG1ABcbx" resolve="SetAccessorDeclaration" />
     <node concept="3EZMnI" id="3zXINoG2Qjq" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$IHwA" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="PMmxH" id="4TAPLm0h1WG" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -3434,8 +3530,14 @@
     <property role="3GE5qa" value="Class / Struct.Constructors" />
     <ref role="1XX52x" to="80bi:6vAOG1ABnEK" resolve="ConstructorDeclaration" />
     <node concept="3EZMnI" id="2a8$IxLSOpu" role="2wV5jI">
+      <node concept="PMmxH" id="6y6b8L7AMC6" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="PMmxH" id="5oHFRyIIyJK" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
+        <node concept="pVoyu" id="6y6b8L7AM_r" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
       </node>
       <node concept="3F0A7n" id="2a8$IxLSSz$" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
@@ -3559,6 +3661,12 @@
     <property role="3GE5qa" value="Enum" />
     <ref role="1XX52x" to="80bi:6$wrg4A_UKD" resolve="EnumMemberDeclaration" />
     <node concept="3EZMnI" id="2a8$IxM17_I" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$6$QX" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6$WB" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="3F0A7n" id="2a8$IxM17_P" role="3EZMnx">
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
       </node>
@@ -3616,6 +3724,12 @@
     <property role="3GE5qa" value="Class / Struct.Fields" />
     <ref role="1XX52x" to="80bi:6hv6i2_B6aE" resolve="FieldDeclaration" />
     <node concept="3EZMnI" id="2a8$IxM2NfK" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$6y9W" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6yar" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5oHFRyIxHhp" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -3851,6 +3965,12 @@
     <ref role="1XX52x" to="80bi:6$wrg4AAmeZ" resolve="InterfaceMethodDeclaration" />
     <node concept="3EZMnI" id="5oHFRyIH69m" role="2wV5jI">
       <node concept="l2Vlx" id="5oHFRyIH69p" role="2iSdaV" />
+      <node concept="PMmxH" id="60ZH30$6_mf" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$6_uT" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="6tzy5CC0Q0n" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -4321,6 +4441,12 @@
     <property role="3GE5qa" value="Interface.Properties" />
     <ref role="1XX52x" to="80bi:7IPlf6q1V6w" resolve="InterfacePropertyDeclaration" />
     <node concept="3EZMnI" id="2e5scIOzC2l" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$II3$" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+        <node concept="ljvvj" id="60ZH30$II4x" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
       <node concept="PMmxH" id="5xx_vq$5yuz" role="3EZMnx">
         <ref role="PMmxG" node="5oHFRyIxpDG" resolve="HaveModifiersComponent" />
       </node>
@@ -20918,6 +21044,9 @@
     <property role="3GE5qa" value="Interface.Properties" />
     <ref role="1XX52x" to="80bi:gdBerkKl9w" resolve="InterfacePropertyGetAccessorDeclaration" />
     <node concept="3EZMnI" id="gdBerkTb2B" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$IHU$" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="3F0ifn" id="gdBerkTb2N" role="3EZMnx">
         <property role="3F0ifm" value="get;" />
         <node concept="VPM3Z" id="gdBerl3FoI" role="3F10Kt">
@@ -20931,6 +21060,9 @@
     <property role="3GE5qa" value="Interface.Properties" />
     <ref role="1XX52x" to="80bi:gdBerkKl9x" resolve="InterfacePropertySetAccessorDeclaration" />
     <node concept="3EZMnI" id="gdBerkTb3j" role="2wV5jI">
+      <node concept="PMmxH" id="60ZH30$IHWX" role="3EZMnx">
+        <ref role="PMmxG" node="7Jk5HDWZnN3" resolve="HasAttributesComponent" />
+      </node>
       <node concept="3F0ifn" id="gdBerkTb3y" role="3EZMnx">
         <property role="3F0ifm" value="set;" />
       </node>
@@ -21551,8 +21683,11 @@
   <node concept="24kQdi" id="7HmXimPhQcI">
     <property role="3GE5qa" value="Expressions.AnonymousFunctions" />
     <ref role="1XX52x" to="80bi:7HmXimPhQcC" resolve="ImplicitParameter" />
-    <node concept="3F0A7n" id="7HmXimPhQcK" role="2wV5jI">
-      <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+    <node concept="3EZMnI" id="60ZH30$3opa" role="2wV5jI">
+      <node concept="l2Vlx" id="60ZH30$3opb" role="2iSdaV" />
+      <node concept="3F0A7n" id="7HmXimPhQcK" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
     </node>
   </node>
   <node concept="3ICUPy" id="7HmXimR0WHi">
@@ -22428,6 +22563,586 @@
         <ref role="1NtTu8" to="80bi:626pIat_VI_" resolve="block" />
       </node>
       <node concept="l2Vlx" id="626pIatIX8h" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7Jk5HDWZjKx">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:6hv6i2_ABc4" resolve="Attribute" />
+    <node concept="3EZMnI" id="7Jk5HDWZjL1" role="2wV5jI">
+      <node concept="3F1sOY" id="60ZH30_dBOl" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:6aIFk8bB0bX" resolve="attributeClass" />
+      </node>
+      <node concept="3F1sOY" id="AKP4wC40Eu" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:7Jk5HDXjmlt" resolve="argumentList" />
+        <node concept="pkWqt" id="AKP4wC4p2z" role="pqm2j">
+          <node concept="3clFbS" id="AKP4wC4p2$" role="2VODD2">
+            <node concept="3clFbF" id="AKP4wC4pj3" role="3cqZAp">
+              <node concept="2OqwBi" id="AKP4wC4qE8" role="3clFbG">
+                <node concept="2OqwBi" id="AKP4wC4pGq" role="2Oq$k0">
+                  <node concept="pncrf" id="AKP4wC4pj2" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="AKP4wC4q5V" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:7Jk5HDXjmlt" resolve="argumentList" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="AKP4wC4r7q" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="11L4FC" id="AKP4wCygfl" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="7Jk5HDWZjL4" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7Jk5HDWZnt$">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:6vAOG1ABcaf" resolve="AttributeSection" />
+    <node concept="3EZMnI" id="7Jk5HDWZnuy" role="2wV5jI">
+      <node concept="3F0ifn" id="7Jk5HDWZnv4" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11LMrY" id="7Jk5HDWZnyU" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3EZMnI" id="7Jk5HDXYHfS" role="3EZMnx">
+        <ref role="1ERwB7" node="6aIFk8cf7hy" resolve="RemoveTarget" />
+        <node concept="3F1sOY" id="6y6b8L7s01F" role="3EZMnx">
+          <ref role="1NtTu8" to="80bi:6aIFk8bTdHj" resolve="target" />
+        </node>
+        <node concept="l2Vlx" id="7Jk5HDXYHfT" role="2iSdaV" />
+        <node concept="3F0ifn" id="7Jk5HDXYHe9" role="3EZMnx">
+          <property role="3F0ifm" value=":" />
+          <node concept="11L4FC" id="7Jk5HDY4L9N" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="pkWqt" id="7Jk5HDXguLY" role="pqm2j">
+          <node concept="3clFbS" id="7Jk5HDXguLZ" role="2VODD2">
+            <node concept="3clFbF" id="6aIFk8bMzoF" role="3cqZAp">
+              <node concept="2OqwBi" id="6aIFk8bTgsN" role="3clFbG">
+                <node concept="2OqwBi" id="6aIFk8bTf$f" role="2Oq$k0">
+                  <node concept="pncrf" id="6aIFk8bTfbN" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6aIFk8bTg3F" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:6aIFk8bTdHj" resolve="target" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="6aIFk8bTgRS" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3F1sOY" id="5n2LpYie9eN" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:6vAOG1ABcag" resolve="attributeList" />
+      </node>
+      <node concept="3F0ifn" id="7Jk5HDWZnzT" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="7Jk5HDWZnDA" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="l2Vlx" id="7Jk5HDWZnu_" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="PKFIW" id="7Jk5HDWZnN3">
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="HasAttributesComponent" />
+    <ref role="1XX52x" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+    <node concept="3F2HdR" id="7Jk5HDWZnQP" role="2wV5jI">
+      <ref role="1NtTu8" to="80bi:7Jk5HDWZnIO" resolve="attributeSections" />
+      <ref role="APP_o" node="2KItQQUBJnc" resolve="RemoveSection" />
+      <node concept="2iRkQZ" id="7Jk5HDX3URt" role="2czzBx" />
+      <node concept="pkWqt" id="7Jk5HDX6Smk" role="pqm2j">
+        <node concept="3clFbS" id="7Jk5HDX6Sml" role="2VODD2">
+          <node concept="3clFbF" id="7Jk5HDX6SA_" role="3cqZAp">
+            <node concept="2OqwBi" id="7Jk5HDX6XYt" role="3clFbG">
+              <node concept="2OqwBi" id="7Jk5HDX6SYU" role="2Oq$k0">
+                <node concept="pncrf" id="7Jk5HDX6SA$" role="2Oq$k0" />
+                <node concept="3Tsc0h" id="7Jk5HDX6UW0" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:7Jk5HDWZnIO" resolve="attributeSections" />
+                </node>
+              </node>
+              <node concept="3GX2aA" id="7Jk5HDX73O5" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="7Jk5HDXCyez">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:7Jk5HDXCy9o" resolve="NamedArgument" />
+    <node concept="3EZMnI" id="7Jk5HDXCyfx" role="2wV5jI">
+      <node concept="1iCGBv" id="7Jk5HDXCyJJ" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:7Jk5HDXCyC8" resolve="property" />
+        <node concept="1sVBvm" id="7Jk5HDXCyJL" role="1sWHZn">
+          <node concept="3F0A7n" id="7Jk5HDXCyKM" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="7Jk5HDXCyJe" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+      </node>
+      <node concept="3F1sOY" id="7Jk5HDXCyHj" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:7Jk5HDXCyyp" resolve="expression" />
+      </node>
+      <node concept="l2Vlx" id="7Jk5HDXCyf$" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="7Jk5HDXCy$i">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:7Jk5HDXCyp0" resolve="PositionalArgument" />
+    <node concept="3F1sOY" id="7Jk5HDXCy$M" role="2wV5jI">
+      <ref role="1NtTu8" to="80bi:7Jk5HDXCyyp" resolve="expression" />
+    </node>
+  </node>
+  <node concept="24kQdi" id="6aIFk8bTdi8">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:6aIFk8bTdc0" resolve="AttributeTargetSpecifier" />
+    <node concept="3F0A7n" id="6aIFk8bTdiC" role="2wV5jI">
+      <property role="1Intyy" value="true" />
+      <ref role="1NtTu8" to="80bi:6aIFk8bTdhb" resolve="value" />
+      <node concept="VPxyj" id="6y6b8L7vVkR" role="3F10Kt" />
+    </node>
+  </node>
+  <node concept="22mcaB" id="6aIFk8c2YGA">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="aqKnT" to="80bi:6aIFk8bTdc0" resolve="AttributeTargetSpecifier" />
+    <node concept="22hDWj" id="6aIFk8c2YHz" role="22hAXT" />
+    <node concept="2F$Pav" id="6aIFk8c2YI2" role="3ft7WO">
+      <node concept="3eGOop" id="6aIFk8c2YK$" role="2$S_pN">
+        <node concept="ucgPf" id="6aIFk8c2YKA" role="3aKz83">
+          <node concept="3clFbS" id="6aIFk8c2YKC" role="2VODD2">
+            <node concept="3clFbF" id="6aIFk8c30Nw" role="3cqZAp">
+              <node concept="2pJPEk" id="6aIFk8c30Nu" role="3clFbG">
+                <node concept="2pJPED" id="6aIFk8c30Nv" role="2pJPEn">
+                  <ref role="2pJxaS" to="80bi:6aIFk8bTdc0" resolve="AttributeTargetSpecifier" />
+                  <node concept="2pJxcG" id="6aIFk8c30Wd" role="2pJxcM">
+                    <ref role="2pJxcJ" to="80bi:6aIFk8bTdhb" resolve="value" />
+                    <node concept="2ZBlsa" id="6aIFk8c30ZL" role="28ntcv" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="16NL0t" id="6aIFk8c61jC" role="upBLP">
+          <node concept="2h3Zct" id="6aIFk8c93xr" role="16NL0q">
+            <property role="2h4Kg1" value="attribute target" />
+          </node>
+        </node>
+      </node>
+      <node concept="2ZThk1" id="6aIFk8c2YJA" role="2ZBHrp">
+        <ref role="2ZWj4r" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+      </node>
+      <node concept="2$S_p_" id="6aIFk8c2YNj" role="2$S_pT">
+        <node concept="3clFbS" id="6aIFk8c2YNk" role="2VODD2">
+          <node concept="3cpWs8" id="60ZH30_dAm4" role="3cqZAp">
+            <node concept="3cpWsn" id="60ZH30_dAm7" role="3cpWs9">
+              <property role="TrG5h" value="attributedNode" />
+              <node concept="3Tqbb2" id="60ZH30_dAm2" role="1tU5fm">
+                <ref role="ehGHo" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+              </node>
+              <node concept="2OqwBi" id="60ZH30_dAFU" role="33vP2m">
+                <node concept="3bvxqY" id="60ZH30_dAFV" role="2Oq$k0" />
+                <node concept="2Xjw5R" id="60ZH30_dAFW" role="2OqNvi">
+                  <node concept="1xMEDy" id="60ZH30_dAFX" role="1xVPHs">
+                    <node concept="chp4Y" id="60ZH30_dAFY" role="ri$Ld">
+                      <ref role="cht4Q" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="60ZH30_dBiX" role="3cqZAp">
+            <node concept="2OqwBi" id="6aIFk8cityr" role="3cqZAk">
+              <node concept="2OqwBi" id="6aIFk8c30bU" role="2Oq$k0">
+                <node concept="1XH99k" id="6aIFk8c2Z0R" role="2Oq$k0">
+                  <ref role="1XH99l" to="80bi:7Jk5HDXal2Y" resolve="AttributeTarget" />
+                </node>
+                <node concept="2ViDtN" id="6aIFk8c30HA" role="2OqNvi" />
+              </node>
+              <node concept="3zZkjj" id="6aIFk8civ7V" role="2OqNvi">
+                <node concept="1bVj0M" id="6aIFk8civ7X" role="23t8la">
+                  <node concept="3clFbS" id="6aIFk8civ7Y" role="1bW5cS">
+                    <node concept="3clFbF" id="6aIFk8civpx" role="3cqZAp">
+                      <node concept="2OqwBi" id="6aIFk8cix5_" role="3clFbG">
+                        <node concept="2qgKlT" id="6aIFk8cixCQ" role="2OqNvi">
+                          <ref role="37wK5l" to="kvwr:6aIFk8cib2p" resolve="supportsTarget" />
+                          <node concept="37vLTw" id="6aIFk8cixNL" role="37wK5m">
+                            <ref role="3cqZAo" node="6aIFk8civ7Z" resolve="it" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="60ZH30_dAOy" role="2Oq$k0">
+                          <ref role="3cqZAo" node="60ZH30_dAm7" resolve="attributedNode" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="6aIFk8civ7Z" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="6aIFk8civ80" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="6aIFk8cf7hy">
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="RemoveAttributeTarget" />
+    <ref role="1h_SK9" to="80bi:6vAOG1ABcaf" resolve="AttributeSection" />
+    <node concept="1hA7zw" id="6aIFk8cf7Em" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove attribute target" />
+      <node concept="1hAIg9" id="6aIFk8cf7En" role="1hA7z_">
+        <node concept="3clFbS" id="6aIFk8cf7Eo" role="2VODD2">
+          <node concept="3clFbJ" id="6aIFk8cf7J0" role="3cqZAp">
+            <node concept="3clFbS" id="6aIFk8cf7J2" role="3clFbx">
+              <node concept="3cpWs6" id="6aIFk8cf8KV" role="3cqZAp" />
+            </node>
+            <node concept="2OqwBi" id="6aIFk8cf8gg" role="3clFbw">
+              <node concept="2OqwBi" id="6aIFk8cf7Tv" role="2Oq$k0">
+                <node concept="0IXxy" id="6aIFk8cf7JT" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6aIFk8cf83D" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:6aIFk8bTdHj" resolve="target" />
+                </node>
+              </node>
+              <node concept="2xy62i" id="6aIFk8cf8Fc" role="2OqNvi">
+                <node concept="1Q80Hx" id="6aIFk8cf8Go" role="2xHN3q" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="6aIFk8cf8R7" role="3cqZAp">
+            <node concept="37vLTI" id="6aIFk8cf9bK" role="3clFbG">
+              <node concept="10Nm6u" id="6aIFk8cf9cX" role="37vLTx" />
+              <node concept="2OqwBi" id="6aIFk8cf8Tn" role="37vLTJ">
+                <node concept="0IXxy" id="6aIFk8cf8R6" role="2Oq$k0" />
+                <node concept="3TrEf2" id="6aIFk8cf8XP" role="2OqNvi">
+                  <ref role="3Tt5mk" to="80bi:6aIFk8bTdHj" resolve="target" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="22mcaB" id="60ZH30_2mC2">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="aqKnT" to="80bi:7Jk5HDXCyp0" resolve="PositionalArgument" />
+    <node concept="22hDWj" id="60ZH30_2mCZ" role="22hAXT" />
+    <node concept="3N5dw7" id="60ZH30_5nXI" role="3ft7WO">
+      <node concept="3N5aqt" id="60ZH30_5nXJ" role="3Na0zg">
+        <node concept="3clFbS" id="60ZH30_5nXK" role="2VODD2">
+          <node concept="3clFbF" id="60ZH30_5nXL" role="3cqZAp">
+            <node concept="2pJPEk" id="60ZH30_5nXM" role="3clFbG">
+              <node concept="2pJPED" id="60ZH30_5nXN" role="2pJPEn">
+                <ref role="2pJxaS" to="80bi:7Jk5HDXCyp0" resolve="PositionalArgument" />
+                <node concept="2pIpSj" id="60ZH30_5nXO" role="2pJxcM">
+                  <ref role="2pIpSl" to="80bi:7Jk5HDXCyyp" resolve="expression" />
+                  <node concept="36biLy" id="60ZH30_5nXP" role="28nt2d">
+                    <node concept="3N4pyC" id="60ZH30_5nXQ" role="36biLW" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2kknPJ" id="60ZH30_5nXR" role="2klrvf">
+        <ref role="2ZyFGn" to="80bi:5VT83U$LgKs" resolve="Expression" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5n2LpYib3p0">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:fEeb94672n" resolve="GlobalAttributeSection" />
+    <node concept="3EZMnI" id="5n2LpYib3pY" role="2wV5jI">
+      <node concept="3F0ifn" id="5n2LpYie8BQ" role="3EZMnx">
+        <property role="3F0ifm" value="[" />
+        <node concept="11LMrY" id="5n2LpYie8Dk" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F0A7n" id="5n2LpYib3qw" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:6y6b8L82HkV" resolve="target" />
+      </node>
+      <node concept="3F0ifn" id="5n2LpYihom1" role="3EZMnx">
+        <property role="3F0ifm" value=":" />
+        <node concept="11L4FC" id="5n2LpYihont" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F1sOY" id="5n2LpYiealE" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5n2LpYihou7" resolve="attributeList" />
+      </node>
+      <node concept="l2Vlx" id="5n2LpYib3q1" role="2iSdaV" />
+      <node concept="3F0ifn" id="5n2LpYie8Gd" role="3EZMnx">
+        <property role="3F0ifm" value="]" />
+        <node concept="11L4FC" id="5n2LpYie8GH" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5n2LpYie9gy">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:5n2LpYie8KZ" resolve="AttributeList" />
+    <node concept="3F2HdR" id="6aIFk8bAXzu" role="2wV5jI">
+      <property role="2czwfO" value="," />
+      <ref role="1NtTu8" to="80bi:5n2LpYie8LW" resolve="attributes" />
+      <node concept="l2Vlx" id="6aIFk8bAXRo" role="2czzBx" />
+      <node concept="2SqB2G" id="60ZH30$9VK0" role="2SqHTX">
+        <property role="TrG5h" value="list" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="5n2LpYj7DqI">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1XX52x" to="80bi:5n2LpYj7C8D" resolve="AttributeClassReference" />
+    <node concept="3EZMnI" id="5n2LpYj7Dre" role="2wV5jI">
+      <node concept="PMmxH" id="5n2LpYj7Dri" role="3EZMnx">
+        <ref role="PMmxG" node="27q4jmdWZQF" resolve="ParentReference" />
+        <node concept="pkWqt" id="5n2LpYj7Drj" role="pqm2j">
+          <node concept="3clFbS" id="5n2LpYj7Drk" role="2VODD2">
+            <node concept="3clFbF" id="5n2LpYj7Drl" role="3cqZAp">
+              <node concept="3y3z36" id="5n2LpYj7Drm" role="3clFbG">
+                <node concept="10Nm6u" id="5n2LpYj7Drn" role="3uHU7w" />
+                <node concept="2OqwBi" id="5n2LpYj7Dro" role="3uHU7B">
+                  <node concept="pncrf" id="5n2LpYj7Drp" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="5n2LpYj7Drq" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:27q4jmdWXho" resolve="parentType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1iCGBv" id="5n2LpYjig8H" role="3EZMnx">
+        <ref role="1NtTu8" to="80bi:5n2LpYj7C8E" resolve="referencedType" />
+        <node concept="1sVBvm" id="5n2LpYjig8Q" role="1sWHZn">
+          <node concept="3F0A7n" id="5n2LpYjigqT" role="2wV5jI">
+            <property role="1Intyy" value="true" />
+            <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+          </node>
+        </node>
+      </node>
+      <node concept="l2Vlx" id="5n2LpYj7Drh" role="2iSdaV" />
+    </node>
+  </node>
+  <node concept="1h_SRR" id="2KItQQUBJnc">
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="RemoveSection" />
+    <ref role="1h_SK9" to="80bi:6vAOG1ABcaf" resolve="AttributeSection" />
+    <node concept="1hA7zw" id="2KItQQUBJnf" role="1h_SK8">
+      <property role="1hAc7j" value="g_hAxAO/delete_action_id" />
+      <property role="1hHO97" value="remove attribute section" />
+      <node concept="1hAIg9" id="2KItQQUBJng" role="1hA7z_">
+        <node concept="3clFbS" id="2KItQQUBJnh" role="2VODD2">
+          <node concept="3clFbJ" id="2KItQQUBJpk" role="3cqZAp">
+            <node concept="2OqwBi" id="2KItQQUBJz3" role="3clFbw">
+              <node concept="0IXxy" id="2KItQQUBJpH" role="2Oq$k0" />
+              <node concept="2xy62i" id="2KItQQUBLwV" role="2OqNvi">
+                <node concept="1Q80Hx" id="2KItQQUBLxC" role="2xHN3q" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="2KItQQUBJpm" role="3clFbx">
+              <node concept="3cpWs6" id="2KItQQUBL_I" role="3cqZAp" />
+            </node>
+          </node>
+          <node concept="3cpWs8" id="2KItQQUBMaI" role="3cqZAp">
+            <node concept="3cpWsn" id="2KItQQUBMaL" role="3cpWs9">
+              <property role="TrG5h" value="parent" />
+              <node concept="3Tqbb2" id="2KItQQUBMaG" role="1tU5fm">
+                <ref role="ehGHo" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+              </node>
+              <node concept="1PxgMI" id="2KItQQUUMb8" role="33vP2m">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="2KItQQUUMcH" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:7Jk5HDWZnHp" resolve="IHasAttributes" />
+                </node>
+                <node concept="2OqwBi" id="2KItQQUBMjK" role="1m5AlR">
+                  <node concept="0IXxy" id="2KItQQUBMc4" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="2KItQQUBMnJ" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="2KItQQUBLDs" role="3cqZAp">
+            <node concept="2OqwBi" id="2KItQQUBLHp" role="3clFbG">
+              <node concept="0IXxy" id="2KItQQUBLDr" role="2Oq$k0" />
+              <node concept="3YRAZt" id="2KItQQUBM4L" role="2OqNvi" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="2KItQQURFCh" role="3cqZAp">
+            <node concept="3clFbS" id="2KItQQURFCj" role="3clFbx">
+              <node concept="3clFbF" id="2KItQQUBMsJ" role="3cqZAp">
+                <node concept="2OqwBi" id="2KItQQUBM_U" role="3clFbG">
+                  <node concept="37vLTw" id="2KItQQUBMsH" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2KItQQUBMaL" resolve="parent" />
+                  </node>
+                  <node concept="1OKiuA" id="2KItQQUBMPG" role="2OqNvi">
+                    <node concept="1Q80Hx" id="2KItQQUBMQh" role="lBI5i" />
+                    <node concept="2B6iha" id="2KItQQV44NV" role="lGT1i" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="2KItQQURGjm" role="3clFbw">
+              <node concept="2OqwBi" id="2KItQQURFMJ" role="2Oq$k0">
+                <node concept="37vLTw" id="2KItQQUUMfZ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="2KItQQUBMaL" resolve="parent" />
+                </node>
+                <node concept="3Tsc0h" id="2KItQQUUM_z" role="2OqNvi">
+                  <ref role="3TtcxE" to="80bi:7Jk5HDWZnIO" resolve="attributeSections" />
+                </node>
+              </node>
+              <node concept="1v1jN8" id="2KItQQUUQHN" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="AKP4wC3Wy4">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="1XX52x" to="80bi:AKP4wC3Wy1" resolve="AttributeArgumentList" />
+    <node concept="3EZMnI" id="AKP4wC4p2k" role="2wV5jI">
+      <node concept="l2Vlx" id="AKP4wC4p2l" role="2iSdaV" />
+      <node concept="3F0ifn" id="AKP4wC4p2o" role="3EZMnx">
+        <property role="3F0ifm" value="(" />
+        <node concept="11L4FC" id="AKP4wC4p2q" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="11LMrY" id="AKP4wC4p2s" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+      <node concept="3F2HdR" id="AKP4wC3WMq" role="3EZMnx">
+        <property role="2czwfO" value="," />
+        <ref role="1NtTu8" to="80bi:AKP4wC3Wy3" resolve="arguments" />
+        <node concept="l2Vlx" id="AKP4wC3WMr" role="2czzBx" />
+        <node concept="3F0ifn" id="AKP4wCe5tA" role="2czzBI">
+          <node concept="VPxyj" id="AKP4wCe5tC" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+      <node concept="3F0ifn" id="AKP4wC4p2v" role="3EZMnx">
+        <property role="3F0ifm" value=")" />
+        <node concept="11L4FC" id="AKP4wC4p2x" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3ICUPy" id="6c7swQsakrv">
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="aqKnT" to="80bi:5n2LpYj7C8D" resolve="AttributeClassReference" />
+    <node concept="1Qtc8_" id="7Jk5HDXvxHl" role="IW6Ez">
+      <node concept="mvV$s" id="6c7swQsmJVz" role="1Qtc8A">
+        <node concept="mvVNg" id="6c7swQsmJWt" role="mvV$0">
+          <node concept="3clFbS" id="6c7swQsmJWu" role="2VODD2">
+            <node concept="3clFbF" id="6c7swQsmJZ9" role="3cqZAp">
+              <node concept="1PxgMI" id="6c7swQsmJZa" role="3clFbG">
+                <property role="1BlNFB" value="true" />
+                <node concept="chp4Y" id="6c7swQsmJZb" role="3oSUPX">
+                  <ref role="cht4Q" to="80bi:6hv6i2_ABc4" resolve="Attribute" />
+                </node>
+                <node concept="2OqwBi" id="6c7swQsmJZc" role="1m5AlR">
+                  <node concept="7Obwk" id="6c7swQsmJZd" role="2Oq$k0" />
+                  <node concept="1mfA1w" id="6c7swQsmJZe" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="A1WHu" id="6c7swQsmLm$" role="A14EM">
+          <ref role="A1WHt" node="6c7swQsgA$D" resolve="Attribute_AddArguments" />
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="7Jk5HDXvxHP" role="1Qtc8$">
+        <node concept="CtIbL" id="7Jk5HDXvxHR" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
+    </node>
+    <node concept="22hDWj" id="6c7swQsjFKm" role="22hAXT" />
+  </node>
+  <node concept="3ICUPy" id="6c7swQsgA$D">
+    <property role="3GE5qa" value="Attributes" />
+    <ref role="aqKnT" to="80bi:6hv6i2_ABc4" resolve="Attribute" />
+    <node concept="22hDWg" id="6c7swQsmLj1" role="22hAXT">
+      <property role="TrG5h" value="Attribute_AddArguments" />
+    </node>
+    <node concept="1Qtc8_" id="6c7swQsgA$F" role="IW6Ez">
+      <node concept="IWgqT" id="7Jk5HDXvay0" role="1Qtc8A">
+        <node concept="1hCUdq" id="7Jk5HDXvay2" role="1hCUd6">
+          <node concept="3clFbS" id="7Jk5HDXvay4" role="2VODD2">
+            <node concept="3clFbF" id="7Jk5HDXvaN_" role="3cqZAp">
+              <node concept="Xl_RD" id="7Jk5HDXvaN$" role="3clFbG">
+                <property role="Xl_RC" value="(" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="IWg2L" id="7Jk5HDXvay6" role="IWgqQ">
+          <node concept="3clFbS" id="7Jk5HDXvay8" role="2VODD2">
+            <node concept="3clFbF" id="7Jk5HDXvjw9" role="3cqZAp">
+              <node concept="2OqwBi" id="7Jk5HDXvmIa" role="3clFbG">
+                <node concept="2OqwBi" id="7Jk5HDXvk26" role="2Oq$k0">
+                  <node concept="7Obwk" id="6c7swQsmLeQ" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="AKP4wC3Zzc" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:7Jk5HDXjmlt" resolve="argumentList" />
+                  </node>
+                </node>
+                <node concept="2DeJnY" id="AKP4wC3ZPz" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="27VH4U" id="7Jk5HDXvaPM" role="2jiSrf">
+          <node concept="3clFbS" id="7Jk5HDXvaPN" role="2VODD2">
+            <node concept="3clFbF" id="7Jk5HDXvb73" role="3cqZAp">
+              <node concept="2OqwBi" id="7Jk5HDXveXP" role="3clFbG">
+                <node concept="2OqwBi" id="6c7swQsatGj" role="2Oq$k0">
+                  <node concept="7Obwk" id="6c7swQsmLdL" role="2Oq$k0" />
+                  <node concept="3TrEf2" id="6c7swQsav77" role="2OqNvi">
+                    <ref role="3Tt5mk" to="80bi:7Jk5HDXjmlt" resolve="argumentList" />
+                  </node>
+                </node>
+                <node concept="3w_OXm" id="AKP4wC3ZL7" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cqGtN" id="7Jk5HDXvs35" role="2jZA2a">
+          <node concept="3cqJkl" id="7Jk5HDXvs36" role="3cqGtW">
+            <node concept="3clFbS" id="7Jk5HDXvs37" role="2VODD2">
+              <node concept="3clFbF" id="7Jk5HDXvs6Q" role="3cqZAp">
+                <node concept="Xl_RD" id="7Jk5HDXvs6P" role="3clFbG">
+                  <property role="Xl_RC" value="add arguments" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cWJ9i" id="6c7swQsgA$H" role="1Qtc8$">
+        <node concept="CtIbL" id="6c7swQsgA$J" role="CtIbM">
+          <property role="CtIbK" value="30NnNOohrQL/RIGHT" />
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/structure.mps
@@ -1327,64 +1327,14 @@
       </node>
     </node>
   </node>
-  <node concept="1TIwiD" id="6hv6i2_AyhB">
-    <property role="EcuMT" value="7232527154588296295" />
-    <property role="3GE5qa" value="Attributes" />
-    <property role="TrG5h" value="GlobalAttribute" />
-    <property role="R4oN_" value="Global attribute" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="3H0Qfr" id="6Y0EU3Z5OYx" role="lGtFl">
-      <node concept="1Pa9Pv" id="6Y0EU3Z5OYy" role="3H0Qfi">
-        <node concept="1PaTwC" id="6Y0EU3Z5OYz" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5OY$" role="1PaTwD">
-            <property role="3oM_SC" value="Represents a global attribute." />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5OYK" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5OYJ" role="1PaTwD">
-            <property role="3oM_SC" value="" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="fEeb946LGZ" role="1PaQFQ">
-          <node concept="3oM_SD" id="fEeb946LGY" role="1PaTwD">
-            <property role="3oM_SC" value="Note that this concept is not implemented. It is a place for extension of the C#" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5OYQ" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5OYP" role="1PaTwD">
-            <property role="3oM_SC" value="base language in the future development." />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="fEeb946LI1" role="1PaQFQ">
-          <node concept="3oM_SD" id="fEeb946LI0" role="1PaTwD">
-            <property role="3oM_SC" value="" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="fEeb946LHt" role="1PaQFQ">
-          <node concept="3oM_SD" id="fEeb946LHs" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: global-attribute-section" />
-          </node>
-        </node>
-      </node>
-    </node>
-  </node>
   <node concept="1TIwiD" id="6vAOG1ABcaT">
     <property role="EcuMT" value="7486903154347131577" />
     <property role="TrG5h" value="PropertyDeclaration" />
     <property role="3GE5qa" value="Class / Struct.Properties" />
     <property role="R4oN_" value="Class property declaration" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="PrWs8" id="6vAOG1ABcaU" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
+    <ref role="1TJDcQ" node="60ZH30zYXEq" resolve="Property" />
     <node concept="PrWs8" id="6vAOG1ABkO$" role="PzmwI">
       <ref role="PrY4T" node="6hv6i2_B0DQ" resolve="IClassMemberDeclaration" />
-    </node>
-    <node concept="1TJgyj" id="6vAOG1ABcaX" role="1TKVEi">
-      <property role="IQ2ns" value="7486903154347131581" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
     </node>
     <node concept="1TJgyj" id="6vAOG1ABcc1" role="1TKVEi">
       <property role="IQ2ns" value="7486903154347131649" />
@@ -1425,16 +1375,28 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrkNf" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrkNe" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: property-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXSY" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXSZ" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXT0" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXT1" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXT2" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30zYXT3" role="1PaTwD">
+            <property role="3oM_SC" value="property-declaration" />
           </node>
         </node>
       </node>
-    </node>
-    <node concept="PrWs8" id="5oHFRyILRl5" role="PzmwI">
-      <ref role="PrY4T" node="5oHFRyIxp1o" resolve="IHaveModifiers" />
-    </node>
-    <node concept="PrWs8" id="5oHFRyILRlq" role="PzmwI">
-      <ref role="PrY4T" node="5oHFRyIxp1s" resolve="IHaveType" />
     </node>
   </node>
   <node concept="1TIwiD" id="6$wrg4AAmeZ">
@@ -1443,13 +1405,7 @@
     <property role="3GE5qa" value="Interface.Methods" />
     <property role="34LRSv" value="method" />
     <property role="R4oN_" value="Interface method declaration" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="6$wrg4AAmf4" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424947155908" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
+    <ref role="1TJDcQ" node="60ZH30zYY06" resolve="Method" />
     <node concept="PrWs8" id="3h4LMeIQtvc" role="PzmwI">
       <ref role="PrY4T" node="3h4LMeIQtuQ" resolve="IFunctionHeader" />
     </node>
@@ -1488,7 +1444,25 @@
         </node>
         <node concept="1PaTwC" id="2pqoNIAe7yv" role="1PaQFQ">
           <node concept="3oM_SD" id="2pqoNIAe7yw" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: interface-method-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjH" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjI" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjJ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjK" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjL" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7ANjM" role="1PaTwD">
+            <property role="3oM_SC" value="interface-method-declaration" />
           </node>
         </node>
       </node>
@@ -1567,16 +1541,7 @@
     <property role="3GE5qa" value="Class / Struct.Constructors" />
     <property role="R4oN_" value="Constructor definition" />
     <property role="34LRSv" value="ctor" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="6vAOG1ABnET" role="1TKVEi">
-      <property role="IQ2ns" value="7486903154347178681" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
-    <node concept="PrWs8" id="6vAOG1ABnEL" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
+    <ref role="1TJDcQ" node="2KItQQV8wB2" resolve="Constructor" />
     <node concept="PrWs8" id="6vAOG1ABnFR" role="PzmwI">
       <ref role="PrY4T" node="6hv6i2_B0DQ" resolve="IClassMemberDeclaration" />
     </node>
@@ -1623,7 +1588,25 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrl9P" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrl9Q" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: constructor-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ58" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ59" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ5a" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ5b" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ5c" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ5d" role="1PaTwD">
+            <property role="3oM_SC" value="constructor-declaration" />
           </node>
         </node>
       </node>
@@ -1735,7 +1718,25 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrfWb" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrfWc" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: class-member-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8x" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8y" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8z" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8$" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8_" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ8A" role="1PaTwD">
+            <property role="3oM_SC" value="class-member-declaration" />
           </node>
         </node>
       </node>
@@ -1932,13 +1933,7 @@
     <property role="TrG5h" value="EnumMemberDeclaration" />
     <property role="3GE5qa" value="Enum" />
     <property role="R4oN_" value="Enum member" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="6$wrg4A_UKE" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424947043370" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
+    <ref role="1TJDcQ" node="60ZH30zYZTk" resolve="Field" />
     <node concept="1TJgyj" id="6$wrg4A_UKI" role="1TKVEi">
       <property role="IQ2ns" value="7575174424947043374" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -1947,9 +1942,6 @@
     </node>
     <node concept="PrWs8" id="6$wrg4A_UKG" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
-    </node>
-    <node concept="PrWs8" id="1HkqSaCLgB5" role="PzmwI">
-      <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
     </node>
     <node concept="3H0Qfr" id="6Y0EU3Z5Pi9" role="lGtFl">
       <node concept="1Pa9Pv" id="6Y0EU3Z5Pia" role="3H0Qfi">
@@ -1977,7 +1969,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5PiZ" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pj0" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: enum-member-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmJ" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmK" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmL" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmM" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmN" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7DXmO" role="1PaTwD">
+            <property role="3oM_SC" value="enum-member-declaration" />
           </node>
         </node>
       </node>
@@ -2132,15 +2142,9 @@
     <property role="3GE5qa" value="Class / Struct.Constants" />
     <property role="R4oN_" value="Constant definition" />
     <property role="34LRSv" value="const" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="60ZH30zYZTk" resolve="Field" />
     <node concept="PrWs8" id="6hv6i2_B47k" role="PzmwI">
       <ref role="PrY4T" node="6hv6i2_B0DQ" resolve="IClassMemberDeclaration" />
-    </node>
-    <node concept="1TJgyj" id="6hv6i2_B47n" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588434903" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
     </node>
     <node concept="1TJgyj" id="6hv6i2_B48F" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588434987" />
@@ -2287,21 +2291,36 @@
   </node>
   <node concept="1TIwiD" id="6vAOG1ABcaf">
     <property role="EcuMT" value="7486903154347131535" />
-    <property role="TrG5h" value="AttributeList" />
+    <property role="TrG5h" value="AttributeSection" />
     <property role="3GE5qa" value="Attributes" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="6aIFk8bTdHj" role="1TKVEi">
+      <property role="IQ2ns" value="7110811360843586387" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="target" />
+      <ref role="20lvS9" node="6aIFk8bTdc0" resolve="AttributeTargetSpecifier" />
+    </node>
     <node concept="1TJgyj" id="6vAOG1ABcag" role="1TKVEi">
       <property role="IQ2ns" value="7486903154347131536" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attribute" />
-      <property role="20lbJX" value="fLJekj6/_1__n" />
-      <ref role="20lvS9" node="6hv6i2_ABc4" resolve="Attribute" />
+      <property role="20kJfa" value="attributeList" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5n2LpYie8KZ" resolve="AttributeList" />
     </node>
     <node concept="3H0Qfr" id="6Y0EU3Z5PfZ" role="lGtFl">
       <node concept="1Pa9Pv" id="6Y0EU3Z5Pg0" role="3H0Qfi">
         <node concept="1PaTwC" id="6Y0EU3Z5Pg1" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5PgT" role="1PaTwD">
-            <property role="3oM_SC" value="A list of attributes." />
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSn" role="1PaTwD">
+            <property role="3oM_SC" value="list" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSo" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSp" role="1PaTwD">
+            <property role="3oM_SC" value="attributes." />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pgg" role="1PaQFQ">
@@ -2311,12 +2330,57 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pgi" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pgj" role="1PaTwD">
-            <property role="3oM_SC" value="This concept serves for encapsulation of the list Editor, which can then be reused" />
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSy" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSz" role="1PaTwD">
+            <property role="3oM_SC" value="serves" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjS$" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjS_" role="1PaTwD">
+            <property role="3oM_SC" value="encapsulation" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSA" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSB" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSC" role="1PaTwD">
+            <property role="3oM_SC" value="list" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSD" role="1PaTwD">
+            <property role="3oM_SC" value="Editor," />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSE" role="1PaTwD">
+            <property role="3oM_SC" value="which" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSF" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSG" role="1PaTwD">
+            <property role="3oM_SC" value="then" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSH" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSI" role="1PaTwD">
+            <property role="3oM_SC" value="reused" />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pgk" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pgl" role="1PaTwD">
-            <property role="3oM_SC" value="at different locations." />
+            <property role="3oM_SC" value="at" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSw" role="1PaTwD">
+            <property role="3oM_SC" value="different" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSx" role="1PaTwD">
+            <property role="3oM_SC" value="locations." />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pgm" role="1PaQFQ">
@@ -2326,7 +2390,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pgo" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pgp" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: attributes" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSq" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSr" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSs" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSt" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSu" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjSv" role="1PaTwD">
+            <property role="3oM_SC" value="attribute-section" />
           </node>
         </node>
       </node>
@@ -2355,7 +2437,8 @@
       <property role="IQ2ns" value="7232527154588296296" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
       <property role="20kJfa" value="globalAttributeList" />
-      <ref role="20lvS9" node="fEeb94672n" resolve="GlobalAttributeList" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="fEeb94672n" resolve="GlobalAttributeSection" />
     </node>
     <node concept="1TJgyj" id="6hv6i2_A$dV" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588304251" />
@@ -2459,12 +2542,6 @@
     <property role="TrG5h" value="FormalParameter" />
     <property role="3GE5qa" value="Class / Struct.Parameters" />
     <ref role="1TJDcQ" node="iSyfcvrmN2" resolve="Parameter" />
-    <node concept="1TJgyj" id="6hv6i2_Bec$" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588476196" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="5nBCUOUb2s7" role="1TKVEi">
       <property role="IQ2ns" value="6190096177244677895" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -2477,6 +2554,9 @@
       <property role="20lbJX" value="fLJekj4/_1" />
       <property role="20kJfa" value="type" />
       <ref role="20lvS9" node="5VT83U$LMPZ" resolve="Type" />
+    </node>
+    <node concept="PrWs8" id="60ZH30$IK5W" role="PzmwI">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
     </node>
   </node>
   <node concept="1TIwiD" id="6hv6i2_B48E">
@@ -2567,15 +2647,9 @@
     <property role="3GE5qa" value="Class / Struct.Fields" />
     <property role="34LRSv" value="field" />
     <property role="R4oN_" value="Field declaration" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="60ZH30zYZTk" resolve="Field" />
     <node concept="PrWs8" id="6hv6i2_B6aF" role="PzmwI">
       <ref role="PrY4T" node="6hv6i2_B0DQ" resolve="IClassMemberDeclaration" />
-    </node>
-    <node concept="1TJgyj" id="6hv6i2_B6aI" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588443310" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
     </node>
     <node concept="1TJgyj" id="6hv6i2_B6bd" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588443341" />
@@ -2625,7 +2699,25 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrfUM" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrfUL" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: field-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KO5" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KO6" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KO7" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KO8" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KO9" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDY4KOa" role="1PaTwD">
+            <property role="3oM_SC" value="field-declaration" />
           </node>
         </node>
       </node>
@@ -3238,14 +3330,11 @@
       <property role="TrG5h" value="varianceAnnotation" />
       <ref role="AX2Wp" node="5LVVOtEJNJY" resolve="VarianceAnnotationEnum" />
     </node>
-    <node concept="1TJgyj" id="6hv6i2_AXON" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588409139" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="PrWs8" id="1HkqSaCLqwX" role="PzmwI">
       <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="PrWs8" id="60ZH30$V2Zk" role="PzmwI">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
     </node>
     <node concept="3H0Qfr" id="7TfmMh1pDR_" role="lGtFl">
       <node concept="1Pa9Pv" id="7TfmMh1pDRA" role="3H0Qfi">
@@ -3330,10 +3419,31 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrkP$" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrkPz" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: set-accessor-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHai" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHaj" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHak" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHal" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHam" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IHan" role="1PaTwD">
+            <property role="3oM_SC" value="set-accessor-declaration" />
           </node>
         </node>
       </node>
+    </node>
+    <node concept="PrWs8" id="60ZH30$IHaQ" role="PzmwI">
+      <ref role="PrY4T" node="60ZH30$IGz$" resolve="ISetAccessor" />
     </node>
   </node>
   <node concept="1TIwiD" id="6vAOG1ABnFB">
@@ -3452,12 +3562,6 @@
     <property role="34LRSv" value="struct" />
     <property role="R4oN_" value="Struct type" />
     <ref role="1TJDcQ" node="6hv6i2_Azc2" resolve="TypeDeclaration" />
-    <node concept="1TJgyj" id="6$wrg4A_l_C" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424946891112" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="3h4LMeIQH$O" role="1TKVEi">
       <property role="IQ2ns" value="3766354144459938100" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -3491,7 +3595,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5PeK" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5PeL" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: struct-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YE" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YF" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YG" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YH" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YI" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z4YJ" role="1PaTwD">
+            <property role="3oM_SC" value="struct-declaration" />
           </node>
         </node>
       </node>
@@ -3510,12 +3632,6 @@
     <property role="34LRSv" value="delegate" />
     <property role="R4oN_" value="Delegate type" />
     <ref role="1TJDcQ" node="6hv6i2_Azc2" resolve="TypeDeclaration" />
-    <node concept="1TJgyj" id="6$wrg4AAmh8" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424947156040" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="PrWs8" id="3h4LMeIQtvi" role="PzmwI">
       <ref role="PrY4T" node="3h4LMeIQtuQ" resolve="IFunctionHeader" />
     </node>
@@ -3545,12 +3661,72 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pcn" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pco" role="1PaTwD">
-            <property role="3oM_SC" value="Note that this concept is not implemented. It is a place for extension of the C#" />
+            <property role="3oM_SC" value="Note" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lt" role="1PaTwD">
+            <property role="3oM_SC" value="that" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lu" role="1PaTwD">
+            <property role="3oM_SC" value="this" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lv" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lw" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lx" role="1PaTwD">
+            <property role="3oM_SC" value="not" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Ly" role="1PaTwD">
+            <property role="3oM_SC" value="implemented." />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lz" role="1PaTwD">
+            <property role="3oM_SC" value="It" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3L$" role="1PaTwD">
+            <property role="3oM_SC" value="is" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3L_" role="1PaTwD">
+            <property role="3oM_SC" value="a" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LA" role="1PaTwD">
+            <property role="3oM_SC" value="place" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LB" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LC" role="1PaTwD">
+            <property role="3oM_SC" value="extension" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LD" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LE" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LF" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pcp" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pcq" role="1PaTwD">
-            <property role="3oM_SC" value="base language in the future development." />
+            <property role="3oM_SC" value="base" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LG" role="1PaTwD">
+            <property role="3oM_SC" value="language" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LH" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LI" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LJ" role="1PaTwD">
+            <property role="3oM_SC" value="future" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3LK" role="1PaTwD">
+            <property role="3oM_SC" value="development." />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5PbW" role="1PaQFQ">
@@ -3560,7 +3736,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5P40" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5P3Z" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: delegate-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Ln" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lo" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lp" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lq" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Lr" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3Ls" role="1PaTwD">
+            <property role="3oM_SC" value="delegate-declaration" />
           </node>
         </node>
       </node>
@@ -3571,39 +3765,64 @@
     <property role="3GE5qa" value="Attributes" />
     <property role="TrG5h" value="Attribute" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="6aIFk8bB0bX" role="1TKVEi">
+      <property role="IQ2ns" value="7110811360838812413" />
+      <property role="20kJfa" value="attributeClass" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <ref role="20lvS9" node="5n2LpYj7C8D" resolve="AttributeClassReference" />
+    </node>
+    <node concept="1TJgyj" id="7Jk5HDXjmlt" role="1TKVEi">
+      <property role="IQ2ns" value="8922781889388701021" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="argumentList" />
+      <ref role="20lvS9" node="AKP4wC3Wy1" resolve="AttributeArgumentList" />
+    </node>
     <node concept="3H0Qfr" id="6Y0EU3Z5PgV" role="lGtFl">
       <node concept="1Pa9Pv" id="6Y0EU3Z5PgW" role="3H0Qfi">
         <node concept="1PaTwC" id="6Y0EU3Z5PgX" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5PhF" role="1PaTwD">
-            <property role="3oM_SC" value="Represents an attribute." />
+            <property role="3oM_SC" value="Represents" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKa" role="1PaTwD">
+            <property role="3oM_SC" value="an" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKb" role="1PaTwD">
+            <property role="3oM_SC" value="attribute." />
           </node>
         </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5Phh" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5Phi" role="1PaTwD">
-            <property role="3oM_SC" value="" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5Phj" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5Phk" role="1PaTwD">
-            <property role="3oM_SC" value="Note that this concept is not implemented. It is a place for extension of the C#" />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5Phl" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5Phm" role="1PaTwD">
-            <property role="3oM_SC" value="base language in the future development." />
-          </node>
-        </node>
-        <node concept="1PaTwC" id="6Y0EU3Z5Phn" role="1PaQFQ">
-          <node concept="3oM_SD" id="6Y0EU3Z5Pho" role="1PaTwD">
+        <node concept="1PaTwC" id="AKP4wC3Q1B" role="1PaQFQ">
+          <node concept="3oM_SD" id="AKP4wC3Q1O" role="1PaTwD">
             <property role="3oM_SC" value="" />
           </node>
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Php" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5PhV" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: attribute-section" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKc" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKd" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKe" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKf" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjKg" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="AKP4wC3Q2q" role="1PaTwD">
+            <property role="3oM_SC" value="attribute" />
           </node>
         </node>
       </node>
+    </node>
+    <node concept="PrWs8" id="60ZH30$MSip" role="PzmwI">
+      <ref role="PrY4T" to="tpck:3fifI_xCcJN" resolve="ScopeProvider" />
     </node>
   </node>
   <node concept="1TIwiD" id="6hv6i2_Azc7">
@@ -3613,12 +3832,6 @@
     <property role="34LRSv" value="enum" />
     <property role="R4oN_" value="Enum type" />
     <ref role="1TJDcQ" node="6hv6i2_Azc2" resolve="TypeDeclaration" />
-    <node concept="1TJgyj" id="6$wrg4A_PeP" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424947020725" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="6$wrg4A_UK$" role="1TKVEi">
       <property role="IQ2ns" value="7575174424947043364" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -3661,7 +3874,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pdx" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pdw" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: enum-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3hy" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3hz" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3h$" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3h_" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3hA" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z3hB" role="1PaTwD">
+            <property role="3oM_SC" value="enum-declaration" />
           </node>
         </node>
       </node>
@@ -3677,12 +3908,6 @@
     <property role="34LRSv" value="interface" />
     <property role="R4oN_" value="Interface type" />
     <ref role="1TJDcQ" node="6hv6i2_Azc2" resolve="TypeDeclaration" />
-    <node concept="1TJgyj" id="6$wrg4AA2AM" role="1TKVEi">
-      <property role="IQ2ns" value="7575174424947075506" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="6$wrg4AA8US" role="1TKVEi">
       <property role="IQ2ns" value="7575174424947101368" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -3716,7 +3941,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5Pe0" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5Pe1" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: interface-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k2" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k3" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k4" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k5" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k6" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z5k7" role="1PaTwD">
+            <property role="3oM_SC" value="interface-declaration" />
           </node>
         </node>
       </node>
@@ -3735,12 +3978,6 @@
     <property role="3GE5qa" value="Class / Struct" />
     <property role="R4oN_" value="Class type" />
     <ref role="1TJDcQ" node="6hv6i2_Azc2" resolve="TypeDeclaration" />
-    <node concept="1TJgyj" id="6hv6i2_ABc5" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588316421" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="6hv6i2_AZEU" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588416698" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -3774,7 +4011,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5P3j" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5P3i" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: class-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRl" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRm" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRn" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRo" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRp" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="7Jk5HDWZjRq" role="1PaTwD">
+            <property role="3oM_SC" value="class-declaration" />
           </node>
         </node>
       </node>
@@ -3832,7 +4087,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5P2_" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5P2$" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: type-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wl" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wm" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wn" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wo" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wp" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7z2wq" role="1PaTwD">
+            <property role="3oM_SC" value="type-declaration" />
           </node>
         </node>
       </node>
@@ -3871,10 +4144,31 @@
         </node>
         <node concept="1PaTwC" id="3rKHSnCrkQq" role="1PaQFQ">
           <node concept="3oM_SD" id="3rKHSnCrkQp" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: get-accessor-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1x" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1y" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1z" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1$" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1_" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="60ZH30$IG1A" role="1PaTwD">
+            <property role="3oM_SC" value="get-accessor-declaration" />
           </node>
         </node>
       </node>
+    </node>
+    <node concept="PrWs8" id="60ZH30$IH9N" role="PzmwI">
+      <ref role="PrY4T" node="60ZH30$IG25" resolve="IGetAccessor" />
     </node>
   </node>
   <node concept="PlHQZ" id="6vAOG1ABnFn">
@@ -3932,13 +4226,7 @@
     <property role="3GE5qa" value="Class / Struct.Methods" />
     <property role="R4oN_" value="Class method declaration" />
     <property role="34LRSv" value="method" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="6hv6i2_B6cq" role="1TKVEi">
-      <property role="IQ2ns" value="7232527154588443418" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
+    <ref role="1TJDcQ" node="60ZH30zYY06" resolve="Method" />
     <node concept="1TJgyj" id="6hv6i2_B6cE" role="1TKVEi">
       <property role="IQ2ns" value="7232527154588443434" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -4026,6 +4314,9 @@
     </node>
     <node concept="PrWs8" id="1HkqSaCLgB0" role="PrDN$">
       <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYWOR" role="PrDN$">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
     </node>
   </node>
   <node concept="1TIwiD" id="6hv6i2_Axqh">
@@ -4171,13 +4462,7 @@
     <property role="3GE5qa" value="Class / Struct.Constructors" />
     <property role="R4oN_" value="Static constructor definition" />
     <property role="34LRSv" value="static-ctor" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="6vAOG1ABnF9" role="1TKVEi">
-      <property role="IQ2ns" value="7486903154347178697" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
+    <ref role="1TJDcQ" node="2KItQQV8wB2" resolve="Constructor" />
     <node concept="1TJgyj" id="6vAOG1ABnF6" role="1TKVEi">
       <property role="IQ2ns" value="7486903154347178694" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -4190,9 +4475,6 @@
       <property role="20kJfa" value="body" />
       <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="1FYNzU$qtcf" resolve="MaybeEmptyBlock" />
-    </node>
-    <node concept="PrWs8" id="6vAOG1ABnG9" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
     <node concept="PrWs8" id="6vAOG1ABnFJ" role="PzmwI">
       <ref role="PrY4T" node="6hv6i2_B0DQ" resolve="IClassMemberDeclaration" />
@@ -4229,7 +4511,25 @@
         </node>
         <node concept="1PaTwC" id="6Y0EU3Z5TGJ" role="1PaQFQ">
           <node concept="3oM_SD" id="6Y0EU3Z5TGI" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: static-constructor-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDO" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDP" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDQ" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDR" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDS" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AMDT" role="1PaTwD">
+            <property role="3oM_SC" value="static-constructor-declaration" />
           </node>
         </node>
       </node>
@@ -6728,7 +7028,7 @@
     <property role="EcuMT" value="3766354144459905662" />
     <property role="TrG5h" value="FixedSizeBufferDeclaration" />
     <property role="3GE5qa" value="Class / Struct.not_implemented" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="60ZH30zYZTk" resolve="Field" />
     <node concept="PrWs8" id="3h4LMeIQ_DZ" role="PzmwI">
       <ref role="PrY4T" node="3h4LMeIQ_DR" resolve="IStructMemberDeclaration" />
     </node>
@@ -6769,13 +7069,34 @@
         </node>
         <node concept="1PaTwC" id="7TfmMh1pDIM" role="1PaQFQ">
           <node concept="3oM_SD" id="7TfmMh1pDIN" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: struct-member-declaration" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9z" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9$" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9_" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9A" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9B" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L7AJ9C" role="1PaTwD">
+            <property role="3oM_SC" value="struct-member-declaration" />
           </node>
         </node>
       </node>
     </node>
     <node concept="PrWs8" id="1HkqSaCLgAY" role="PrDN$">
       <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
+    </node>
+    <node concept="PrWs8" id="6y6b8L7AJbx" role="PrDN$">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
     </node>
   </node>
   <node concept="1TIwiD" id="3h4LMeIRHqY">
@@ -13539,18 +13860,9 @@
     <property role="3GE5qa" value="Interface.Properties" />
     <property role="R4oN_" value="Interface property declaration" />
     <property role="34LRSv" value="property" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <ref role="1TJDcQ" node="60ZH30zYXEq" resolve="Property" />
     <node concept="PrWs8" id="7IPlf6q1V78" role="PzmwI">
       <ref role="PrY4T" node="6$wrg4AA8Vb" resolve="IInterfaceMemberDeclaration" />
-    </node>
-    <node concept="PrWs8" id="2e5scIOzC1r" role="PzmwI">
-      <ref role="PrY4T" node="5oHFRyIxp1s" resolve="IHaveType" />
-    </node>
-    <node concept="PrWs8" id="2e5scIOzC1z" role="PzmwI">
-      <ref role="PrY4T" node="5oHFRyIxp1o" resolve="IHaveModifiers" />
-    </node>
-    <node concept="PrWs8" id="2e5scIOzC1H" role="PzmwI">
-      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
     </node>
     <node concept="3H0Qfr" id="2pqoNIAe7yX" role="lGtFl">
       <node concept="1Pa9Pv" id="2pqoNIAe7zw" role="3H0Qfi">
@@ -14728,12 +15040,6 @@
     <property role="TrG5h" value="AccessorDeclaration" />
     <property role="R5$K7" value="true" />
     <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="3zXINoFWW$1" role="1TKVEi">
-      <property role="IQ2ns" value="4106644276571785473" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="attributeList" />
-      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeList" />
-    </node>
     <node concept="1TJgyj" id="3zXINoFWW$3" role="1TKVEi">
       <property role="IQ2ns" value="4106644276571785475" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -15966,7 +16272,25 @@
         </node>
         <node concept="1PaTwC" id="1HkqSaCLqCj" role="1PaQFQ">
           <node concept="3oM_SD" id="1HkqSaCLqCk" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: none" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIkv" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIkw" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIkx" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIky" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIkz" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6oIHlJhpIk$" role="1PaTwD">
+            <property role="3oM_SC" value="none" />
           </node>
           <node concept="3oM_SD" id="1HkqSaCLqCl" role="1PaTwD">
             <property role="3oM_SC" value="corresponding" />
@@ -16257,21 +16581,22 @@
   <node concept="1TIwiD" id="fEeb94672n">
     <property role="EcuMT" value="282100264961863831" />
     <property role="3GE5qa" value="Attributes" />
-    <property role="TrG5h" value="GlobalAttributeList" />
-    <property role="R4oN_" value="Global attribute" />
-    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
-    <node concept="1TJgyj" id="fEeb94672w" role="1TKVEi">
-      <property role="IQ2ns" value="282100264961863840" />
-      <property role="20lmBu" value="fLJjDmT/aggregation" />
-      <property role="20kJfa" value="globalAttribute" />
-      <property role="20lbJX" value="fLJekj6/_1__n" />
-      <ref role="20lvS9" node="6hv6i2_AyhB" resolve="GlobalAttribute" />
-    </node>
+    <property role="TrG5h" value="GlobalAttributeSection" />
+    <property role="R4oN_" value="Global attribute section" />
     <node concept="3H0Qfr" id="fEeb94672o" role="lGtFl">
       <node concept="1Pa9Pv" id="fEeb94672p" role="3H0Qfi">
         <node concept="1PaTwC" id="fEeb94672q" role="1PaQFQ">
           <node concept="3oM_SD" id="fEeb94672r" role="1PaTwD">
-            <property role="3oM_SC" value="A list of global" />
+            <property role="3oM_SC" value="A" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3B" role="1PaTwD">
+            <property role="3oM_SC" value="list" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3C" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3D" role="1PaTwD">
+            <property role="3oM_SC" value="global" />
           </node>
           <node concept="3oM_SD" id="fEeb946LIM" role="1PaTwD">
             <property role="3oM_SC" value="attributes." />
@@ -16284,12 +16609,57 @@
         </node>
         <node concept="1PaTwC" id="fEeb946LIf" role="1PaQFQ">
           <node concept="3oM_SD" id="fEeb946LIe" role="1PaTwD">
-            <property role="3oM_SC" value="This concept serves for encapsulation of the list's Editor, which can then be reused" />
+            <property role="3oM_SC" value="This" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3E" role="1PaTwD">
+            <property role="3oM_SC" value="concept" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3F" role="1PaTwD">
+            <property role="3oM_SC" value="serves" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3G" role="1PaTwD">
+            <property role="3oM_SC" value="for" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3H" role="1PaTwD">
+            <property role="3oM_SC" value="encapsulation" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3I" role="1PaTwD">
+            <property role="3oM_SC" value="of" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3J" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3K" role="1PaTwD">
+            <property role="3oM_SC" value="list's" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3L" role="1PaTwD">
+            <property role="3oM_SC" value="Editor," />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3M" role="1PaTwD">
+            <property role="3oM_SC" value="which" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3N" role="1PaTwD">
+            <property role="3oM_SC" value="can" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3O" role="1PaTwD">
+            <property role="3oM_SC" value="then" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3P" role="1PaTwD">
+            <property role="3oM_SC" value="be" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3Q" role="1PaTwD">
+            <property role="3oM_SC" value="reused" />
           </node>
         </node>
         <node concept="1PaTwC" id="fEeb946LIp" role="1PaQFQ">
           <node concept="3oM_SD" id="fEeb946LIo" role="1PaTwD">
-            <property role="3oM_SC" value="at different locations." />
+            <property role="3oM_SC" value="at" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3R" role="1PaTwD">
+            <property role="3oM_SC" value="different" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3S" role="1PaTwD">
+            <property role="3oM_SC" value="locations." />
           </node>
         </node>
         <node concept="1PaTwC" id="fEeb946LI_" role="1PaQFQ">
@@ -16299,10 +16669,40 @@
         </node>
         <node concept="1PaTwC" id="fEeb94672u" role="1PaQFQ">
           <node concept="3oM_SD" id="fEeb94672v" role="1PaTwD">
-            <property role="3oM_SC" value="Original name in the C# grammar: global-attribute-sections" />
+            <property role="3oM_SC" value="Original" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3T" role="1PaTwD">
+            <property role="3oM_SC" value="name" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3U" role="1PaTwD">
+            <property role="3oM_SC" value="in" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3V" role="1PaTwD">
+            <property role="3oM_SC" value="the" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3W" role="1PaTwD">
+            <property role="3oM_SC" value="C#" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3X" role="1PaTwD">
+            <property role="3oM_SC" value="grammar:" />
+          </node>
+          <node concept="3oM_SD" id="6y6b8L82H3Y" role="1PaTwD">
+            <property role="3oM_SC" value="global-attribute-section" />
           </node>
         </node>
       </node>
+    </node>
+    <node concept="1TJgyi" id="6y6b8L82HkV" role="1TKVEl">
+      <property role="IQ2nx" value="7531756407839446331" />
+      <property role="TrG5h" value="target" />
+      <ref role="AX2Wp" node="7Jk5HDXYHQA" resolve="GlobalAttributeTarget" />
+    </node>
+    <node concept="1TJgyj" id="5n2LpYihou7" role="1TKVEi">
+      <property role="IQ2ns" value="6179718927850243975" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="attributeList" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5n2LpYie8KZ" resolve="AttributeList" />
     </node>
   </node>
   <node concept="1TIwiD" id="7g7u0mJfucB">
@@ -17024,6 +17424,9 @@
     <property role="TrG5h" value="InterfacePropertyGetAccessorDeclaration" />
     <property role="34LRSv" value="get" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
+    <node concept="PrWs8" id="60ZH30$IH6v" role="PzmwI">
+      <ref role="PrY4T" node="60ZH30$IG25" resolve="IGetAccessor" />
+    </node>
   </node>
   <node concept="1TIwiD" id="gdBerkKl9x">
     <property role="EcuMT" value="292062066074800737" />
@@ -17031,6 +17434,9 @@
     <property role="TrG5h" value="InterfacePropertySetAccessorDeclaration" />
     <property role="34LRSv" value="set" />
     <ref role="1TJDcQ" node="gdBerkKl2E" resolve="InterfacePropertyAccessorDeclaration" />
+    <node concept="PrWs8" id="60ZH30$IH7U" role="PzmwI">
+      <ref role="PrY4T" node="60ZH30$IGz$" resolve="ISetAccessor" />
+    </node>
   </node>
   <node concept="1TIwiD" id="2H$QQEVkVn6">
     <property role="EcuMT" value="3126865292757808582" />
@@ -18120,6 +18526,217 @@
           </node>
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="PlHQZ" id="7Jk5HDWZnHp">
+    <property role="EcuMT" value="8922781889383463769" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="IHasAttributes" />
+    <node concept="1TJgyj" id="7Jk5HDWZnIO" role="1TKVEi">
+      <property role="IQ2ns" value="8922781889383463860" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="attributeSections" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="6vAOG1ABcaf" resolve="AttributeSection" />
+    </node>
+  </node>
+  <node concept="25R3W" id="7Jk5HDXal2Y">
+    <property role="3F6X1D" value="8922781889386336446" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AttributeTarget" />
+    <node concept="25R33" id="7Jk5HDXalcT" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337081" />
+      <property role="TrG5h" value="event" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXal2Z" role="25R1y">
+      <property role="3tVfz5" value="8922781889386336447" />
+      <property role="TrG5h" value="field" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXalfh" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337233" />
+      <property role="TrG5h" value="method" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXalfK" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337264" />
+      <property role="TrG5h" value="param" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXalfL" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337265" />
+      <property role="TrG5h" value="property" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXalgJ" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337327" />
+      <property role="TrG5h" value="return" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXalgK" role="25R1y">
+      <property role="3tVfz5" value="8922781889386337328" />
+      <property role="TrG5h" value="type" />
+    </node>
+    <node concept="25R33" id="60ZH30$V4dF" role="25R1y">
+      <property role="3tVfz5" value="6935460070044746603" />
+      <property role="TrG5h" value="typevar" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7Jk5HDXCy9o">
+    <property role="EcuMT" value="8922781889394254424" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="NamedArgument" />
+    <ref role="1TJDcQ" node="7Jk5HDY4K_w" resolve="AttributeArgument" />
+    <node concept="1TJgyj" id="7Jk5HDXCyC8" role="1TKVEi">
+      <property role="IQ2ns" value="8922781889394256392" />
+      <property role="20kJfa" value="property" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6vAOG1ABcaT" resolve="PropertyDeclaration" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7Jk5HDXCyp0">
+    <property role="EcuMT" value="8922781889394255424" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="PositionalArgument" />
+    <ref role="1TJDcQ" node="7Jk5HDY4K_w" resolve="AttributeArgument" />
+  </node>
+  <node concept="25R3W" id="7Jk5HDXYHQA">
+    <property role="3F6X1D" value="8922781889400069542" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="GlobalAttributeTarget" />
+    <ref role="1H5jkz" node="7Jk5HDXYHTy" resolve="assembly" />
+    <node concept="25R33" id="7Jk5HDXYHTy" role="25R1y">
+      <property role="3tVfz5" value="8922781889400069730" />
+      <property role="TrG5h" value="assembly" />
+    </node>
+    <node concept="25R33" id="7Jk5HDXYHVs" role="25R1y">
+      <property role="3tVfz5" value="8922781889400069852" />
+      <property role="TrG5h" value="module" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="7Jk5HDY4K_w">
+    <property role="TrG5h" value="AttributeArgument" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="EcuMT" value="8922781889399201745" />
+    <property role="R5$K7" value="true" />
+    <node concept="1TJgyj" id="7Jk5HDXCyyp" role="1TKVEi">
+      <property role="IQ2ns" value="8922781889394256025" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="5VT83U$LgKs" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="6aIFk8bTdc0">
+    <property role="EcuMT" value="7110811360843584256" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AttributeTargetSpecifier" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyi" id="6aIFk8bTdhb" role="1TKVEl">
+      <property role="IQ2nx" value="7110811360843584587" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" node="7Jk5HDXal2Y" resolve="AttributeTarget" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="60ZH30zYXEq">
+    <property role="TrG5h" value="Property" />
+    <property role="EcuMT" value="6935460070028991130" />
+    <property role="R5$K7" value="true" />
+    <node concept="PrWs8" id="6oIHlJhtTUf" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYXGj" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYXGk" role="PzmwI">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
+    </node>
+    <node concept="PrWs8" id="6oIHlJhujJG" role="PzmwI">
+      <ref role="PrY4T" node="5oHFRyIxp1o" resolve="IHaveModifiers" />
+    </node>
+    <node concept="PrWs8" id="6oIHlJhtTUg" role="PzmwI">
+      <ref role="PrY4T" node="5oHFRyIxp1s" resolve="IHaveType" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="60ZH30zYY06">
+    <property role="EcuMT" value="6935460070028992518" />
+    <property role="TrG5h" value="Method" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="PrWs8" id="6vAOG1ABnEL" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYY3p" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYY3S" role="PzmwI">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="60ZH30zYZTk">
+    <property role="TrG5h" value="Field" />
+    <property role="EcuMT" value="6935460070029000276" />
+    <property role="R5$K7" value="true" />
+    <node concept="PrWs8" id="60ZH30zZ3rK" role="PzmwI">
+      <ref role="PrY4T" node="1HkqSaCLgAV" resolve="IReferencableMemberDeclaration" />
+    </node>
+    <node concept="PrWs8" id="60ZH30zYZUJ" role="PzmwI">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="60ZH30$IG25">
+    <property role="EcuMT" value="6935460070041501829" />
+    <property role="TrG5h" value="IGetAccessor" />
+    <node concept="PrWs8" id="60ZH30$IG4U" role="PrDN$">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="60ZH30$IGz$">
+    <property role="EcuMT" value="6935460070041503972" />
+    <property role="TrG5h" value="ISetAccessor" />
+    <node concept="PrWs8" id="60ZH30$IG_t" role="PrDN$">
+      <ref role="PrY4T" node="7Jk5HDWZnHp" resolve="IHasAttributes" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5n2LpYie8KZ">
+    <property role="EcuMT" value="6179718927849393215" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AttributeList" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="5n2LpYie8LW" role="1TKVEi">
+      <property role="IQ2ns" value="6179718927849393276" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="attributes" />
+      <property role="20lbJX" value="fLJekj6/_1__n" />
+      <ref role="20lvS9" node="6hv6i2_ABc4" resolve="Attribute" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="5n2LpYj7C8D">
+    <property role="EcuMT" value="6179718927864463913" />
+    <property role="TrG5h" value="AttributeClassReference" />
+    <property role="R4oN_" value="Reference to an attribute class" />
+    <property role="3GE5qa" value="References.TypeRelatedReferences" />
+    <ref role="1TJDcQ" node="27q4jmdWW$T" resolve="NotGenericParameterTypeReference" />
+    <node concept="1TJgyj" id="5n2LpYj7C8E" role="1TKVEi">
+      <property role="IQ2ns" value="6179718927864463914" />
+      <property role="20kJfa" value="referencedType" />
+      <property role="20lbJX" value="fLJekj4/_1" />
+      <ref role="20lvS9" node="6hv6i2_Azc3" resolve="ClassDeclaration" />
+      <ref role="20ksaX" node="27q4jmdWXhm" resolve="referencedType" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="2KItQQV8wB2">
+    <property role="EcuMT" value="3183613299772230082" />
+    <property role="TrG5h" value="Constructor" />
+    <property role="R5$K7" value="true" />
+    <ref role="1TJDcQ" node="60ZH30zYY06" resolve="Method" />
+  </node>
+  <node concept="1TIwiD" id="AKP4wC3Wy1">
+    <property role="EcuMT" value="698291348617283713" />
+    <property role="3GE5qa" value="Attributes" />
+    <property role="TrG5h" value="AttributeArgumentList" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" />
+    <node concept="1TJgyj" id="AKP4wC3Wy3" role="1TKVEi">
+      <property role="IQ2ns" value="698291348617283715" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="arguments" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
+      <ref role="20lvS9" node="7Jk5HDY4K_w" resolve="AttributeArgument" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
+++ b/CsBaseLanguage/languages/CsBaseLanguage/models/typesystem.mps
@@ -61,14 +61,14 @@
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
       <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
@@ -89,7 +89,7 @@
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
       <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
-      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ngI" index="2WEnae">
         <reference id="1205756909548" name="member" index="2WH_rO" />
       </concept>
       <concept id="1205769003971" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodDeclaration" flags="ng" index="2XrIbr" />
@@ -139,6 +139,7 @@
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1145572800087" name="jetbrains.mps.lang.smodel.structure.Node_GetPrevSiblingsOperation" flags="nn" index="2Ttrtt" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
       <concept id="1171500988903" name="jetbrains.mps.lang.smodel.structure.Node_GetChildrenOperation" flags="nn" index="32TBzR" />
       <concept id="1154546920561" name="jetbrains.mps.lang.smodel.structure.OperationParm_ConceptList" flags="ng" index="3gmYPX">
@@ -174,7 +175,7 @@
         <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
         <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
       </concept>
-      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
         <property id="1169194664001" name="name" index="TrG5h" />
       </concept>
     </language>
@@ -702,6 +703,63 @@
         </node>
       </node>
       <node concept="3Tm6S6" id="5e5Epz9Ynpa" role="1B3o_S" />
+    </node>
+  </node>
+  <node concept="18kY7G" id="5n2LpYjpmQ$">
+    <property role="TrG5h" value="check_PositionalArgument" />
+    <property role="3GE5qa" value="Attributes" />
+    <node concept="3clFbS" id="5n2LpYjpmQ_" role="18ibNy">
+      <node concept="3clFbJ" id="5n2LpYjpmT1" role="3cqZAp">
+        <node concept="2OqwBi" id="5n2LpYjpp7j" role="3clFbw">
+          <node concept="2OqwBi" id="5n2LpYjpn3c" role="2Oq$k0">
+            <node concept="1YBJjd" id="5n2LpYjpmT4" role="2Oq$k0">
+              <ref role="1YBMHb" node="5n2LpYjpmQB" resolve="arg" />
+            </node>
+            <node concept="2Ttrtt" id="6XvgmLH4j5o" role="2OqNvi" />
+          </node>
+          <node concept="2HwmR7" id="5n2LpYjpsnd" role="2OqNvi">
+            <node concept="1bVj0M" id="5n2LpYjpsnf" role="23t8la">
+              <node concept="3clFbS" id="5n2LpYjpsng" role="1bW5cS">
+                <node concept="3clFbF" id="5n2LpYjpstg" role="3cqZAp">
+                  <node concept="2OqwBi" id="5n2LpYjpsFd" role="3clFbG">
+                    <node concept="37vLTw" id="5n2LpYjpstf" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5n2LpYjpsnh" resolve="it" />
+                    </node>
+                    <node concept="1mIQ4w" id="5n2LpYjpttS" role="2OqNvi">
+                      <node concept="chp4Y" id="5n2LpYjptyg" role="cj9EA">
+                        <ref role="cht4Q" to="80bi:7Jk5HDXCy9o" resolve="NamedArgument" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="gl6BB" id="5n2LpYjpsnh" role="1bW2Oz">
+                <property role="TrG5h" value="it" />
+                <node concept="2jxLKc" id="5n2LpYjpsni" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbS" id="5n2LpYjpmT3" role="3clFbx">
+          <node concept="2MkqsV" id="5n2LpYjptEP" role="3cqZAp">
+            <node concept="Xl_RD" id="5n2LpYjptEY" role="2MkJ7o">
+              <property role="Xl_RC" value="Positional arguments must precede named arguments." />
+            </node>
+            <node concept="2OqwBi" id="2KItQQV7b3Z" role="1urrMF">
+              <node concept="1YBJjd" id="5n2LpYjptIA" role="2Oq$k0">
+                <ref role="1YBMHb" node="5n2LpYjpmQB" resolve="arg" />
+              </node>
+              <node concept="3TrEf2" id="2KItQQV7bhf" role="2OqNvi">
+                <ref role="3Tt5mk" to="80bi:7Jk5HDXCyyp" resolve="expression" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="5n2LpYjpmQB" role="1YuTPh">
+      <property role="TrG5h" value="arg" />
+      <ref role="1YaFvo" to="80bi:7Jk5HDXCyp0" resolve="PositionalArgument" />
     </node>
   </node>
 </model>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/CsBaseLanguage.tests.msd
@@ -13,7 +13,6 @@
   </facets>
   <dependencies>
     <dependency reexport="false">5b1f863d-65a0-41a6-a801-33896be24202(jetbrains.mps.ide.editor)</dependency>
-    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
     <dependency reexport="false">d74e25c9-4d91-43b6-bad7-d18af7bf6674(CsBaseLanguage)</dependency>
     <dependency reexport="false">707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)</dependency>
   </dependencies>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/.model
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/.model
@@ -7,12 +7,16 @@
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage" version="3" />
     <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" />
     <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" />
     <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" />
     <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
   </imports>
 </model>
 

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Attribute_AddArguments.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Attribute_AddArguments.mpsr
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131577" name="CsBaseLanguage.structure.PropertyDeclaration" flags="ng" index="1ux1T">
+        <child id="7486903154347131649" name="accessorDeclaration" index="1ux71" />
+      </concept>
+      <concept id="8922781889399201745" name="CsBaseLanguage.structure.AttributeArgument" flags="ng" index="6eo$b">
+        <child id="8922781889394256025" name="expression" index="6tzT3" />
+      </concept>
+      <concept id="8922781889394255424" name="CsBaseLanguage.structure.PositionalArgument" flags="ng" index="6tz2q" />
+      <concept id="8922781889394254424" name="CsBaseLanguage.structure.NamedArgument" flags="ng" index="6tzi2">
+        <reference id="8922781889394256392" name="property" index="6tzNi" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="3766354144460199614" name="CsBaseLanguage.structure.Public" flags="ng" index="2qAx6t" />
+      <concept id="698291348617283713" name="CsBaseLanguage.structure.AttributeArgumentList" flags="ng" index="xJLN9">
+        <child id="698291348617283715" name="arguments" index="xJLNb" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc">
+        <reference id="2439281069887050838" name="referencedType" index="2Gaslz" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz">
+        <child id="7232527154588416698" name="classMemberDeclaration" index="31Leeq" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="8922781889388701021" name="argumentList" index="6Ane7" />
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
+        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="6209812394072707160" name="CsBaseLanguage.structure.IHaveModifiers" flags="ngI" index="3SE3Ww">
+        <child id="6209812394072707161" name="iModifier" index="3SE3Wx" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="AKP4wC3Q7a">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="Attribute_AddArguments" />
+    <node concept="1qefOq" id="AKP4wC3Q7g" role="25YQCW">
+      <node concept="31LFg6" id="AKP4wC3Q7e" role="1qenE9">
+        <property role="TrG5h" value="file" />
+        <node concept="31LiCz" id="AKP4wC3Q7h" role="31LlDr">
+          <property role="TrG5h" value="FooAttribute" />
+          <node concept="1ux1T" id="6oIHlJhdnSL" role="31Leeq">
+            <property role="TrG5h" value="Property" />
+            <node concept="1ux0t" id="6oIHlJhdnSM" role="1ux71">
+              <node concept="2Y_LOE" id="6oIHlJhdnSN" role="j3B8P" />
+            </node>
+            <node concept="1ux0x" id="6oIHlJhdnSO" role="1ux71">
+              <node concept="2Y_LOE" id="6oIHlJhdnSP" role="j3B8P" />
+            </node>
+            <node concept="3UfwP1" id="6oIHlJhdnSQ" role="3SE38M">
+              <node concept="3UfM66" id="6oIHlJhdnTO" role="3UfBpY" />
+            </node>
+            <node concept="2qAx6t" id="6oIHlJhdnUl" role="3SE3Wx" />
+          </node>
+        </node>
+        <node concept="31LiCz" id="AKP4wC3Q7r" role="31LlDr">
+          <property role="TrG5h" value="Bar" />
+          <node concept="1ux1f" id="AKP4wC3Q7t" role="7amPI">
+            <node concept="37Y$Aw" id="AKP4wC3Q7u" role="1ux1g">
+              <node concept="31LmC$" id="AKP4wC3Q7v" role="37Y$Bz">
+                <node concept="36R4uQ" id="AKP4wC3Q7w" role="1DcEYZ">
+                  <ref role="2Gaslz" node="AKP4wC3Q7h" resolve="FooAttribute" />
+                  <node concept="LIFWc" id="AKP4wC3Q7x" role="lGtFl">
+                    <property role="ZRATv" value="true" />
+                    <property role="OXtK3" value="true" />
+                    <property role="p6zMq" value="12" />
+                    <property role="p6zMs" value="12" />
+                    <property role="LIFWd" value="property_name" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="AKP4wC3Q7y" role="25YQFr">
+      <node concept="31LFg6" id="AKP4wC3Q7z" role="1qenE9">
+        <property role="TrG5h" value="file" />
+        <node concept="31LiCz" id="AKP4wC3Q7$" role="31LlDr">
+          <property role="TrG5h" value="FooAttribute" />
+          <node concept="1ux1T" id="6oIHlJhdnZ5" role="31Leeq">
+            <property role="TrG5h" value="Property" />
+            <node concept="1ux0t" id="6oIHlJhdnZ6" role="1ux71">
+              <node concept="2Y_LOE" id="6oIHlJhdnZ7" role="j3B8P" />
+            </node>
+            <node concept="1ux0x" id="6oIHlJhdnZ8" role="1ux71">
+              <node concept="2Y_LOE" id="6oIHlJhdnZ9" role="j3B8P" />
+            </node>
+            <node concept="3UfwP1" id="6oIHlJhdnZa" role="3SE38M">
+              <node concept="3UfM66" id="6oIHlJhdnZb" role="3UfBpY" />
+            </node>
+            <node concept="2qAx6t" id="6oIHlJhdnZc" role="3SE3Wx" />
+          </node>
+        </node>
+        <node concept="31LiCz" id="AKP4wC3Q7H" role="31LlDr">
+          <property role="TrG5h" value="Bar" />
+          <node concept="1ux1f" id="AKP4wC3Q7I" role="7amPI">
+            <node concept="37Y$Aw" id="AKP4wC3Q7J" role="1ux1g">
+              <node concept="31LmC$" id="AKP4wC3Q7K" role="37Y$Bz">
+                <node concept="36R4uQ" id="AKP4wC3Q7L" role="1DcEYZ">
+                  <ref role="2Gaslz" node="AKP4wC3Q7$" resolve="FooAttribute" />
+                </node>
+                <node concept="xJLN9" id="AKP4wCe5tq" role="6Ane7">
+                  <node concept="6tz2q" id="6oIHlJhdnZH" role="xJLNb">
+                    <node concept="3UcVBg" id="6oIHlJhdnZG" role="6tzT3">
+                      <property role="1pzoAX" value="1" />
+                    </node>
+                  </node>
+                  <node concept="6tzi2" id="6oIHlJhpyBF" role="xJLNb">
+                    <ref role="6tzNi" node="6oIHlJhdnZ5" resolve="Property" />
+                    <node concept="3UcVBg" id="6oIHlJhpyBL" role="6tzT3">
+                      <property role="1pzoAX" value="2" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="AKP4wC3Qee" role="LjaKd">
+      <node concept="2TK7Tu" id="AKP4wC3Qed" role="3cqZAp">
+        <property role="2TTd_B" value="(" />
+      </node>
+      <node concept="2HxZob" id="6oIHlJhdnCq" role="3cqZAp">
+        <node concept="1iFQzN" id="6oIHlJhdnCW" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="6oIHlJhdnKj" role="3cqZAp">
+        <property role="2TTd_B" value="1" />
+      </node>
+      <node concept="2HxZob" id="6oIHlJhdnMe" role="3cqZAp">
+        <node concept="1iFQzN" id="6oIHlJhdnMf" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:6KwcZ1G3Pjm" resolve="Insert" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="6oIHlJhdnQp" role="3cqZAp">
+        <property role="2TTd_B" value="Property" />
+      </node>
+      <node concept="2HxZob" id="6oIHlJheBul" role="3cqZAp">
+        <node concept="1iFQzN" id="6oIHlJheBup" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="yd1bK" id="6oIHlJhdEGt" role="3cqZAp">
+        <node concept="pLAjd" id="6oIHlJhdEGv" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="6oIHlJhdoqR" role="3cqZAp">
+        <property role="2TTd_B" value="2" />
+      </node>
+      <node concept="3clFbH" id="6oIHlJhdnMd" role="3cqZAp" />
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Attributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/Attributes.mpsr
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="avov" ref="r:284f1d8b-134d-4155-890e-620a45e7f33b(CsBaseLanguage.typesystem)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1215507671101" name="jetbrains.mps.lang.test.structure.NodeErrorCheckOperation" flags="ng" index="1TM$A">
+        <child id="8489045168660938517" name="errorRef" index="3lydEf" />
+      </concept>
+      <concept id="1215603922101" name="jetbrains.mps.lang.test.structure.NodeOperationsContainer" flags="ng" index="7CXmI">
+        <child id="1215604436604" name="nodeOperations" index="7EUXB" />
+      </concept>
+      <concept id="7691029917083872157" name="jetbrains.mps.lang.test.structure.IRuleReference" flags="ngI" index="2u4UPC">
+        <reference id="8333855927540250453" name="declaration" index="39XzEq" />
+      </concept>
+      <concept id="4531408400484511853" name="jetbrains.mps.lang.test.structure.ReportErrorStatementReference" flags="ng" index="2PYRI3" />
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131577" name="CsBaseLanguage.structure.PropertyDeclaration" flags="ng" index="1ux1T">
+        <child id="7486903154347131649" name="accessorDeclaration" index="1ux71" />
+      </concept>
+      <concept id="8922781889399201745" name="CsBaseLanguage.structure.AttributeArgument" flags="ng" index="6eo$b">
+        <child id="8922781889394256025" name="expression" index="6tzT3" />
+      </concept>
+      <concept id="8922781889394255424" name="CsBaseLanguage.structure.PositionalArgument" flags="ng" index="6tz2q" />
+      <concept id="8922781889394254424" name="CsBaseLanguage.structure.NamedArgument" flags="ng" index="6tzi2">
+        <reference id="8922781889394256392" name="property" index="6tzNi" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="3766354144460199614" name="CsBaseLanguage.structure.Public" flags="ng" index="2qAx6t" />
+      <concept id="698291348617283713" name="CsBaseLanguage.structure.AttributeArgumentList" flags="ng" index="xJLN9">
+        <child id="698291348617283715" name="arguments" index="xJLNb" />
+      </concept>
+      <concept id="2439281069887047993" name="CsBaseLanguage.structure.NotGenericParameterTypeReference" flags="ng" index="2Gatwc">
+        <reference id="2439281069887050838" name="referencedType" index="2Gaslz" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz">
+        <child id="7232527154588416698" name="classMemberDeclaration" index="31Leeq" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="8922781889388701021" name="argumentList" index="6Ane7" />
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6209812394072707160" name="CsBaseLanguage.structure.IHaveModifiers" flags="ngI" index="3SE3Ww">
+        <child id="6209812394072707161" name="iModifier" index="3SE3Wx" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190981614" name="CsBaseLanguage.structure.IntLiteral" flags="ng" index="3UcVBg">
+        <property id="3129541975290926181" name="value" index="1pzoAX" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="2KItQQV7acs">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="3GE5qa" value="structure" />
+    <property role="TrG5h" value="Attributes" />
+    <node concept="1qefOq" id="2KItQQV7acx" role="1SKRRt">
+      <node concept="31LiCz" id="2KItQQV7acz" role="1qenE9">
+        <property role="TrG5h" value="FooAttribute" />
+        <node concept="1ux1T" id="2KItQQV7acC" role="31Leeq">
+          <property role="TrG5h" value="Property" />
+          <node concept="1ux0t" id="2KItQQV7acD" role="1ux71">
+            <node concept="2Y_LOE" id="2KItQQV7acE" role="j3B8P" />
+          </node>
+          <node concept="1ux0x" id="2KItQQV7acF" role="1ux71">
+            <node concept="2Y_LOE" id="2KItQQV7acG" role="j3B8P" />
+          </node>
+          <node concept="3UfwP1" id="2KItQQV7acH" role="3SE38M">
+            <node concept="3UfM66" id="2KItQQV7acJ" role="3UfBpY" />
+          </node>
+          <node concept="2qAx6t" id="2KItQQV7aME" role="3SE3Wx" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV7act" role="1SKRRt">
+      <node concept="31LmC$" id="2KItQQV7acv" role="1qenE9">
+        <node concept="36R4uQ" id="2KItQQV7acw" role="1DcEYZ">
+          <ref role="2Gaslz" node="2KItQQV7acz" resolve="FooAttribute" />
+        </node>
+        <node concept="xJLN9" id="AKP4wCe5tx" role="6Ane7">
+          <node concept="6tz2q" id="AKP4wCyeBT" role="xJLNb">
+            <node concept="3UcVBg" id="AKP4wCyeBS" role="6tzT3">
+              <property role="1pzoAX" value="1" />
+            </node>
+          </node>
+          <node concept="6tzi2" id="AKP4wCyeBV" role="xJLNb">
+            <ref role="6tzNi" node="2KItQQV7acC" resolve="Property" />
+            <node concept="3UcVBg" id="6oIHlJhpyGn" role="6tzT3">
+              <property role="1pzoAX" value="2" />
+            </node>
+          </node>
+          <node concept="6tz2q" id="6oIHlJhuwOJ" role="xJLNb">
+            <node concept="3UcVBg" id="6oIHlJhuwQn" role="6tzT3">
+              <property role="1pzoAX" value="3" />
+              <node concept="7CXmI" id="6XvgmLH4qE6" role="lGtFl">
+                <node concept="1TM$A" id="6XvgmLH4qE7" role="7EUXB">
+                  <node concept="2PYRI3" id="6XvgmLH4qE8" role="3lydEf">
+                    <ref role="39XzEq" to="avov:5n2LpYjptEP" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_AddAttributes.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWi7HT">
+    <property role="TrG5h" value="ClassDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="6TvF8nWi7HU" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWi7U4" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWi7HX" role="25YQFr">
+      <node concept="31LiCz" id="6TvF8nWi7HY" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="6TvF8nWi7OF" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWi7OG" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWi7OH" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWi7OI" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWi7I4" role="25YQCW">
+      <node concept="31LiCz" id="6TvF8nWi7I5" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="6TvF8nWi7I6" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="empty_classMemberDeclaration" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_CtorStatic.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_CtorStatic.mpsr
@@ -81,12 +81,12 @@
           <node concept="1ux1M" id="3tcg5UgnyOf" role="1uUBl">
             <node concept="31KRCQ" id="3tcg5UgnyOg" role="1ux1N" />
           </node>
-          <node concept="LIFWc" id="3tcg5UgnyOk" role="lGtFl">
+          <node concept="LIFWc" id="AKP4wC2vJL" role="lGtFl">
             <property role="ZRATv" value="true" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_bk8szz_a0a" />
+            <property role="LIFWd" value="Constant_bk8szz_a1a" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_InternalModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_InternalModifier.mpsr
@@ -93,12 +93,12 @@
     <node concept="1qefOq" id="3tcg5UgnYm5" role="25YQCW">
       <node concept="31LiCz" id="3tcg5UgnYm4" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="3tcg5UgnYme" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC2Rbx" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
@@ -106,7 +106,7 @@
       <node concept="31LiCz" id="3tcg5UgnYmg" role="1qenE9">
         <property role="TrG5h" value="Foo" />
         <node concept="2qAx7z" id="3tcg5UgnYmm" role="3SE3Wx" />
-        <node concept="LIFWc" id="3tcg5UgnYmv" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC2GrZ" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersAbstract.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersAbstract.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -70,27 +69,19 @@
     <node concept="1qefOq" id="CnxWk9j9Ua" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9j9Ub" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9j9Uc" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC33UN" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="CnxWk9j9Ud" role="25YQFr">
       <node concept="31LiCz" id="CnxWk9j9Ue" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAKWw" id="CnxWk9j9Uq" role="3SE3Wx">
-          <node concept="LIFWc" id="CnxWk9jf4L" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="8" />
-            <property role="p6zMs" value="8" />
-            <property role="LIFWd" value="Constant_ajn85x_a" />
-          </node>
-        </node>
+        <node concept="2qAKWw" id="CnxWk9j9Uq" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersInternal.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersInternal.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -70,27 +69,19 @@
     <node concept="1qefOq" id="CnxWk9j4JD" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9j4JE" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9j4JF" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC33Z7" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="CnxWk9j4JG" role="25YQFr">
       <node concept="31LiCz" id="CnxWk9j4JH" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx7z" id="CnxWk9j4JO" role="3SE3Wx">
-          <node concept="LIFWc" id="CnxWk9j4Kw" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="8" />
-            <property role="p6zMs" value="8" />
-            <property role="LIFWd" value="Constant_66e4yf_a" />
-          </node>
-        </node>
+        <node concept="2qAx7z" id="CnxWk9j4JO" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersNew.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersNew.mpsr
@@ -82,12 +82,12 @@
         <property role="TrG5h" value="Foo" />
         <node concept="31LiCz" id="CnxWk9jn5p" role="31Leeq">
           <property role="TrG5h" value="Bar" />
-          <node concept="LIFWc" id="CnxWk9jn5q" role="lGtFl">
+          <node concept="LIFWc" id="AKP4wC342t" role="lGtFl">
             <property role="LIFWa" value="0" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_yk1pkl_b0" />
+            <property role="LIFWd" value="Constant_yk1pkl_c0" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPartial.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPartial.mpsr
@@ -69,12 +69,12 @@
     <node concept="1qefOq" id="CnxWk9jpE7" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9jpE8" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9jpE9" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC345l" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPrivate.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPrivate.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -74,15 +73,7 @@
         <property role="TrG5h" value="Foo" />
         <node concept="31LiCz" id="CnxWk9j4JV" role="31Leeq">
           <property role="TrG5h" value="Bar" />
-          <node concept="2qAx6s" id="CnxWk9j4KE" role="3SE3Wx">
-            <node concept="LIFWc" id="CnxWk9j4KN" role="lGtFl">
-              <property role="ZRATv" value="true" />
-              <property role="OXtK3" value="true" />
-              <property role="p6zMq" value="7" />
-              <property role="p6zMs" value="7" />
-              <property role="LIFWd" value="Constant_f1tvxw_a" />
-            </node>
-          </node>
+          <node concept="2qAx6s" id="CnxWk9j4KE" role="3SE3Wx" />
         </node>
       </node>
     </node>
@@ -91,12 +82,12 @@
         <property role="TrG5h" value="Foo" />
         <node concept="31LiCz" id="CnxWk9j4KV" role="31Leeq">
           <property role="TrG5h" value="Bar" />
-          <node concept="LIFWc" id="CnxWk9j4L4" role="lGtFl">
+          <node concept="LIFWc" id="AKP4wC3499" role="lGtFl">
             <property role="LIFWa" value="0" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_yk1pkl_b0" />
+            <property role="LIFWd" value="Constant_yk1pkl_c0" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersProtected.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersProtected.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -74,15 +73,7 @@
         <property role="TrG5h" value="Foo" />
         <node concept="31LiCz" id="CnxWk9jcuM" role="31Leeq">
           <property role="TrG5h" value="Bar" />
-          <node concept="2qAx7y" id="CnxWk9jcuY" role="3SE3Wx">
-            <node concept="LIFWc" id="CnxWk9jcv7" role="lGtFl">
-              <property role="ZRATv" value="true" />
-              <property role="OXtK3" value="true" />
-              <property role="p6zMq" value="9" />
-              <property role="p6zMs" value="9" />
-              <property role="LIFWd" value="Constant_ccl2n_a" />
-            </node>
-          </node>
+          <node concept="2qAx7y" id="CnxWk9jcuY" role="3SE3Wx" />
         </node>
       </node>
     </node>
@@ -91,12 +82,12 @@
         <property role="TrG5h" value="Foo" />
         <node concept="31LiCz" id="CnxWk9jcuR" role="31Leeq">
           <property role="TrG5h" value="Bar" />
-          <node concept="LIFWc" id="CnxWk9jcuS" role="lGtFl">
+          <node concept="LIFWc" id="AKP4wC34eo" role="lGtFl">
             <property role="LIFWa" value="0" />
             <property role="OXtK3" value="true" />
             <property role="p6zMq" value="0" />
             <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_yk1pkl_b0" />
+            <property role="LIFWd" value="Constant_yk1pkl_c0" />
           </node>
         </node>
       </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPublic.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersPublic.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -70,27 +69,19 @@
     <node concept="1qefOq" id="CnxWk9j1XS" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9j1XR" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9j1XV" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC34id" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="CnxWk9j1XY" role="25YQFr">
       <node concept="31LiCz" id="CnxWk9j1XX" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="CnxWk9j9TZ" role="3SE3Wx">
-          <node concept="LIFWc" id="CnxWk9j9U0" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="CnxWk9j9TZ" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersSealed.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersSealed.mpsr
@@ -69,12 +69,12 @@
     <node concept="1qefOq" id="CnxWk9jkts" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9jktt" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9jktu" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC34kC" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersStatic.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ClassDeclaration_ModifiersStatic.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -70,27 +69,19 @@
     <node concept="1qefOq" id="CnxWk9jf4S" role="25YQCW">
       <node concept="31LiCz" id="CnxWk9jf4T" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="CnxWk9jf4U" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC34m6" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="CnxWk9jf4V" role="25YQFr">
       <node concept="31LiCz" id="CnxWk9jf4W" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAK3s" id="CnxWk9jf54" role="3SE3Wx">
-          <node concept="LIFWc" id="CnxWk9jf5d" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_tnigf_a" />
-          </node>
-        </node>
+        <node concept="2qAK3s" id="CnxWk9jf54" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstDeclaration_AddAttributes.mpsr
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131550" name="CsBaseLanguage.structure.ConstantDeclaratorList" flags="ng" index="1ux1u">
+        <child id="7486903154347131551" name="constantDeclarator" index="1ux1v" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM" />
+      <concept id="7232527154588434899" name="CsBaseLanguage.structure.ConstantDeclaration" flags="ng" index="31KPzN">
+        <child id="7232527154588434987" name="constantDeclaratorList" index="31KPGb" />
+      </concept>
+      <concept id="7232527154588434986" name="CsBaseLanguage.structure.ConstantDeclarator" flags="ng" index="31KPGa">
+        <child id="1945218857512106799" name="constant" index="2YAbkh" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWjoLy">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="ConstDeclaration_AddAttributes" />
+    <node concept="1qefOq" id="6TvF8nWjoLz" role="25YQCW">
+      <node concept="31KPzN" id="6TvF8nWjoLR" role="1qenE9">
+        <node concept="1ux1u" id="6TvF8nWjoLS" role="31KPGb">
+          <node concept="31KPGa" id="6TvF8nWjoLT" role="1ux1v">
+            <node concept="zF7EM" id="6TvF8nWjoLU" role="2YAbkh">
+              <property role="TrG5h" value="field" />
+              <node concept="LIFWc" id="6TvF8nWjoLZ" role="lGtFl">
+                <property role="ZRATv" value="true" />
+                <property role="OXtK3" value="true" />
+                <property role="p6zMq" value="5" />
+                <property role="p6zMs" value="5" />
+                <property role="LIFWd" value="VNC_property_name" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjoLV" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjoLX" role="3UfBpY" />
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6TvF8nWjoLO" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWjoLP" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjoM0" role="25YQFr">
+      <node concept="31KPzN" id="6TvF8nWjoM1" role="1qenE9">
+        <node concept="1ux1u" id="6TvF8nWjoM2" role="31KPGb">
+          <node concept="31KPGa" id="6TvF8nWjoM3" role="1ux1v">
+            <node concept="zF7EM" id="6TvF8nWjoM4" role="2YAbkh">
+              <property role="TrG5h" value="field" />
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjoM6" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjoM7" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="6TvF8nWjoM8" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWjoM9" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWjoMa" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWjoMb" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstructorDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstructorDeclaration_AddAttributes.mpsr
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="7486903154347178672" name="CsBaseLanguage.structure.ConstructorDeclaration" flags="ng" index="1uUxK">
+        <child id="7486903154347178702" name="formalParameterList" index="1uUwe" />
+        <child id="7486903154347178686" name="body" index="1uUxY" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz">
+        <child id="7232527154588416698" name="classMemberDeclaration" index="31Leeq" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvG8Q">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="ConstructorDeclaration_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUvGh3" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUvGh2" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvG8V" role="25YQCW">
+      <node concept="31LiCz" id="2KItQQUvPvF" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUxK" id="2KItQQUvPvK" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="2KItQQUvPvL" role="1uUxY">
+            <node concept="31KRCQ" id="2KItQQUvPvM" role="1ux1N" />
+          </node>
+          <node concept="1ux1I" id="2KItQQUvPvN" role="1uUwe" />
+          <node concept="LIFWc" id="2KItQQUvPvO" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="3" />
+            <property role="p6zMs" value="3" />
+            <property role="LIFWd" value="property_name" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="AKP4wC3lbX" role="25YQFr">
+      <node concept="31LiCz" id="AKP4wC3lbY" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUxK" id="AKP4wC3lbZ" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="AKP4wC3lc0" role="1uUxY">
+            <node concept="31KRCQ" id="AKP4wC3lc1" role="1ux1N" />
+          </node>
+          <node concept="1ux1I" id="AKP4wC3lc2" role="1uUwe" />
+          <node concept="1ux1f" id="AKP4wC3q$U" role="7amPI">
+            <node concept="37Y$Aw" id="AKP4wC3q$V" role="1ux1g">
+              <node concept="31LmC$" id="AKP4wC3q$W" role="37Y$Bz">
+                <node concept="36R4uQ" id="AKP4wC3q$X" role="1DcEYZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstructorDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/ConstructorDeclaration_AddTarget.mpsr
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="7486903154347178672" name="CsBaseLanguage.structure.ConstructorDeclaration" flags="ng" index="1uUxK">
+        <child id="7486903154347178702" name="formalParameterList" index="1uUwe" />
+        <child id="7486903154347178686" name="body" index="1uUxY" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz">
+        <child id="7232527154588416698" name="classMemberDeclaration" index="31Leeq" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV8v$d">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="ConstructorDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV8v$e" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV8v$f" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV8v$g" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV8v$h" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV8v$i" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8v$j" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV8v$k" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV8v$l" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV8v$m" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8v$n" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV8v$o" role="3tpDZA">
+          <property role="3cmrfH" value="1" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8v$p" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8v$q" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8v$r" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8v$s" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8v$t" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8v$u" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8v$v" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8v$w" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8v$x" role="37wK5m">
+              <property role="Xl_RC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8v$H" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8v$I" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV8v$J" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV8wmH" role="25YQCW">
+      <node concept="31LiCz" id="2KItQQV8wmJ" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUxK" id="2KItQQV8wmK" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="2KItQQV8wmL" role="1uUxY">
+            <node concept="31KRCQ" id="2KItQQV8wmM" role="1ux1N" />
+          </node>
+          <node concept="1ux1I" id="2KItQQV8wmN" role="1uUwe" />
+          <node concept="1ux1f" id="2KItQQV8wmO" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQV8wmP" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQV8wmQ" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQV8wmR" role="1DcEYZ">
+                  <node concept="LIFWc" id="2KItQQV8wqU" role="lGtFl">
+                    <property role="ZRATv" value="true" />
+                    <property role="OXtK3" value="true" />
+                    <property role="p6zMq" value="0" />
+                    <property role="p6zMs" value="0" />
+                    <property role="LIFWd" value="empty_referencedType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV8wvb" role="25YQFr">
+      <node concept="31LiCz" id="2KItQQV8wvd" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUxK" id="2KItQQV8wve" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="2KItQQV8wvf" role="1uUxY">
+            <node concept="31KRCQ" id="2KItQQV8wvg" role="1ux1N" />
+          </node>
+          <node concept="1ux1I" id="2KItQQV8wvh" role="1uUwe" />
+          <node concept="1ux1f" id="2KItQQV8wvi" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQV8wvj" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQV8wvk" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQV8wvl" role="1DcEYZ" />
+              </node>
+            </node>
+            <node concept="1DiBT2" id="2KItQQV90qv" role="1DiBoh">
+              <property role="1DiB$9" value="7Jk5HDXalfh/method" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_end.mpsr
@@ -60,12 +60,12 @@
     <node concept="1qefOq" id="5xx_vqzZTVf" role="25YQCW">
       <node concept="31LiCz" id="5xx_vqzZTVg" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vqzZUdu" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC34tG" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="5" />
           <property role="p6zMs" value="5" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
@@ -83,15 +83,7 @@
     <node concept="1qefOq" id="5xx_vqzZTVn" role="25YQFr">
       <node concept="31LiCz" id="5xx_vqzZTVo" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vqzZTVp" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vqzZU4K" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vqzZTVp" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -61,12 +60,12 @@
     <node concept="1qefOq" id="5xx_vqzXU2u" role="25YQCW">
       <node concept="31LiCz" id="5xx_vqzXU2t" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vqzZUdA" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3cWX" role="lGtFl">
           <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
@@ -84,15 +83,7 @@
     <node concept="1qefOq" id="5xx_vqzXU2X" role="25YQFr">
       <node concept="31LiCz" id="5xx_vqzXU37" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vqzXUe0" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vqzZS1U" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vqzXUe0" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ClassDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -61,12 +60,12 @@
     <node concept="1qefOq" id="5xx_vq$07Ch" role="25YQCW">
       <node concept="31LiCz" id="5xx_vq$07Ci" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$07Cj" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3cYT" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_yk1pkl_b0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
         </node>
       </node>
     </node>
@@ -84,15 +83,7 @@
     <node concept="1qefOq" id="5xx_vq$07Cp" role="25YQFr">
       <node concept="31LiCz" id="5xx_vq$07Cq" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$07Cr" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$07Cs" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$07Cr" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_end.mpsr
@@ -104,12 +104,12 @@
         <node concept="3UfwP1" id="3tcg5UgoNPl" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoNPw" role="3UfBpY" />
         </node>
-        <node concept="LIFWc" id="3tcg5UgoNPF" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3d47" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="5" />
           <property role="p6zMs" value="5" />
-          <property role="LIFWd" value="Constant_g163qj_b0" />
+          <property role="LIFWd" value="Constant_g163qj_c0" />
         </node>
       </node>
     </node>
@@ -128,15 +128,7 @@
         <node concept="3UfwP1" id="3tcg5UgoNPM" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoNPX" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5UgoNQ4" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5UgoNQd" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5UgoNQ4" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -105,12 +104,12 @@
         <node concept="3UfwP1" id="3tcg5UgoUF4" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoUFf" role="3UfBpY" />
         </node>
-        <node concept="LIFWc" id="3tcg5UgoUFR" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3d6Z" role="lGtFl">
           <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_g163qj_b0" />
+          <property role="LIFWd" value="Constant_g163qj_c0" />
         </node>
       </node>
     </node>
@@ -129,15 +128,7 @@
         <node concept="3UfwP1" id="3tcg5UgoUFq" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoUFr" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5UgoUFA" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5UgoUFJ" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5UgoUFA" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_ConstantDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -105,12 +104,12 @@
         <node concept="3UfwP1" id="3tcg5UgoPWM" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoPWX" role="3UfBpY" />
         </node>
-        <node concept="LIFWc" id="3tcg5UgoPX_" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3d9p" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_g163qj_b0" />
+          <property role="LIFWd" value="Constant_g163qj_c0" />
         </node>
       </node>
     </node>
@@ -129,15 +128,7 @@
         <node concept="3UfwP1" id="3tcg5UgoPX8" role="3SE38M">
           <node concept="3UfM66" id="3tcg5UgoPX9" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5UgoPXq" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5UgoPXz" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5UgoPXq" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_end.mpsr
@@ -81,12 +81,12 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$01CE" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$01CF" role="3Sw9wT" />
-        <node concept="LIFWc" id="5xx_vq$02hW" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dbN" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="8" />
           <property role="p6zMs" value="8" />
-          <property role="LIFWd" value="Constant_syxbnf_b0" />
+          <property role="LIFWd" value="Constant_syxbnf_c0" />
         </node>
       </node>
     </node>
@@ -95,15 +95,7 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$01CJ" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$01CK" role="3Sw9wT" />
-        <node concept="2qAx6t" id="5xx_vq$01CL" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$01CM" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$01CL" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -82,12 +81,12 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$02GC" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$02GD" role="3Sw9wT" />
-        <node concept="LIFWc" id="5xx_vq$02GE" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3ddJ" role="lGtFl">
+          <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_syxbnf_b0" />
-          <property role="LIFWa" value="2" />
+          <property role="LIFWd" value="Constant_syxbnf_c0" />
         </node>
       </node>
     </node>
@@ -96,15 +95,7 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$02GH" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$02GI" role="3Sw9wT" />
-        <node concept="2qAx6t" id="5xx_vq$02GJ" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$02GK" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$02GJ" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_DelegateDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -82,12 +81,12 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$010W" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$0113" role="3Sw9wT" />
-        <node concept="LIFWc" id="5xx_vq$011k" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dfd" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_syxbnf_b0" />
+          <property role="LIFWd" value="Constant_syxbnf_c0" />
         </node>
       </node>
     </node>
@@ -96,15 +95,7 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="5xx_vq$0118" role="1fIg$P" />
         <node concept="1pH0Yj" id="5xx_vq$0119" role="3Sw9wT" />
-        <node concept="2qAx6t" id="5xx_vq$011o" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$011x" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$011o" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_end.mpsr
@@ -71,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$02Hz" role="25YQCW">
       <node concept="31LiCB" id="5xx_vq$02H$" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$02H_" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dh9" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="4" />
           <property role="p6zMs" value="4" />
-          <property role="LIFWd" value="Constant_oivnnd_b0" />
+          <property role="LIFWd" value="Constant_oivnnd_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$02HA" role="25YQFr">
       <node concept="31LiCB" id="5xx_vq$02HB" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$02HC" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$02HD" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$02HC" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$03cO" role="25YQCW">
       <node concept="31LiCB" id="5xx_vq$03cP" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$03cQ" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3diB" role="lGtFl">
           <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_oivnnd_b0" />
+          <property role="LIFWd" value="Constant_oivnnd_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$03cR" role="25YQFr">
       <node concept="31LiCB" id="5xx_vq$03cS" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$03cT" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$03cU" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$03cT" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_EnumDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$02hC" role="25YQCW">
       <node concept="31LiCB" id="5xx_vq$02GQ" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$02I3" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dkz" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_oivnnd_b0" />
+          <property role="LIFWd" value="Constant_oivnnd_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$02H8" role="25YQFr">
       <node concept="31LiCB" id="5xx_vq$02Hc" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$02Hi" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$02Hr" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$02Hi" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_end.mpsr
@@ -71,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$0517" role="25YQCW">
       <node concept="31LiCA" id="5xx_vq$0518" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="LIFWc" id="5xx_vq$0519" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dmv" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="9" />
           <property role="p6zMs" value="9" />
-          <property role="LIFWd" value="Constant_6bvvxx_b0" />
+          <property role="LIFWd" value="Constant_6bvvxx_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$051a" role="25YQFr">
       <node concept="31LiCA" id="5xx_vq$051b" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="2qAx6t" id="5xx_vq$051c" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$051d" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$051c" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$04eH" role="25YQCW">
       <node concept="31LiCA" id="5xx_vq$04eI" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="LIFWc" id="5xx_vq$04eJ" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dnX" role="lGtFl">
+          <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_6bvvxx_b0" />
-          <property role="LIFWa" value="2" />
+          <property role="LIFWd" value="Constant_6bvvxx_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$04eK" role="25YQFr">
       <node concept="31LiCA" id="5xx_vq$04eL" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="2qAx6t" id="5xx_vq$04eM" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$04eN" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$04eM" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$03Wt" role="25YQCW">
       <node concept="31LiCA" id="5xx_vq$03Ws" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="LIFWc" id="5xx_vq$03WE" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dpr" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_6bvvxx_b0" />
+          <property role="LIFWd" value="Constant_6bvvxx_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$03Wx" role="25YQFr">
       <node concept="31LiCA" id="5xx_vq$03Ww" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="2qAx6t" id="5xx_vq$03WI" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$03WR" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$03WI" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_end.mpsr
@@ -85,7 +85,7 @@
         <node concept="1ux1I" id="3tcg5Ugp48n" role="1fIg$P" />
         <node concept="3UfwP1" id="3tcg5Ugp48u" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp48z" role="3UfBpY">
-            <node concept="LIFWc" id="3tcg5Ugp493" role="lGtFl">
+            <node concept="LIFWc" id="AKP4wC3drn" role="lGtFl">
               <property role="ZRATv" value="true" />
               <property role="OXtK3" value="true" />
               <property role="p6zMq" value="3" />
@@ -103,15 +103,7 @@
         <node concept="3UfwP1" id="3tcg5Ugp48D" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp48E" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5Ugp48M" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5Ugp48V" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5Ugp48M" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -86,7 +85,7 @@
         <node concept="1ux1I" id="3tcg5Ugp6g6" role="1fIg$P" />
         <node concept="3UfwP1" id="3tcg5Ugp6g7" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp6g8" role="3UfBpY">
-            <node concept="LIFWc" id="3tcg5Ugp6gu" role="lGtFl">
+            <node concept="LIFWc" id="AKP4wC3dzs" role="lGtFl">
               <property role="LIFWa" value="2" />
               <property role="OXtK3" value="true" />
               <property role="p6zMq" value="2" />
@@ -104,15 +103,7 @@
         <node concept="3UfwP1" id="3tcg5Ugp6gh" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp6gi" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5Ugp6gy" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5Ugp6gF" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5Ugp6gy" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_InterfaceMethodDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -86,7 +85,7 @@
         <node concept="1ux1I" id="3tcg5Ugp6fw" role="1fIg$P" />
         <node concept="3UfwP1" id="3tcg5Ugp6fx" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp6fy" role="3UfBpY">
-            <node concept="LIFWc" id="3tcg5Ugp6fZ" role="lGtFl">
+            <node concept="LIFWc" id="AKP4wC3dAk" role="lGtFl">
               <property role="LIFWa" value="0" />
               <property role="OXtK3" value="true" />
               <property role="p6zMq" value="0" />
@@ -104,15 +103,7 @@
         <node concept="3UfwP1" id="3tcg5Ugp6fF" role="3Sw9wT">
           <node concept="3UfM66" id="3tcg5Ugp6fG" role="3UfBpY" />
         </node>
-        <node concept="2qAx6t" id="3tcg5Ugp6fO" role="3SE3Wx">
-          <node concept="LIFWc" id="3tcg5Ugp6fX" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="3tcg5Ugp6fO" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_end.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_end.mpsr
@@ -71,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$0dL5" role="25YQCW">
       <node concept="31LiC_" id="5xx_vq$0dL6" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$0dLl" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dCg" role="lGtFl">
           <property role="ZRATv" value="true" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="6" />
           <property role="p6zMs" value="6" />
-          <property role="LIFWd" value="Constant_c64ig3_b0" />
+          <property role="LIFWd" value="Constant_c64ig3_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$0dL8" role="25YQFr">
       <node concept="31LiC_" id="5xx_vq$0dL9" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$0dLa" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$0dLb" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$0dLa" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_middle.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_middle.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$0dLt" role="25YQCW">
       <node concept="31LiC_" id="5xx_vq$0dLu" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$0dLv" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dEc" role="lGtFl">
+          <property role="LIFWa" value="2" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="2" />
           <property role="p6zMs" value="2" />
-          <property role="LIFWd" value="Constant_c64ig3_b0" />
-          <property role="LIFWa" value="2" />
+          <property role="LIFWd" value="Constant_c64ig3_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$0dLw" role="25YQFr">
       <node concept="31LiC_" id="5xx_vq$0dLx" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$0dLy" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$0dLz" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$0dLy" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_start.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/CreateModifierOnSpace_StructDeclaration_start.mpsr
@@ -18,7 +18,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -72,27 +71,19 @@
     <node concept="1qefOq" id="5xx_vq$0d4g" role="25YQCW">
       <node concept="31LiC_" id="5xx_vq$0d4f" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="5xx_vq$0d4p" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dGA" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_c64ig3_b0" />
+          <property role="LIFWd" value="Constant_c64ig3_c0" />
         </node>
       </node>
     </node>
     <node concept="1qefOq" id="5xx_vq$0d4s" role="25YQFr">
       <node concept="31LiC_" id="5xx_vq$0d4r" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="2qAx6t" id="5xx_vq$0d4z" role="3SE3Wx">
-          <node concept="LIFWc" id="5xx_vq$0d4G" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="6" />
-            <property role="p6zMs" value="6" />
-            <property role="LIFWd" value="Constant_7b68ld_a" />
-          </node>
-        </node>
+        <node concept="2qAx6t" id="5xx_vq$0d4z" role="3SE3Wx" />
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_AddAttributes.mpsr
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588300036" name="CsBaseLanguage.structure.DelegateDeclaration" flags="ng" index="31LiC$" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWjoMc">
+    <property role="TrG5h" value="DelegateDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="6TvF8nWjoMd" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWjoPS" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjoMj" role="25YQFr">
+      <node concept="31LiC$" id="6TvF8nWjoMA" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="6TvF8nWjoMB" role="1fIg$P" />
+        <node concept="1pH0Yj" id="6TvF8nWjoMC" role="3Sw9wT" />
+        <node concept="1ux1f" id="6TvF8nWjoME" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWjoMF" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWjoMG" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWjoMH" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjoMo" role="25YQCW">
+      <node concept="31LiC$" id="6TvF8nWjoMv" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="6TvF8nWjoMw" role="1fIg$P" />
+        <node concept="1pH0Yj" id="6TvF8nWjoMy" role="3Sw9wT" />
+        <node concept="LIFWc" id="6TvF8nWjoM_" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_AddTarget.mpsr
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588300036" name="CsBaseLanguage.structure.DelegateDeclaration" flags="ng" index="31LiC$" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV89p7">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="DelegateDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV89p8" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV89p9" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV89pa" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV89pb" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV89pc" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV89pe" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV89pf" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV89pg" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV89ph" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV89pi" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV89sS" role="3tpDZA">
+          <property role="3cmrfH" value="2" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8ais" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV89K2" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV89zn" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV89zo" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV89zp" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV89zq" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV89zr" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV89Ql" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV89Rg" role="37wK5m">
+              <property role="Xl_RC" value="return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV89pj" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV89pk" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8fTo" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8fTp" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8fTq" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8fTr" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8fTs" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8fTt" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8fTu" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8fTv" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8fTw" role="37wK5m">
+              <property role="Xl_RC" value="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8gsR" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8gsT" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV8fTn" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV89pl" role="25YQCW">
+      <node concept="31LiC$" id="2KItQQV89rD" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="2KItQQV89rE" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQV89rG" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQV89rI" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV89rJ" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV89rK" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV89rL" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV89rM" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV89rN" role="25YQFr">
+      <node concept="31LiC$" id="2KItQQV89rO" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="2KItQQV89rP" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQV89rQ" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQV89rR" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV89rS" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV89rT" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV89rU" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV8gxk" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalgK/type" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_InternalModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/DelegateDeclaration_InternalModifier.mpsr
@@ -79,12 +79,12 @@
         <property role="TrG5h" value="foo" />
         <node concept="1ux1I" id="yQEJGZBwLG" role="1fIg$P" />
         <node concept="1pH0Yj" id="yQEJGZBwLT" role="3Sw9wT" />
-        <node concept="LIFWc" id="yQEJGZBwMk" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dJW" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_syxbnf_b0" />
+          <property role="LIFWd" value="Constant_syxbnf_c0" />
         </node>
       </node>
     </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/EnumDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/EnumDeclaration_AddAttributes.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300039" name="CsBaseLanguage.structure.EnumDeclaration" flags="ng" index="31LiCB" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWieEs">
+    <property role="TrG5h" value="EnumDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="1qefOq" id="6TvF8nWieEt" role="25YQCW">
+      <node concept="31LiCB" id="6TvF8nWieEv" role="1qenE9">
+        <property role="TrG5h" value="Enum" />
+        <node concept="LIFWc" id="6TvF8nWiS8X" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="4" />
+          <property role="p6zMs" value="4" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWieEA" role="25YQFr">
+      <node concept="31LiCB" id="6TvF8nWieEC" role="1qenE9">
+        <property role="TrG5h" value="Enum" />
+        <node concept="1ux1f" id="6TvF8nWieEE" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWieEF" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWieEG" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWieEH" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6TvF8nWiWKE" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWiWKD" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/EnumMember_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/EnumMember_AddAttributes.mpsr
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300039" name="CsBaseLanguage.structure.EnumDeclaration" flags="ng" index="31LiCB">
+        <child id="7575174424947043377" name="enumMemberDeclaration" index="1fHW4K" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7575174424947043369" name="CsBaseLanguage.structure.EnumMemberDeclaration" flags="ng" index="1fHW4C" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWieEK">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="EnumMember_AddAttributes" />
+    <node concept="1qefOq" id="6TvF8nWieEL" role="25YQCW">
+      <node concept="31LiCB" id="6TvF8nWieEM" role="1qenE9">
+        <property role="TrG5h" value="Enum" />
+        <node concept="1fHW4C" id="6TvF8nWixaa" role="1fHW4K">
+          <property role="TrG5h" value="Member" />
+          <node concept="LIFWc" id="6TvF8nWixab" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="6" />
+            <property role="p6zMs" value="6" />
+            <property role="LIFWd" value="property_name" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6TvF8nWieEZ" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWieLk" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWi_Ko" role="25YQFr">
+      <node concept="31LiCB" id="6TvF8nWieER" role="1qenE9">
+        <property role="TrG5h" value="Enum" />
+        <node concept="1fHW4C" id="6TvF8nWieES" role="1fHW4K">
+          <property role="TrG5h" value="Member" />
+          <node concept="1ux1f" id="6TvF8nWiszT" role="7amPI">
+            <node concept="37Y$Aw" id="6TvF8nWiszU" role="1ux1g">
+              <node concept="31LmC$" id="6TvF8nWiszV" role="37Y$Bz">
+                <node concept="36R4uQ" id="6TvF8nWiszW" role="1DcEYZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FieldDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FieldDeclaration_AddAttributes.mpsr
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131554" name="CsBaseLanguage.structure.VariableDeclaratorList" flags="ng" index="1ux1y">
+        <child id="7486903154347131555" name="VariableDeclarator" index="1ux1z" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM" />
+      <concept id="7232527154588443306" name="CsBaseLanguage.structure.FieldDeclaration" flags="ng" index="31KRIa">
+        <child id="7232527154588443341" name="variableDeclaratorList" index="31KRJH" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWjfcw">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="FieldDeclaration_AddAttributes" />
+    <node concept="1qefOq" id="6TvF8nWjfcA" role="25YQCW">
+      <node concept="31KRIa" id="6TvF8nWjfcx" role="1qenE9">
+        <node concept="1ux1y" id="6TvF8nWjfcy" role="31KRJH">
+          <node concept="zF7EM" id="6TvF8nWjfcz" role="1ux1z">
+            <property role="TrG5h" value="field" />
+            <node concept="LIFWc" id="6TvF8nWjfcD" role="lGtFl">
+              <property role="ZRATv" value="true" />
+              <property role="OXtK3" value="true" />
+              <property role="p6zMq" value="5" />
+              <property role="p6zMs" value="5" />
+              <property role="LIFWd" value="VNC_property_name" />
+            </node>
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjfc$" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjfcB" role="3UfBpY" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjfcE" role="25YQFr">
+      <node concept="31KRIa" id="6TvF8nWjfcG" role="1qenE9">
+        <node concept="1ux1y" id="6TvF8nWjfcH" role="31KRJH">
+          <node concept="zF7EM" id="6TvF8nWjfcI" role="1ux1z">
+            <property role="TrG5h" value="field" />
+          </node>
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjfcK" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjfcL" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="6TvF8nWjfcM" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWjfcN" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWjfcO" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWjfcP" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="6TvF8nWjfsE" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWjfsD" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FieldDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FieldDeclaration_AddTarget.mpsr
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131554" name="CsBaseLanguage.structure.VariableDeclaratorList" flags="ng" index="1ux1y">
+        <child id="7486903154347131555" name="VariableDeclarator" index="1ux1z" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7769220957754731518" name="CsBaseLanguage.structure.VariableDeclaration" flags="ng" index="zF7EM" />
+      <concept id="7232527154588443306" name="CsBaseLanguage.structure.FieldDeclaration" flags="ng" index="31KRIa">
+        <child id="7232527154588443341" name="variableDeclaratorList" index="31KRJH" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV89h1">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="FieldDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV89hg" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV89hh" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV89hi" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV89hj" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV89hk" role="3cqZAp">
+        <node concept="3cmrfG" id="2KItQQV89hl" role="3tpDZA">
+          <property role="3cmrfH" value="1" />
+        </node>
+        <node concept="2OqwBi" id="2KItQQV89hm" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV89hn" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV89ho" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV89hp" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV89hq" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8lX1" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8p5B" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8oQa" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8mB6" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8lXZ" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8oLz" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8p2f" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8pgx" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8phd" role="37wK5m">
+              <property role="Xl_RC" value="field" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV89hr" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV89hs" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV89kO" role="25YQCW">
+      <node concept="31KRIa" id="2KItQQV89kJ" role="1qenE9">
+        <node concept="1ux1y" id="2KItQQV89kK" role="31KRJH">
+          <node concept="zF7EM" id="2KItQQV89kL" role="1ux1z">
+            <property role="TrG5h" value="field" />
+          </node>
+        </node>
+        <node concept="3UfwP1" id="2KItQQV89kM" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQV89lJ" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="2KItQQV89lL" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV89lM" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV89lN" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV89lO" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV89mV" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV89lP" role="25YQFr">
+      <node concept="31KRIa" id="2KItQQV89lQ" role="1qenE9">
+        <node concept="1ux1y" id="2KItQQV89lR" role="31KRJH">
+          <node concept="zF7EM" id="2KItQQV89lS" role="1ux1z">
+            <property role="TrG5h" value="field" />
+          </node>
+        </node>
+        <node concept="3UfwP1" id="2KItQQV89lT" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQV89lU" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="2KItQQV89lV" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV89lW" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV89lX" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV89lY" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV89mU" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXal2Z/field" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/File_AddGlobalAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/File_AddGlobalAttributes.mpsr
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
+        <child id="7232527154588296296" name="globalAttributeList" index="31LjP8" />
+        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="282100264961863831" name="CsBaseLanguage.structure.GlobalAttributeSection" flags="ng" index="17W$w_">
+        <child id="6179718927850243975" name="attributeList" index="37xO8o" />
+      </concept>
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV7Luq">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="File_AddGlobalAttributes" />
+    <node concept="1qefOq" id="2KItQQV7Lur" role="25YQCW">
+      <node concept="31LFg6" id="2KItQQV7Lus" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2KItQQV7Lut" role="31LlDr" />
+        <node concept="LIFWc" id="2KItQQV7Luu" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_jqfb9k_f0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV7Luv" role="25YQFr">
+      <node concept="31LFg6" id="2KItQQV7Luw" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2KItQQV7Lux" role="31LlDr" />
+        <node concept="17W$w_" id="2KItQQV7LuA" role="31LjP8">
+          <node concept="37Y$Aw" id="2KItQQV7LuB" role="37xO8o">
+            <node concept="31LmC$" id="2KItQQV7LuC" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV7LuD" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2KItQQV7Lu$" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV7Lu_" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:5n2LpYi75Gz" resolve="AddGlobalAttributes" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/File_ChangeGlobalAttributeTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/File_ChangeGlobalAttributeTarget.mpsr
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
+        <property id="1227184461946" name="keys" index="2TTd_B" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7232527154588416719" name="CsBaseLanguage.structure.INamespaceMemberDeclaration" flags="ngI" index="31LefJ" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="7232527154588265766" name="CsBaseLanguage.structure.File" flags="ng" index="31LFg6">
+        <child id="7232527154588296296" name="globalAttributeList" index="31LjP8" />
+        <child id="7232527154588304251" name="namespaceMemberDeclaration" index="31LlDr" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="282100264961863831" name="CsBaseLanguage.structure.GlobalAttributeSection" flags="ng" index="17W$w_">
+        <property id="7531756407839446331" name="target" index="wzfAR" />
+        <child id="6179718927850243975" name="attributeList" index="37xO8o" />
+      </concept>
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV7QwE">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="File_ChangeGlobalAttributeTarget" />
+    <node concept="1qefOq" id="2KItQQV7QwJ" role="25YQFr">
+      <node concept="31LFg6" id="2KItQQV7QwK" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2KItQQV7QwL" role="31LlDr" />
+        <node concept="17W$w_" id="2KItQQV7QwM" role="31LjP8">
+          <property role="wzfAR" value="7Jk5HDXYHVs/module" />
+          <node concept="37Y$Aw" id="2KItQQV7QwN" role="37xO8o">
+            <node concept="31LmC$" id="2KItQQV7QwO" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV7QwP" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2KItQQV7QwQ" role="LjaKd">
+      <node concept="2HxZob" id="2KItQQV7QGa" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV7QGc" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV7QPN" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV7T5y" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV7Ru_" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV7QPT" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV7T0G" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV7Thc" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV7Ti8" role="3tpDZA">
+          <property role="3cmrfH" value="2" />
+        </node>
+      </node>
+      <node concept="2TK7Tu" id="2KItQQV84aD" role="3cqZAp">
+        <property role="2TTd_B" value="module" />
+      </node>
+      <node concept="yd1bK" id="2KItQQV7TTj" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV7TTl" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV7QwS" role="25YQCW">
+      <node concept="31LFg6" id="2KItQQV7QwT" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="31LefJ" id="2KItQQV7QwU" role="31LlDr" />
+        <node concept="17W$w_" id="2KItQQV7QwV" role="31LjP8">
+          <node concept="37Y$Aw" id="2KItQQV7QwW" role="37xO8o">
+            <node concept="31LmC$" id="2KItQQV7QwX" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV7QwY" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="LIFWc" id="2KItQQV7QwZ" role="lGtFl">
+            <property role="LIFWa" value="0" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="property_target" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_AddAttributes.mpsr
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I">
+        <child id="7486903154347131567" name="formalParameter" index="1ux1J" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvPy9">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="FormalParameter_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUzJmY" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUzJmX" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$75D" role="25YQCW">
+      <node concept="1ux1I" id="2KItQQU$75F" role="1qenE9">
+        <node concept="31KZC3" id="2KItQQU$75H" role="1ux1J">
+          <property role="TrG5h" value="foo" />
+          <node concept="3UfwP1" id="2KItQQU$75I" role="2UegB9">
+            <node concept="3UfM66" id="2KItQQU$75G" role="3UfBpY" />
+          </node>
+          <node concept="LIFWc" id="2KItQQU$75J" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="3" />
+            <property role="p6zMs" value="3" />
+            <property role="LIFWd" value="property_name" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$bPF" role="25YQFr">
+      <node concept="1ux1I" id="2KItQQU$bPG" role="1qenE9">
+        <node concept="31KZC3" id="2KItQQU$bPH" role="1ux1J">
+          <property role="TrG5h" value="foo" />
+          <node concept="3UfwP1" id="2KItQQU$bPI" role="2UegB9">
+            <node concept="3UfM66" id="2KItQQU$bPJ" role="3UfBpY" />
+          </node>
+          <node concept="1ux1f" id="2KItQQU$bPL" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQU$bPM" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQU$bPN" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQU$bPO" role="1DcEYZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/FormalParameter_AddTarget.mpsr
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I">
+        <child id="7486903154347131567" name="formalParameter" index="1ux1J" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588476195" name="CsBaseLanguage.structure.FormalParameter" flags="ng" index="31KZC3">
+        <child id="8700838527816343363" name="type" index="2UegB9" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV95Yk">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="FormalParameter_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV95Yl" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV95Ym" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV95Yn" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV95Yo" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV95Yp" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV95Yq" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV95Yr" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV95Ys" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV95Yt" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV95Yu" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV95Yv" role="3tpDZA">
+          <property role="3cmrfH" value="1" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV95Yw" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV95Yx" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV95Yy" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV95Yz" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV95Y$" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV95Y_" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV95YA" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV95YB" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV95YC" role="37wK5m">
+              <property role="Xl_RC" value="param" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV95YD" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV95YE" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV95YF" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV96dk" role="25YQCW">
+      <node concept="1ux1I" id="2KItQQV96dj" role="1qenE9">
+        <node concept="31KZC3" id="2KItQQV96fV" role="1ux1J">
+          <property role="TrG5h" value="foo" />
+          <node concept="3UfwP1" id="2KItQQV96fW" role="2UegB9">
+            <node concept="3UfM66" id="2KItQQV96fU" role="3UfBpY" />
+          </node>
+          <node concept="1ux1f" id="2KItQQV96fX" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQV96fY" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQV96fZ" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQV96g0" role="1DcEYZ">
+                  <node concept="LIFWc" id="2KItQQV96g1" role="lGtFl">
+                    <property role="ZRATv" value="true" />
+                    <property role="OXtK3" value="true" />
+                    <property role="p6zMq" value="0" />
+                    <property role="p6zMs" value="0" />
+                    <property role="LIFWd" value="empty_referencedType" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV96hf" role="25YQFr">
+      <node concept="1ux1I" id="2KItQQV96hg" role="1qenE9">
+        <node concept="31KZC3" id="2KItQQV96hh" role="1ux1J">
+          <property role="TrG5h" value="foo" />
+          <node concept="3UfwP1" id="2KItQQV96hi" role="2UegB9">
+            <node concept="3UfM66" id="2KItQQV96hj" role="3UfBpY" />
+          </node>
+          <node concept="1ux1f" id="2KItQQV96hk" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQV96hl" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQV96hm" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQV96hn" role="1DcEYZ" />
+              </node>
+            </node>
+            <node concept="1DiBT2" id="2KItQQV96jZ" role="1DiBoh">
+              <property role="1DiB$9" value="7Jk5HDXalfK/param" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/GetAccessorDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/GetAccessorDeclaration_AddTarget.mpsr
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV96mT">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="GetAccessorDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV96mU" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV96mV" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV96mW" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV96mX" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV96mY" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV96mZ" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV96n0" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV96n1" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV96n2" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV96n3" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV96n4" role="3tpDZA">
+          <property role="3cmrfH" value="2" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV96n5" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV96n6" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV96n7" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV96n8" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV96n9" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV96na" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV96nb" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV96nc" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV96nd" role="37wK5m">
+              <property role="Xl_RC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV96ne" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV96nf" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV96ng" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV96nh" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV96ni" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV96nj" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV96nk" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV96nl" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV96nm" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV96nn" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV96no" role="37wK5m">
+              <property role="Xl_RC" value="return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV96np" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV96nq" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV96nr" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV96N8" role="25YQCW">
+      <node concept="1ux0t" id="2KItQQV96N6" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQV96N7" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQV96Rq" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV96Rr" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV96Rs" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV96Rt" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV96Ru" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV96Tv" role="25YQFr">
+      <node concept="1ux0t" id="2KItQQV96Tw" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQV96Tx" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQV96Ty" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV96Tz" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV96T$" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV96T_" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV96XS" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalgJ/return" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/GetAccessor_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/GetAccessor_AddAttributes.mpsr
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUB$wJ">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="GetAccessor_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUB$wK" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUB$wL" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUB$wM" role="25YQCW">
+      <node concept="1ux0t" id="2KItQQUB$wW" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQUB$wX" role="j3B8P" />
+        <node concept="LIFWc" id="2KItQQUB$x1" role="lGtFl">
+          <property role="LIFWa" value="2" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="2" />
+          <property role="p6zMs" value="2" />
+          <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUB$wP" role="25YQFr">
+      <node concept="1ux0t" id="2KItQQUB$x3" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQUB$x4" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQUB$x6" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUB$x7" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUB$x8" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUB$x9" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_AddAttributes.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300038" name="CsBaseLanguage.structure.InterfaceDeclaration" flags="ng" index="31LiCA" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQU$h_l">
+    <property role="TrG5h" value="InterfaceDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="2KItQQU$h_m" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQU$h_n" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$h_y" role="25YQCW">
+      <node concept="31LiCA" id="2KItQQU$h_x" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="2KItQQU$h_z" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$h_$" role="25YQFr">
+      <node concept="31LiCA" id="2KItQQU$h_A" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="2KItQQU$h_C" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQU$h_D" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQU$h_E" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQU$h_F" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_InternalModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceDeclaration_InternalModifier.mpsr
@@ -23,7 +23,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -93,12 +92,12 @@
     <node concept="1qefOq" id="3tcg5UgpG0S" role="25YQCW">
       <node concept="31LiCA" id="3tcg5UgpG0R" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
-        <node concept="LIFWc" id="3tcg5UgpG1r" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dLq" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_6bvvxx_b0" />
+          <property role="LIFWd" value="Constant_6bvvxx_c0" />
         </node>
       </node>
     </node>
@@ -106,13 +105,6 @@
       <node concept="31LiCA" id="3tcg5UgpG1j" role="1qenE9">
         <property role="TrG5h" value="IFoo" />
         <node concept="2qAx7z" id="3tcg5UgpG1v" role="3SE3Wx" />
-        <node concept="LIFWc" id="3tcg5UgpG1C" role="lGtFl">
-          <property role="ZRATv" value="true" />
-          <property role="OXtK3" value="true" />
-          <property role="p6zMq" value="0" />
-          <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="empty_interfaceMemberDeclaration" />
-        </node>
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceGetAccessor_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceGetAccessor_AddAttributes.mpsr
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="292062066074800736" name="CsBaseLanguage.structure.InterfacePropertyGetAccessorDeclaration" flags="ng" index="3gNcU6" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUBDpR">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="InterfaceGetAccessor_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUBDpS" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUBDpT" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDpU" role="25YQCW">
+      <node concept="3gNcU6" id="2KItQQUBDq6" role="1qenE9">
+        <node concept="LIFWc" id="2KItQQUBDq7" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="4" />
+          <property role="p6zMs" value="4" />
+          <property role="LIFWd" value="Constant_cdg39s_b0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDpY" role="25YQFr">
+      <node concept="3gNcU6" id="2KItQQUBDqa" role="1qenE9">
+        <node concept="1ux1f" id="2KItQQUBDqc" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUBDqd" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUBDqe" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUBDqf" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceMethodDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceMethodDeclaration_AddAttributes.mpsr
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7575174424947155903" name="CsBaseLanguage.structure.InterfaceMethodDeclaration" flags="ng" index="1fIgUY" />
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvG8i">
+    <property role="TrG5h" value="InterfaceMethodDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="2KItQQUvG8j" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUvG8k" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvG8l" role="25YQFr">
+      <node concept="1fIgUY" id="2KItQQUvG8I" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="2KItQQUvG8J" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQUvG8K" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQUvG8M" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUvG8N" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUvG8O" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUvG8P" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvG8D" role="25YQCW">
+      <node concept="1fIgUY" id="2KItQQUvG8A" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1I" id="2KItQQUvG8B" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQUvG8E" role="3Sw9wT" />
+        <node concept="LIFWc" id="2KItQQUvG8G" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfacePropertyDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfacePropertyDeclaration_AddAttributes.mpsr
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="292062066074800736" name="CsBaseLanguage.structure.InterfacePropertyGetAccessorDeclaration" flags="ng" index="3gNcU6" />
+      <concept id="292062066074800737" name="CsBaseLanguage.structure.InterfacePropertySetAccessorDeclaration" flags="ng" index="3gNcU7" />
+      <concept id="8914124434097811872" name="CsBaseLanguage.structure.InterfacePropertyDeclaration" flags="ng" index="3xGIlh">
+        <child id="292062066074801987" name="accessorDeclaration" index="3gNcI_" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvr2J">
+    <property role="TrG5h" value="InterfacePropertyDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="2KItQQUvr2K" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUvr2L" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvr3b" role="25YQCW">
+      <node concept="3xGIlh" id="2KItQQUvr37" role="1qenE9">
+        <property role="TrG5h" value="Property" />
+        <node concept="3gNcU6" id="2KItQQUvr3e" role="3gNcI_" />
+        <node concept="3gNcU7" id="2KItQQUvr3h" role="3gNcI_" />
+        <node concept="3UfwP1" id="2KItQQUvr39" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQUvr3c" role="3UfBpY" />
+        </node>
+        <node concept="LIFWc" id="2KItQQUvr3p" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="8" />
+          <property role="p6zMs" value="8" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvr3j" role="25YQFr">
+      <node concept="3xGIlh" id="2KItQQUvr3k" role="1qenE9">
+        <property role="TrG5h" value="Property" />
+        <node concept="3gNcU6" id="2KItQQUvr3l" role="3gNcI_" />
+        <node concept="3gNcU7" id="2KItQQUvr3m" role="3gNcI_" />
+        <node concept="3UfwP1" id="2KItQQUvr3n" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQUvr3o" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="2KItQQUvr3q" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUvr3r" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUvr3s" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUvr3t" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceSetAccessor_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/InterfaceSetAccessor_AddAttributes.mpsr
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="292062066074800737" name="CsBaseLanguage.structure.InterfacePropertySetAccessorDeclaration" flags="ng" index="3gNcU7" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUBDsn">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="InterfaceSetAccessor_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUBDso" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUBDsp" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDsq" role="25YQCW">
+      <node concept="3gNcU7" id="2KItQQUBDsA" role="1qenE9">
+        <node concept="LIFWc" id="2KItQQUBDsB" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="4" />
+          <property role="p6zMs" value="4" />
+          <property role="LIFWd" value="Constant_a49hg6_b0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDsu" role="25YQFr">
+      <node concept="3gNcU7" id="2KItQQUBDsE" role="1qenE9">
+        <node concept="1ux1f" id="2KItQQUBDsG" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUBDsH" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUBDsI" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUBDsJ" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/MethodDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/MethodDeclaration_AddAttributes.mpsr
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvG5v">
+    <property role="TrG5h" value="MethodDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="2KItQQUvG5w" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUvG5x" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvG5y" role="25YQFr">
+      <node concept="31KRCM" id="2KItQQUvG61" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1M" id="2KItQQUvG62" role="31KRCR">
+          <node concept="31KRCQ" id="2KItQQUvG63" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="2KItQQUvG64" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQUvG65" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQUvG67" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUvG68" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUvG69" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUvG6a" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvG5W" role="25YQCW">
+      <node concept="31KRCM" id="2KItQQUvG5R" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1M" id="2KItQQUvG5S" role="31KRCR">
+          <node concept="31KRCQ" id="2KItQQUvG5T" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="2KItQQUvG5U" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQUvG5X" role="3Sw9wT" />
+        <node concept="LIFWc" id="2KItQQUvG5Z" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/MethodDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/MethodDeclaration_AddTarget.mpsr
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131566" name="CsBaseLanguage.structure.FormalParameterList" flags="ng" index="1ux1I" />
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="3766354144459872182" name="CsBaseLanguage.structure.IFunctionHeader" flags="ngI" index="2qBh2l">
+        <child id="7575174424947156020" name="formalParameterList" index="1fIg$P" />
+      </concept>
+      <concept id="7232527154588443410" name="CsBaseLanguage.structure.MethodDeclaration" flags="ng" index="31KRCM">
+        <child id="7232527154588443415" name="body" index="31KRCR" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="3129541975290303051" name="CsBaseLanguage.structure.VoidType" flags="ng" index="1pH0Yj" />
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+      <concept id="6209812394075305792" name="CsBaseLanguage.structure.IHaveTypeOrVoid" flags="ngI" index="3Sw9wS">
+        <child id="6209812394075305793" name="typeOrVoid" index="3Sw9wT" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV8pu2">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="MethodDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV8pu3" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV8pu4" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV8pu5" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV8pu6" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV8pu7" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8pu8" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV8pu9" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV8pua" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV8pub" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8puc" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV8pud" role="3tpDZA">
+          <property role="3cmrfH" value="2" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8pue" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8puf" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8pug" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8puh" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8pui" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8puj" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8puk" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8pul" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8pum" role="37wK5m">
+              <property role="Xl_RC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8pun" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8puo" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8pup" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8puq" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8pur" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8pus" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8put" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8puu" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8puv" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8puw" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8pux" role="37wK5m">
+              <property role="Xl_RC" value="return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8puy" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8puz" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV8pu$" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV8pG1" role="25YQCW">
+      <node concept="31KRCM" id="2KItQQV8pFW" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1M" id="2KItQQV8pFX" role="31KRCR">
+          <node concept="31KRCQ" id="2KItQQV8pFY" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="2KItQQV8pFZ" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQV8pKi" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQV8pKk" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV8pKl" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV8pKm" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV8pKn" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV8pKo" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV8pKp" role="25YQFr">
+      <node concept="31KRCM" id="2KItQQV8pKq" role="1qenE9">
+        <property role="TrG5h" value="foo" />
+        <node concept="1ux1M" id="2KItQQV8pKr" role="31KRCR">
+          <node concept="31KRCQ" id="2KItQQV8pKs" role="1ux1N" />
+        </node>
+        <node concept="1ux1I" id="2KItQQV8pKt" role="1fIg$P" />
+        <node concept="1pH0Yj" id="2KItQQV8pKu" role="3Sw9wT" />
+        <node concept="1ux1f" id="2KItQQV8pKv" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV8pKw" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV8pKx" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV8pKy" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV8pQp" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalgJ/return" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/PropertyDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/PropertyDeclaration_AddAttributes.mpsr
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131577" name="CsBaseLanguage.structure.PropertyDeclaration" flags="ng" index="1ux1T">
+        <child id="7486903154347131649" name="accessorDeclaration" index="1ux71" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6TvF8nWjtx_">
+    <property role="TrG5h" value="PropertyDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="6TvF8nWjtxA" role="LjaKd">
+      <node concept="1MFPAf" id="6TvF8nWjtxB" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttribute" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjtxC" role="25YQFr">
+      <node concept="1ux1T" id="6TvF8nWjty1" role="1qenE9">
+        <property role="TrG5h" value="Property" />
+        <node concept="1ux0t" id="6TvF8nWjty2" role="1ux71">
+          <node concept="2Y_LOE" id="6TvF8nWjty3" role="j3B8P" />
+        </node>
+        <node concept="1ux0x" id="6TvF8nWjty4" role="1ux71">
+          <node concept="2Y_LOE" id="6TvF8nWjty5" role="j3B8P" />
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjty6" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjty7" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="6TvF8nWjty9" role="7amPI">
+          <node concept="37Y$Aw" id="6TvF8nWjtya" role="1ux1g">
+            <node concept="31LmC$" id="6TvF8nWjtyb" role="37Y$Bz">
+              <node concept="36R4uQ" id="6TvF8nWjtyc" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6TvF8nWjtxI" role="25YQCW">
+      <node concept="1ux1T" id="6TvF8nWjtxM" role="1qenE9">
+        <property role="TrG5h" value="Property" />
+        <node concept="1ux0t" id="6TvF8nWjtxN" role="1ux71">
+          <node concept="2Y_LOE" id="6TvF8nWjtxO" role="j3B8P" />
+        </node>
+        <node concept="1ux0x" id="6TvF8nWjtxP" role="1ux71">
+          <node concept="2Y_LOE" id="6TvF8nWjtxQ" role="j3B8P" />
+        </node>
+        <node concept="3UfwP1" id="6TvF8nWjtxR" role="3SE38M">
+          <node concept="3UfM66" id="6TvF8nWjtxT" role="3UfBpY" />
+        </node>
+        <node concept="LIFWc" id="6TvF8nWjtxZ" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="8" />
+          <property role="p6zMs" value="8" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/PropertyDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/PropertyDeclaration_AddTarget.mpsr
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131613" name="CsBaseLanguage.structure.GetAccessorDeclaration" flags="ng" index="1ux0t" />
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="7486903154347131577" name="CsBaseLanguage.structure.PropertyDeclaration" flags="ng" index="1ux1T">
+        <child id="7486903154347131649" name="accessorDeclaration" index="1ux71" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+      <concept id="6209812394072707164" name="CsBaseLanguage.structure.IHaveType" flags="ngI" index="3SE3W$">
+        <child id="6209812394072710474" name="type" index="3SE38M" />
+      </concept>
+      <concept id="6843536562190757247" name="CsBaseLanguage.structure.Type" flags="ng" index="3UfwP1">
+        <child id="6843536562190767680" name="nonArrayType" index="3UfBpY" />
+      </concept>
+      <concept id="6843536562190680504" name="CsBaseLanguage.structure.IntType" flags="ng" index="3UfM66" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV8v5O">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="PropertyDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV8v5P" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV8v5Q" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV8v5R" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV8v5S" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV8v5T" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8v5U" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV8v5V" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV8v5W" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV8v5X" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8v5Y" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV8v5Z" role="3tpDZA">
+          <property role="3cmrfH" value="2" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8v60" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8v61" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8v62" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8v63" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8v64" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8v65" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8v66" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8v67" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8v68" role="37wK5m">
+              <property role="Xl_RC" value="field" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8v69" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8v6a" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8v6b" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8v6c" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8v6d" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8v6e" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8v6f" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8v6g" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8v6h" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8v6i" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8v6j" role="37wK5m">
+              <property role="Xl_RC" value="property" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV8v6k" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV8v6l" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV8v6m" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV8vnM" role="25YQCW">
+      <node concept="1ux1T" id="2KItQQV8vnF" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux0t" id="2KItQQV8vnG" role="1ux71">
+          <node concept="2Y_LOE" id="2KItQQV8vnH" role="j3B8P" />
+        </node>
+        <node concept="1ux0x" id="2KItQQV8vnI" role="1ux71">
+          <node concept="2Y_LOE" id="2KItQQV8vnJ" role="j3B8P" />
+        </node>
+        <node concept="3UfwP1" id="2KItQQV8vnK" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQV8vs3" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="2KItQQV8vs5" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV8vs6" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV8vs7" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV8vs8" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV8vsa" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV8vua" role="25YQFr">
+      <node concept="1ux1T" id="2KItQQV8vub" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux0t" id="2KItQQV8vuc" role="1ux71">
+          <node concept="2Y_LOE" id="2KItQQV8vud" role="j3B8P" />
+        </node>
+        <node concept="1ux0x" id="2KItQQV8vue" role="1ux71">
+          <node concept="2Y_LOE" id="2KItQQV8vuf" role="j3B8P" />
+        </node>
+        <node concept="3UfwP1" id="2KItQQV8vug" role="3SE38M">
+          <node concept="3UfM66" id="2KItQQV8vuh" role="3UfBpY" />
+        </node>
+        <node concept="1ux1f" id="2KItQQV8vui" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV8vuj" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV8vuk" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV8vul" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV8v$c" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalfL/property" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/RemoveAttributeSections.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/RemoveAttributeSections.mpsr
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="tp6m" ref="r:00000000-0000-4000-0000-011c895903a2(jetbrains.mps.lang.test.runtime)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1239709250944" name="jetbrains.mps.baseLanguage.structure.PrefixIncrementExpression" flags="nn" index="2$rviw" />
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+        <child id="1239714902950" name="expression" index="2$L3a6" />
+      </concept>
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+        <child id="1144230900587" name="variable" index="1Duv9x" />
+      </concept>
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+        <child id="1144231399730" name="condition" index="1Dwp0S" />
+        <child id="1144231408325" name="iteration" index="1Dwrff" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="6c7swQs2V$4">
+    <property role="TrG5h" value="RemoveAttributeSections" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="6c7swQs2V$5" role="LjaKd">
+      <node concept="1Dw8fO" id="6c7swQs33cz" role="3cqZAp">
+        <node concept="3cpWsn" id="6c7swQs33c$" role="1Duv9x">
+          <property role="TrG5h" value="i" />
+          <node concept="10Oyi0" id="6c7swQs33id" role="1tU5fm" />
+          <node concept="3cmrfG" id="6c7swQs37bT" role="33vP2m">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+        <node concept="3clFbS" id="6c7swQs33c_" role="2LFqv$">
+          <node concept="3clFbF" id="6c7swQs3bkX" role="3cqZAp">
+            <node concept="2YIFZM" id="6c7swQs3bmw" role="3clFbG">
+              <ref role="37wK5l" to="tp6m:14TMHtHs1EN" resolve="runWithTwoStepDeletion" />
+              <ref role="1Pybhc" to="tp6m:5s44y2Lh6_5" resolve="EditorTestUtil" />
+              <node concept="1bVj0M" id="6c7swQs3bnw" role="37wK5m">
+                <node concept="3clFbS" id="6c7swQs3bnz" role="1bW5cS">
+                  <node concept="2HxZob" id="6c7swQs3bB2" role="3cqZAp">
+                    <node concept="1iFQzN" id="6c7swQs3bCN" role="3iKnsn">
+                      <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                    </node>
+                  </node>
+                  <node concept="2HxZob" id="6c7swQs3bGj" role="3cqZAp">
+                    <node concept="1iFQzN" id="6c7swQs3bGk" role="3iKnsn">
+                      <ref role="1iFR8X" to="ekwn:7HPyHg84hwg" resolve="Delete" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbT" id="6c7swQs3bL3" role="37wK5m">
+                <property role="3clFbU" value="true" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3eOVzh" id="6c7swQs3aYQ" role="1Dwp0S">
+          <node concept="3cmrfG" id="6c7swQs3aZj" role="3uHU7w">
+            <property role="3cmrfH" value="2" />
+          </node>
+          <node concept="37vLTw" id="6c7swQs37c_" role="3uHU7B">
+            <ref role="3cqZAo" node="6c7swQs33c$" resolve="i" />
+          </node>
+        </node>
+        <node concept="2$rviw" id="6c7swQs3b6H" role="1Dwrff">
+          <node concept="37vLTw" id="6c7swQs3b8h" role="2$L3a6">
+            <ref role="3cqZAo" node="6c7swQs33c$" resolve="i" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6c7swQs2V$7" role="25YQFr">
+      <node concept="31LiCz" id="6c7swQs2V$8" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="6c7swQs2W7P" role="lGtFl">
+          <property role="LIFWa" value="0" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="0" />
+          <property role="p6zMs" value="0" />
+          <property role="LIFWd" value="Constant_yk1pkl_c0" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="6c7swQs2VMN" role="25YQCW">
+      <node concept="31LiCz" id="6c7swQs2VMO" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="6c7swQs2VMP" role="7amPI">
+          <node concept="37Y$Aw" id="6c7swQs2VMQ" role="1ux1g">
+            <node concept="31LmC$" id="6c7swQs2VMR" role="37Y$Bz">
+              <node concept="36R4uQ" id="6c7swQs2VMS" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+        <node concept="1ux1f" id="6c7swQs2VMT" role="7amPI">
+          <node concept="37Y$Aw" id="6c7swQs2VMU" role="1ux1g">
+            <node concept="31LmC$" id="6c7swQs2VMV" role="37Y$Bz">
+              <node concept="36R4uQ" id="6c7swQs2VMW" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="LIFWc" id="6c7swQs2VOh" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="1" />
+            <property role="p6zMs" value="1" />
+            <property role="LIFWd" value="Constant_s0m7dt_d0" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/SetAccessorDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/SetAccessorDeclaration_AddTarget.mpsr
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV9738">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="SetAccessorDeclaration_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV9739" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV973a" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV973b" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV973c" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV973d" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV973e" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV973f" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV973g" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV973h" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV973i" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV97px" role="3tpDZA">
+          <property role="3cmrfH" value="3" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV973k" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV973l" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV973m" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV973n" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV973o" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV973p" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV973q" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV973r" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV973s" role="37wK5m">
+              <property role="Xl_RC" value="method" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV973t" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV973u" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV97jk" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV97jl" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV97jm" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV97jn" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV97jo" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV97jp" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV97jq" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV97jr" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV97js" role="37wK5m">
+              <property role="Xl_RC" value="param" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV97ji" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV97jj" role="yd6KS">
+          <property role="pLAjf" value="VK_DOWN" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV973v" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV973w" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV973x" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV973y" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV973z" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV973$" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV973_" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV973A" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV973B" role="37wK5m">
+              <property role="Xl_RC" value="return" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV973C" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV973D" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV973E" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV973F" role="25YQCW">
+      <node concept="1ux0x" id="2KItQQV978w" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQV978x" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQV97ax" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV97ay" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV97az" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV97a$" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV97cQ" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV97eS" role="25YQFr">
+      <node concept="1ux0x" id="2KItQQV97eT" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQV97eU" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQV97eV" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV97eW" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV97eX" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV97eY" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV97jh" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalgJ/return" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/SetAccessor_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/SetAccessor_AddAttributes.mpsr
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968596" name="caretPosition" index="LIFWa" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131617" name="CsBaseLanguage.structure.SetAccessorDeclaration" flags="ng" index="1ux0x" />
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="4106644276571785472" name="CsBaseLanguage.structure.AccessorDeclaration" flags="ng" index="j3B8Q">
+        <child id="4106644276571785475" name="body" index="j3B8P" />
+      </concept>
+      <concept id="1945218857512325908" name="CsBaseLanguage.structure.EmptyBlock" flags="ng" index="2Y_LOE" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUBDnm">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="SetAccessor_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQUBDnn" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUBDno" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDnp" role="25YQCW">
+      <node concept="1ux0x" id="2KItQQUBDn_" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQUBDnA" role="j3B8P" />
+        <node concept="LIFWc" id="2KItQQUBDnB" role="lGtFl">
+          <property role="LIFWa" value="2" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="2" />
+          <property role="p6zMs" value="2" />
+          <property role="LIFWd" value="ALIAS_EDITOR_COMPONENT" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBDnt" role="25YQFr">
+      <node concept="1ux0x" id="2KItQQUBDnE" role="1qenE9">
+        <node concept="2Y_LOE" id="2KItQQUBDnF" role="j3B8P" />
+        <node concept="1ux1f" id="2KItQQUBDnG" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUBDnH" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUBDnI" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUBDnJ" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StaticConstructorDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StaticConstructorDeclaration_AddAttributes.mpsr
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="7486903154347131570" name="CsBaseLanguage.structure.Block" flags="ng" index="1ux1M">
+        <child id="7486903154347131571" name="statement" index="1ux1N" />
+      </concept>
+      <concept id="7486903154347178693" name="CsBaseLanguage.structure.StaticConstructorDeclaration" flags="ng" index="1uUw5">
+        <child id="7486903154347178773" name="body" index="1uUBl" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588443414" name="CsBaseLanguage.structure.Statement" flags="ng" index="31KRCQ" />
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz">
+        <child id="7232527154588416698" name="classMemberDeclaration" index="31Leeq" />
+      </concept>
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUvPuZ">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="StaticConstructorDeclaration_AddAttributes" />
+    <node concept="1qefOq" id="2KItQQUvPv0" role="25YQCW">
+      <node concept="31LiCz" id="2KItQQUvPvs" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUw5" id="2KItQQUvPvt" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="2KItQQUvPvu" role="1uUBl">
+            <node concept="31KRCQ" id="2KItQQUvPvv" role="1ux1N" />
+          </node>
+          <node concept="LIFWc" id="2KItQQUvPvw" role="lGtFl">
+            <property role="ZRATv" value="true" />
+            <property role="OXtK3" value="true" />
+            <property role="p6zMq" value="0" />
+            <property role="p6zMs" value="0" />
+            <property role="LIFWd" value="Constant_bk8szz_a1a" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUvPv6" role="25YQFr">
+      <node concept="31LiCz" id="2KItQQUvPvx" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1uUw5" id="2KItQQUvPvy" role="31Leeq">
+          <property role="TrG5h" value="Foo" />
+          <node concept="1ux1M" id="2KItQQUvPvz" role="1uUBl">
+            <node concept="31KRCQ" id="2KItQQUvPv$" role="1ux1N" />
+          </node>
+          <node concept="1ux1f" id="2KItQQUvPvA" role="7amPI">
+            <node concept="37Y$Aw" id="2KItQQUvPvB" role="1ux1g">
+              <node concept="31LmC$" id="2KItQQUvPvC" role="37Y$Bz">
+                <node concept="36R4uQ" id="2KItQQUvPvD" role="1DcEYZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2KItQQUvPvf" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUvPvg" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_AddAttributes.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300037" name="CsBaseLanguage.structure.StructDeclaration" flags="ng" index="31LiC_" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQU$mo$">
+    <property role="TrG5h" value="StructDeclaration_AddAttributes" />
+    <property role="3GE5qa" value="editor.Attributes" />
+    <node concept="3clFbS" id="2KItQQU$mo_" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQU$moA" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$moL" role="25YQCW">
+      <node concept="31LiC_" id="2KItQQU$moK" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="LIFWc" id="2KItQQU$moM" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="3" />
+          <property role="p6zMs" value="3" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$moN" role="25YQFr">
+      <node concept="31LiC_" id="2KItQQU$moP" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="2KItQQU$moR" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQU$moS" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQU$moT" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQU$moU" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_CtorStatic.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_CtorStatic.mpsr
@@ -81,13 +81,6 @@
           <node concept="1ux1M" id="3tcg5UgqaHy" role="1uUBl">
             <node concept="31KRCQ" id="3tcg5UgqaHz" role="1ux1N" />
           </node>
-          <node concept="LIFWc" id="3tcg5UgqaHB" role="lGtFl">
-            <property role="ZRATv" value="true" />
-            <property role="OXtK3" value="true" />
-            <property role="p6zMq" value="0" />
-            <property role="p6zMs" value="0" />
-            <property role="LIFWd" value="Constant_bk8szz_a0a" />
-          </node>
         </node>
       </node>
     </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_InternalModifier.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/StructDeclaration_InternalModifier.mpsr
@@ -23,7 +23,6 @@
         <property id="1229194968596" name="caretPosition" index="LIFWa" />
         <property id="1229194968595" name="cellId" index="LIFWd" />
         <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
-        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
       </concept>
       <concept id="1227182079811" name="jetbrains.mps.lang.test.structure.TypeKeyStatement" flags="nn" index="2TK7Tu">
         <property id="1227184461946" name="keys" index="2TTd_B" />
@@ -93,12 +92,12 @@
     <node concept="1qefOq" id="3tcg5UgqsoF" role="25YQCW">
       <node concept="31LiC_" id="3tcg5UgqsoE" role="1qenE9">
         <property role="TrG5h" value="Foo" />
-        <node concept="LIFWc" id="3tcg5UgqsoO" role="lGtFl">
+        <node concept="LIFWc" id="AKP4wC3dMS" role="lGtFl">
           <property role="LIFWa" value="0" />
           <property role="OXtK3" value="true" />
           <property role="p6zMq" value="0" />
           <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="Constant_c64ig3_b0" />
+          <property role="LIFWd" value="Constant_c64ig3_c0" />
         </node>
       </node>
     </node>
@@ -106,13 +105,6 @@
       <node concept="31LiC_" id="3tcg5UgqsoQ" role="1qenE9">
         <property role="TrG5h" value="Foo" />
         <node concept="2qAx7z" id="3tcg5UgqsoW" role="3SE3Wx" />
-        <node concept="LIFWc" id="3tcg5Ugqsp5" role="lGtFl">
-          <property role="ZRATv" value="true" />
-          <property role="OXtK3" value="true" />
-          <property role="p6zMq" value="0" />
-          <property role="p6zMs" value="0" />
-          <property role="LIFWd" value="empty_structMemberDeclaration" />
-        </node>
       </node>
     </node>
   </node>

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeDeclaration_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeDeclaration_AddTarget.mpsr
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588300035" name="CsBaseLanguage.structure.ClassDeclaration" flags="ng" index="31LiCz" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQUBIk5">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="TypeDeclaration_AddTarget" />
+    <node concept="1qefOq" id="2KItQQUBIk7" role="25YQCW">
+      <node concept="31LiCz" id="2KItQQUBIk6" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="2KItQQUBIk8" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUBIk9" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUBIka" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUBIkb" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQUBIkc" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQUBIkd" role="25YQFr">
+      <node concept="31LiCz" id="2KItQQUBIke" role="1qenE9">
+        <property role="TrG5h" value="Foo" />
+        <node concept="1ux1f" id="2KItQQUBIkf" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQUBIkg" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQUBIkh" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQUBIki" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV7G4T" role="1DiBoh">
+            <property role="1DiB$9" value="7Jk5HDXalgK/type" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3clFbS" id="2KItQQUBIp5" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQUBIp4" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV7C9h" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV7C9l" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV7FRh" role="3cqZAp">
+        <node concept="3cmrfG" id="2KItQQV7FUD" role="3tpDZA">
+          <property role="3cmrfH" value="1" />
+        </node>
+        <node concept="2OqwBi" id="2KItQQV7FSv" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV7FSw" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV7FSx" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV7FSy" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV7FSz" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV8pnt" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV8pnu" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV8pnv" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV8pnw" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV8pnx" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV8pny" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV8pnz" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV8pn$" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV8pn_" role="37wK5m">
+              <property role="Xl_RC" value="type" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV7Goh" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV7Goj" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeParameter_AddAttributes.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeParameter_AddAttributes.mpsr
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588409138" name="CsBaseLanguage.structure.TypeParameter" flags="ng" index="31Lcgi" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQU$mt9">
+    <property role="3GE5qa" value="editor.Attributes" />
+    <property role="TrG5h" value="TypeParameter_AddAttributes" />
+    <node concept="3clFbS" id="2KItQQU$mta" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQU$mtb" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:7Jk5HDX73PP" resolve="AddAttributes" />
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$mtc" role="25YQCW">
+      <node concept="31Lcgi" id="2KItQQU$mts" role="1qenE9">
+        <property role="TrG5h" value="T" />
+        <node concept="LIFWc" id="2KItQQU$mtt" role="lGtFl">
+          <property role="ZRATv" value="true" />
+          <property role="OXtK3" value="true" />
+          <property role="p6zMq" value="1" />
+          <property role="p6zMs" value="1" />
+          <property role="LIFWd" value="property_name" />
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQU$mti" role="25YQFr">
+      <node concept="31Lcgi" id="2KItQQU$mtv" role="1qenE9">
+        <property role="TrG5h" value="T" />
+        <node concept="1ux1f" id="2KItQQU$mtx" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQU$mty" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQU$mtz" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQU$mt$" role="1DcEYZ" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeParameter_AddTarget.mpsr
+++ b/CsBaseLanguage/solutions/CsBaseLanguage.tests/models/CsBaseLanguage.tests.EditorAndStructure@tests/TypeParameter_AddTarget.mpsr
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:fcdf8a98-8638-4be9-822b-7c6b6a82fdf7(CsBaseLanguage.tests.EditorAndStructure@tests)" content="root">
+  <persistence version="9" />
+  <imports>
+    <import index="wux4" ref="r:1a34c280-eca2-468e-8a4f-0c633774bfe5(CsBaseLanguage.intentions)" implicit="true" />
+    <import index="ekwn" ref="r:9832fb5f-2578-4b58-8014-a5de79da988e(jetbrains.mps.ide.editor.actions)" implicit="true" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" implicit="true" />
+    <import index="6lvu" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cellMenu(MPS.Editor/)" implicit="true" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="1228934484974" name="jetbrains.mps.lang.test.structure.PressKeyStatement" flags="nn" index="yd1bK">
+        <child id="1228934507814" name="keyStrokes" index="yd6KS" />
+      </concept>
+      <concept id="7011073693661765739" name="jetbrains.mps.lang.test.structure.InvokeActionStatement" flags="nn" index="2HxZob">
+        <child id="1101347953350127927" name="actionReference" index="3iKnsn" />
+      </concept>
+      <concept id="1229187653856" name="jetbrains.mps.lang.test.structure.EditorTestCase" flags="lg" index="LiM7Y">
+        <child id="3143335925185262946" name="testNodeBefore" index="25YQCW" />
+        <child id="3143335925185262981" name="testNodeResult" index="25YQFr" />
+        <child id="1229187755283" name="code" index="LjaKd" />
+      </concept>
+      <concept id="1229194968594" name="jetbrains.mps.lang.test.structure.AnonymousCellAnnotation" flags="ng" index="LIFWc">
+        <property id="6268941039745498163" name="selectionStart" index="p6zMq" />
+        <property id="6268941039745498165" name="selectionEnd" index="p6zMs" />
+        <property id="1229194968595" name="cellId" index="LIFWd" />
+        <property id="1932269937152561478" name="useLabelSelection" index="OXtK3" />
+        <property id="1229432188737" name="isLastPosition" index="ZRATv" />
+      </concept>
+      <concept id="5773579205429866751" name="jetbrains.mps.lang.test.structure.EditorComponentExpression" flags="nn" index="369mXd" />
+      <concept id="4239542196496927193" name="jetbrains.mps.lang.test.structure.MPSActionReference" flags="ng" index="1iFQzN">
+        <reference id="4239542196496929559" name="action" index="1iFR8X" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1225989773458" name="jetbrains.mps.lang.test.structure.InvokeIntentionStatement" flags="nn" index="1MFPAf">
+        <reference id="1225989811227" name="intention" index="1MFYO6" />
+      </concept>
+    </language>
+    <language id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin">
+      <concept id="1207318242772" name="jetbrains.mps.lang.plugin.structure.KeyMapKeystroke" flags="ng" index="pLAjd">
+        <property id="1207318242774" name="keycode" index="pLAjf" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="8427750732757990717" name="jetbrains.mps.baseLanguage.unitTest.structure.BinaryAssert" flags="nn" index="3tpDYu">
+        <child id="8427750732757990725" name="actual" index="3tpDZA" />
+        <child id="8427750732757990724" name="expected" index="3tpDZB" />
+      </concept>
+      <concept id="1171978097730" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertEquals" flags="nn" index="3vlDli" />
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+    </language>
+    <language id="d74e25c9-4d91-43b6-bad7-d18af7bf6674" name="CsBaseLanguage">
+      <concept id="7486903154347131535" name="CsBaseLanguage.structure.AttributeSection" flags="ng" index="1ux1f">
+        <child id="7486903154347131536" name="attributeList" index="1ux1g" />
+        <child id="7110811360843586387" name="target" index="1DiBoh" />
+      </concept>
+      <concept id="8922781889383463769" name="CsBaseLanguage.structure.IHasAttributes" flags="ngI" index="7amQ3">
+        <child id="8922781889383463860" name="attributeSections" index="7amPI" />
+      </concept>
+      <concept id="7232527154588409138" name="CsBaseLanguage.structure.TypeParameter" flags="ng" index="31Lcgi" />
+      <concept id="7232527154588316420" name="CsBaseLanguage.structure.Attribute" flags="ng" index="31LmC$">
+        <child id="7110811360838812413" name="attributeClass" index="1DcEYZ" />
+      </concept>
+      <concept id="6179718927864463913" name="CsBaseLanguage.structure.AttributeClassReference" flags="ng" index="36R4uQ" />
+      <concept id="6179718927849393215" name="CsBaseLanguage.structure.AttributeList" flags="ng" index="37Y$Aw">
+        <child id="6179718927849393276" name="attributes" index="37Y$Bz" />
+      </concept>
+      <concept id="7110811360843584256" name="CsBaseLanguage.structure.AttributeTargetSpecifier" flags="ng" index="1DiBT2">
+        <property id="7110811360843584587" name="value" index="1DiB$9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="LiM7Y" id="2KItQQV95DI">
+    <property role="3GE5qa" value="editor.Attributes.Targets" />
+    <property role="TrG5h" value="TypeParameter_AddTarget" />
+    <node concept="3clFbS" id="2KItQQV95DJ" role="LjaKd">
+      <node concept="1MFPAf" id="2KItQQV95DK" role="3cqZAp">
+        <ref role="1MFYO6" to="wux4:6aIFk8bISX5" resolve="AddAttributeTarget" />
+      </node>
+      <node concept="2HxZob" id="2KItQQV95DL" role="3cqZAp">
+        <node concept="1iFQzN" id="2KItQQV95DM" role="3iKnsn">
+          <ref role="1iFR8X" to="ekwn:2XByp9s_j7f" resolve="Complete" />
+        </node>
+      </node>
+      <node concept="3vlDli" id="2KItQQV95DN" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV95DO" role="3tpDZB">
+          <node concept="2OqwBi" id="2KItQQV95DP" role="2Oq$k0">
+            <node concept="369mXd" id="2KItQQV95DQ" role="2Oq$k0" />
+            <node concept="liA8E" id="2KItQQV95DR" role="2OqNvi">
+              <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV95DS" role="2OqNvi">
+            <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getNumberOfActions()" resolve="getNumberOfActions" />
+          </node>
+        </node>
+        <node concept="3cmrfG" id="2KItQQV95DT" role="3tpDZA">
+          <property role="3cmrfH" value="1" />
+        </node>
+      </node>
+      <node concept="3vwNmj" id="2KItQQV95DU" role="3cqZAp">
+        <node concept="2OqwBi" id="2KItQQV95DV" role="3vwVQn">
+          <node concept="2OqwBi" id="2KItQQV95DW" role="2Oq$k0">
+            <node concept="2OqwBi" id="2KItQQV95DX" role="2Oq$k0">
+              <node concept="369mXd" id="2KItQQV95DY" role="2Oq$k0" />
+              <node concept="liA8E" id="2KItQQV95DZ" role="2OqNvi">
+                <ref role="37wK5l" to="exr9:~EditorComponent.getNodeSubstituteChooser()" resolve="getNodeSubstituteChooser" />
+              </node>
+            </node>
+            <node concept="liA8E" id="2KItQQV95E0" role="2OqNvi">
+              <ref role="37wK5l" to="6lvu:~NodeSubstituteChooser.getCurrentSubstituteAction()" resolve="getCurrentSubstituteAction" />
+            </node>
+          </node>
+          <node concept="liA8E" id="2KItQQV95E1" role="2OqNvi">
+            <ref role="37wK5l" to="f4zo:~SubstituteAction.canSubstituteStrictly(java.lang.String)" resolve="canSubstituteStrictly" />
+            <node concept="Xl_RD" id="2KItQQV95E2" role="37wK5m">
+              <property role="Xl_RC" value="typevar" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yd1bK" id="2KItQQV95E3" role="3cqZAp">
+        <node concept="pLAjd" id="2KItQQV95E4" role="yd6KS">
+          <property role="pLAjf" value="VK_ENTER" />
+        </node>
+      </node>
+      <node concept="3clFbH" id="2KItQQV95E5" role="3cqZAp" />
+    </node>
+    <node concept="1qefOq" id="2KItQQV95OP" role="25YQCW">
+      <node concept="31Lcgi" id="2KItQQV95OO" role="1qenE9">
+        <property role="TrG5h" value="T" />
+        <node concept="1ux1f" id="2KItQQV95Rr" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV95Rs" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV95Rt" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV95Ru" role="1DcEYZ">
+                <node concept="LIFWc" id="2KItQQV95Rv" role="lGtFl">
+                  <property role="ZRATv" value="true" />
+                  <property role="OXtK3" value="true" />
+                  <property role="p6zMq" value="0" />
+                  <property role="p6zMs" value="0" />
+                  <property role="LIFWd" value="empty_referencedType" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="2KItQQV95SH" role="25YQFr">
+      <node concept="31Lcgi" id="2KItQQV95SI" role="1qenE9">
+        <property role="TrG5h" value="T" />
+        <node concept="1ux1f" id="2KItQQV95SJ" role="7amPI">
+          <node concept="37Y$Aw" id="2KItQQV95SK" role="1ux1g">
+            <node concept="31LmC$" id="2KItQQV95SL" role="37Y$Bz">
+              <node concept="36R4uQ" id="2KItQQV95SM" role="1DcEYZ" />
+            </node>
+          </node>
+          <node concept="1DiBT2" id="2KItQQV95Vq" role="1DiBoh">
+            <property role="1DiB$9" value="60ZH30$V4dF/typevar" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+


### PR DESCRIPTION
Includes regular and global attributes. The relevant concepts have an initially empty and hidden list of attribute sections. These become visible upon adding the first section with an intention, after which more can be added with the keyboard as usual. Global attribute sections always specify one of two targets as required by the C# specification, while for regular attribute sections one can optionally be added with an intention and the available targets depend on the context.

Some logic is also provided to validate attribute argument lists and constrain the properties available for named arguments, but typesystem support is needed for the numerous additional requirements.

Finally, several abstract and interface concepts have been added to help manage the common behaviours.